### PR TITLE
feat: add HTTP and Ansible Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 - **Group management** — list, create, edit (name, GID, members), and delete local groups; system groups (gid < 1000) are protected
 - **ACL management** — view, add, and remove POSIX ACL entries (`getfacl`/`setfacl`, requires `acl` package) and NFSv4 ACL entries (`nfs4_getfacl`/`nfs4_setfacl`, requires `nfs4-acl-tools`) per dataset; one-click enable for datasets with `acltype=off`; recursive apply supported for POSIX
 - **Live updates** — Server-Sent Events push pool, dataset, snapshot, I/O, user and group changes; server polls every 10 s and pushes only on change; falls back to 30 s REST polling if SSE is unavailable
-- **Prometheus metrics** — `GET /metrics` exposes Go runtime and process stats
+- **Prometheus metrics** — `GET /metrics` exposes Go runtime and process stats, HTTP request counters and latency histograms (`http_requests_total`, `http_request_duration_seconds`), and Ansible playbook metrics (`ansible_runs_total`, `ansible_run_duration_seconds`)
 
 ## Screenshots
 
@@ -532,9 +532,13 @@ The browser UI uses `EventSource` to subscribe to all six topics and falls back 
 
 ## Planned
 
-| Feature                  | Notes                                                        |
-|--------------------------|--------------------------------------------------------------|
-| SMB/NFS share management | Create and manage Samba and NFS exports                      |
-| File browser             | Browse dataset contents, set permissions                     |
-| ZFS send/receive         | Pool replication and off-site backup                         |
-| Alerts                   | Configurable thresholds for pool health, disk temp, capacity |
+| Feature                  | Notes                                                                                                                      |
+|--------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Snapshot rollback        | Roll a dataset back to a snapshot with confirm dialog; destroys newer snapshots                                            |
+| Dataset rename           | Rename a dataset or volume in place                                                                                        |
+| Snapshot clone           | Create a new dataset from an existing snapshot                                                                             |
+| NFS share management     | List, create, and remove NFS exports; platform-aware for Linux and FreeBSD (`/etc/exports` format + reload command differ) |
+| SMB share management     | List, create, and remove Samba shares (`smb.conf`); Linux and FreeBSD service handling                                     |
+| File browser             | Browse dataset contents, set permissions                                                                                   |
+| ZFS send/receive         | Pool replication and off-site backup                                                                                       |
+| Alerts                   | Configurable thresholds for pool health, disk temp, capacity                                                               |

--- a/internal/ansible/metrics.go
+++ b/internal/ansible/metrics.go
@@ -1,0 +1,96 @@
+package ansible
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ansibleDurationBuckets are histogram bucket boundaries for playbook run duration in seconds.
+// Ansible runs typically take 1–10 s; the upper buckets catch slow runs.
+const ansibleBucketCount = 8
+
+var ansibleDurationBuckets = [ansibleBucketCount]float64{0.5, 1, 2.5, 5, 10, 30, 60, 120}
+
+type ansibleSample struct {
+	count   int64
+	sum     float64
+	buckets [ansibleBucketCount]int64 // non-cumulative per-slot counts
+}
+
+type ansibleMetrics struct {
+	mu   sync.Mutex
+	runs map[string]int64          // "playbook|status" → count  (status: ok/failed)
+	lat  map[string]*ansibleSample // playbook → duration sample
+}
+
+func newAnsibleMetrics() *ansibleMetrics {
+	return &ansibleMetrics{
+		runs: make(map[string]int64),
+		lat:  make(map[string]*ansibleSample),
+	}
+}
+
+// record updates metrics after a completed playbook run.
+func (m *ansibleMetrics) record(playbook string, d time.Duration, failed bool) {
+	status := "ok"
+	if failed {
+		status = "failed"
+	}
+	secs := d.Seconds()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.runs[playbook+"|"+status]++
+
+	s, ok := m.lat[playbook]
+	if !ok {
+		s = &ansibleSample{}
+		m.lat[playbook] = s
+	}
+	s.count++
+	s.sum += secs
+	for i, le := range ansibleDurationBuckets {
+		if secs <= le {
+			s.buckets[i]++
+			break
+		}
+	}
+	// observations above the highest bucket count only in +Inf (via s.count)
+}
+
+func (m *ansibleMetrics) emitTo(w io.Writer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fmt.Fprint(w,
+		"# HELP ansible_runs_total Total Ansible playbook runs by playbook and outcome.\n"+
+			"# TYPE ansible_runs_total counter\n")
+	for key, count := range m.runs {
+		parts := strings.SplitN(key, "|", 2)
+		fmt.Fprintf(w, "ansible_runs_total{playbook=%q,status=%q} %d\n",
+			parts[0], parts[1], count)
+	}
+
+	fmt.Fprint(w,
+		"# HELP ansible_run_duration_seconds Ansible playbook run duration histogram.\n"+
+			"# TYPE ansible_run_duration_seconds histogram\n")
+	for playbook, s := range m.lat {
+		cumulative := int64(0)
+		for i, le := range ansibleDurationBuckets {
+			cumulative += s.buckets[i]
+			fmt.Fprintf(w, "ansible_run_duration_seconds_bucket{playbook=%q,le=%q} %d\n",
+				playbook, strconv.FormatFloat(le, 'f', -1, 64), cumulative)
+		}
+		fmt.Fprintf(w, "ansible_run_duration_seconds_bucket{playbook=%q,le=\"+Inf\"} %d\n",
+			playbook, s.count)
+		fmt.Fprintf(w, "ansible_run_duration_seconds_sum{playbook=%q} %s\n",
+			playbook, strconv.FormatFloat(s.sum, 'f', -1, 64))
+		fmt.Fprintf(w, "ansible_run_duration_seconds_count{playbook=%q} %d\n",
+			playbook, s.count)
+	}
+}

--- a/internal/ansible/runner.go
+++ b/internal/ansible/runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -80,6 +81,7 @@ func (o *PlaybookOutput) Steps() []TaskStep {
 type Runner struct {
 	PlaybookDir   string
 	InventoryPath string
+	metrics       ansibleMetrics
 }
 
 // NewRunner creates a Runner whose paths are relative to baseDir.
@@ -96,6 +98,7 @@ func NewRunner(baseDir string) *Runner {
 	return &Runner{
 		PlaybookDir:   filepath.Join(baseDir, "playbooks"),
 		InventoryPath: filepath.Join(baseDir, "playbooks", "inventory", "localhost"),
+		metrics:       *newAnsibleMetrics(),
 	}
 }
 
@@ -110,8 +113,14 @@ func NewRunner(baseDir string) *Runner {
 //  2. Process-level: non-zero exit code after successful JSON parse (e.g. unreachable host).
 //
 // Returns an error if any task failed, including a descriptive message from the task.
+// EmitMetrics writes Ansible metrics in Prometheus text format to w.
+func (r *Runner) EmitMetrics(w io.Writer) {
+	r.metrics.emitTo(w)
+}
+
 func (r *Runner) Run(playbook string, extraVars map[string]string) (*PlaybookOutput, error) {
 	playbookPath := filepath.Join(r.PlaybookDir, playbook)
+	playbookLabel := strings.TrimSuffix(playbook, ".yml")
 
 	args := []string{"-i", r.InventoryPath, playbookPath}
 
@@ -144,24 +153,29 @@ func (r *Runner) Run(playbook string, extraVars map[string]string) (*PlaybookOut
 	if parseErr != nil {
 		if runErr != nil {
 			slog.Error("ansible-playbook failed", "playbook", playbook, "duration_ms", elapsed.Milliseconds(), "err", runErr, "stderr", stderr.String())
+			r.metrics.record(playbookLabel, elapsed, true)
 			return nil, fmt.Errorf("ansible-playbook %s failed: %w\nstderr: %s", playbook, runErr, stderr.String())
 		}
+		r.metrics.record(playbookLabel, elapsed, true)
 		return nil, fmt.Errorf("parse ansible output: %w", parseErr)
 	}
 
 	// Scan task results for failures — this is the authoritative failure signal.
 	if err := firstFailure(out); err != nil {
 		slog.Error("ansible-playbook task failed", "playbook", playbook, "duration_ms", elapsed.Milliseconds(), "err", err)
+		r.metrics.record(playbookLabel, elapsed, true)
 		return out, err
 	}
 
 	// Fallback: non-zero exit but no task-level failure detected.
 	if runErr != nil {
 		slog.Error("ansible-playbook exited non-zero", "playbook", playbook, "duration_ms", elapsed.Milliseconds(), "err", runErr)
+		r.metrics.record(playbookLabel, elapsed, true)
 		return out, fmt.Errorf("ansible-playbook %s: %w", playbook, runErr)
 	}
 
 	slog.Info("ansible-playbook done", "playbook", playbook, "duration_ms", elapsed.Milliseconds())
+	r.metrics.record(playbookLabel, elapsed, false)
 	return out, nil
 }
 

--- a/internal/api/httpmetrics.go
+++ b/internal/api/httpmetrics.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// httpDurationBuckets are the histogram bucket boundaries in seconds.
+const httpBucketCount = 11
+
+var httpDurationBuckets = [httpBucketCount]float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+type httpSample struct {
+	count   int64
+	sum     float64
+	buckets [httpBucketCount]int64 // non-cumulative per-slot counts
+}
+
+type httpMetrics struct {
+	mu       sync.Mutex
+	requests map[string]int64     // "METHOD|path|status" → count
+	latency  map[string]*httpSample // "METHOD|path" → sample
+}
+
+func newHTTPMetrics() *httpMetrics {
+	return &httpMetrics{
+		requests: make(map[string]int64),
+		latency:  make(map[string]*httpSample),
+	}
+}
+
+var globalHTTP = newHTTPMetrics()
+
+// RecordHTTP records a completed HTTP request. Called from the requestLogger middleware in main.go.
+// Only API paths (/api/... and /metrics) are recorded; static file requests are ignored.
+func RecordHTTP(method, path string, status int, d time.Duration) {
+	p := normalizePath(path)
+	if p == "" {
+		return
+	}
+	globalHTTP.observe(method, p, status, d)
+}
+
+// normalizePath returns the normalised path for metric recording, collapsing
+// variable segments to keep cardinality low. Returns "" for non-API paths
+// (static files, favicons, images) which should not be recorded.
+//
+//	/api/datasets/tank/data  → /api/datasets/{name}
+//	/api/snapshots/tank@s    → /api/snapshots/{name}
+//	/api/pools               → /api/pools  (no variable segment)
+//	/metrics                 → /metrics
+//	/app.js, /favicon.ico, … → ""  (skipped)
+func normalizePath(p string) string {
+	if p == "/metrics" {
+		return p
+	}
+	if !strings.HasPrefix(p, "/api/") {
+		return ""
+	}
+	// Strip /api/ and split on first remaining slash.
+	resource, sub, hasMore := strings.Cut(strings.TrimPrefix(p, "/api/"), "/")
+	if hasMore && sub != "" {
+		return "/api/" + resource + "/{name}"
+	}
+	return p
+}
+
+func (m *httpMetrics) observe(method, path string, status int, d time.Duration) {
+	rk := method + "|" + path + "|" + strconv.Itoa(status)
+	lk := method + "|" + path
+	secs := d.Seconds()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.requests[rk]++
+
+	s, ok := m.latency[lk]
+	if !ok {
+		s = &httpSample{}
+		m.latency[lk] = s
+	}
+	s.count++
+	s.sum += secs
+	for i, le := range httpDurationBuckets {
+		if secs <= le {
+			s.buckets[i]++
+			break
+		}
+	}
+	// observations above the highest bucket boundary count only in +Inf (via s.count)
+}
+
+func (m *httpMetrics) emitTo(w io.Writer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fmt.Fprint(w,
+		"# HELP http_requests_total Total HTTP requests by method, path, and status code.\n"+
+			"# TYPE http_requests_total counter\n")
+	for key, count := range m.requests {
+		parts := strings.SplitN(key, "|", 3)
+		fmt.Fprintf(w, "http_requests_total{method=%q,path=%q,status=%q} %d\n",
+			parts[0], parts[1], parts[2], count)
+	}
+
+	fmt.Fprint(w,
+		"# HELP http_request_duration_seconds HTTP request latency histogram.\n"+
+			"# TYPE http_request_duration_seconds histogram\n")
+	for key, s := range m.latency {
+		parts := strings.SplitN(key, "|", 2)
+		method, path := parts[0], parts[1]
+		cumulative := int64(0)
+		for i, le := range httpDurationBuckets {
+			cumulative += s.buckets[i]
+			fmt.Fprintf(w, "http_request_duration_seconds_bucket{method=%q,path=%q,le=%q} %d\n",
+				method, path, strconv.FormatFloat(le, 'f', -1, 64), cumulative)
+		}
+		fmt.Fprintf(w, "http_request_duration_seconds_bucket{method=%q,path=%q,le=\"+Inf\"} %d\n",
+			method, path, s.count)
+		fmt.Fprintf(w, "http_request_duration_seconds_sum{method=%q,path=%q} %s\n",
+			method, path, strconv.FormatFloat(s.sum, 'f', -1, 64))
+		fmt.Fprintf(w, "http_request_duration_seconds_count{method=%q,path=%q} %d\n",
+			method, path, s.count)
+	}
+}

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -90,6 +90,9 @@ func (h *Handler) getMetrics(w http.ResponseWriter, _ *http.Request) {
 			"# TYPE dumpstore_build_info gauge\n"+
 			"dumpstore_build_info{version=%q,goversion=%q} 1\n",
 		h.version, runtime.Version())
+
+	globalHTTP.emitTo(w)
+	h.runner.EmitMetrics(w)
 }
 
 func gauge(w http.ResponseWriter, name, help string, val float64) {

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func requestLogger(next http.Handler) http.Handler {
 		start := time.Now()
 		rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(rw, r)
+		elapsed := time.Since(start)
 
 		level := slog.LevelInfo
 		if rw.status >= 500 {
@@ -114,9 +115,10 @@ func requestLogger(next http.Handler) http.Handler {
 			"method", r.Method,
 			"path", r.URL.Path,
 			"status", rw.status,
-			"duration_ms", time.Since(start).Milliseconds(),
+			"duration_ms", elapsed.Milliseconds(),
 			"remote", r.RemoteAddr,
 		)
+		api.RecordHTTP(r.Method, r.URL.Path, rw.status, elapsed)
 	})
 }
 


### PR DESCRIPTION
## Summary

- **HTTP metrics**: `http_requests_total{method,path,status}` counter and `http_request_duration_seconds{method,path}` histogram; paths normalised to `/api/resource/{name}` to keep cardinality low; static file requests skipped entirely
- **Ansible metrics**: `ansible_runs_total{playbook,status}` counter and `ansible_run_duration_seconds{playbook}` histogram; per-task breakdown intentionally omitted (task names can include variable interpolation → cardinality risk; detail is already in structured logs)
- Both emitted from `GET /metrics` alongside existing Go runtime metrics

## Design decisions

- Non-API paths (`/app.js`, `/favicon.ico`, images) are not recorded — metrics focus on API endpoints only
- `ansible_tasks_total` dropped in favour of run-level counters; task-level detail belongs in tracing/logs

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `curl http://localhost:8080/metrics` shows `http_requests_total`, `http_request_duration_seconds`, `ansible_runs_total`, `ansible_run_duration_seconds` after making a few requests and write ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)