### PR TITLE
feat: NFS share management via ZFS sharenfs property

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 - **Snapshot management** — list, create (recursive), and delete snapshots
 - **User management** — list, create, edit (shell, password, primary/supplementary groups), and delete local users; system users (uid < 1000) are visible but protected
 - **Group management** — list, create, edit (name, GID, members), and delete local groups; system groups (gid < 1000) are protected
+- **NFS share management** — enable, configure, and disable NFS sharing per dataset via the ZFS `sharenfs` property; cross-platform (Linux and FreeBSD)
 - **ACL management** — view, add, and remove POSIX ACL entries (`getfacl`/`setfacl`, requires `acl` package) and NFSv4 ACL entries (`nfs4_getfacl`/`nfs4_setfacl`, requires `nfs4-acl-tools`) per dataset; one-click enable for datasets with `acltype=off`; recursive apply supported for POSIX
 - **Live updates** — Server-Sent Events push pool, dataset, snapshot, I/O, user and group changes; server polls every 10 s and pushes only on change; falls back to 30 s REST polling if SSE is unavailable
 - **Prometheus metrics** — `GET /metrics` exposes Go runtime and process stats, HTTP request counters and latency histograms (`http_requests_total`, `http_request_duration_seconds`), and Ansible playbook metrics (`ansible_runs_total`, `ansible_run_duration_seconds`)
@@ -203,28 +204,37 @@ DELETE /api/acl/{dataset}     → acl_remove_posix.yml      (ansible)
 
 ## Requirements
 
-|                       | Linux                          | FreeBSD                                      |
-|-----------------------|--------------------------------|----------------------------------------------|
-| ZFS                   | `zfsutils-linux` or equivalent | built-in (`zfsutils` pkg for older releases) |
-| Ansible               | `ansible` package (Python 3)   | `py311-ansible` or equivalent                |
-| Service manager       | systemd                        | rc.d (via `daemon(8)`)                       |
-| S.M.A.R.T. (optional) | `smartmontools`                | `smartmontools` pkg                          |
-| POSIX ACLs (optional) | `acl` pkg (`getfacl`/`setfacl`) | `py311-pylibacl` or `acl` port             |
-| NFSv4 ACLs (optional) | `nfs4-acl-tools` pkg (`nfs4_getfacl`/`nfs4_setfacl`) | `nfs4-acl-tools` port       |
-| Build                 | Go 1.22+                       | Go 1.22+                                     |
+|                        | Linux                                                     | FreeBSD                                      |
+|------------------------|-----------------------------------------------------------|----------------------------------------------|
+| ZFS                    | `zfsutils-linux` or equivalent                            | built-in (`zfsutils` pkg for older releases) |
+| Ansible                | `ansible` package (Python 3)                              | `py311-ansible` or equivalent                |
+| Service manager        | systemd                                                   | rc.d (via `daemon(8)`)                       |
+| S.M.A.R.T. (optional)  | `smartmontools`                                           | `smartmontools` pkg                          |
+| POSIX ACLs (optional)  | `acl` pkg (`getfacl`/`setfacl`)                           | `py311-pylibacl` or `acl` port               |
+| NFS sharing (optional) | `nfs-kernel-server` (Debian) or `nfs-utils` (RHEL/Fedora) | built-in base system                         |
+| NFSv4 ACLs (optional)  | `nfs4-acl-tools` pkg (`nfs4_getfacl`/`nfs4_setfacl`)      | `nfs4-acl-tools` port                        |
+| Build                  | Go 1.22+                                                  | Go 1.22+                                     |
 
 Go and Ansible are the only hard requirements. ZFS must be available on the target machine; the binary itself builds and runs on any platform.
 
-The ACL tools are optional — the ACL dialog will show an error if the required tool is not installed on the target host. Install only what you need:
+The NFS server and ACL tools are optional — the relevant dialogs will show an error if the required tool is not installed. Install only what you need:
 
 ```bash
 # Debian/Ubuntu — POSIX ACLs
 apt install acl
 
+# Debian/Ubuntu — NFS sharing
+apt install nfs-kernel-server
+systemctl enable --now nfs-server
+
 # Debian/Ubuntu — NFSv4 ACLs
 apt install nfs4-acl-tools
 
-# RHEL/Fedora
+# RHEL/Fedora — NFS sharing
+dnf install nfs-utils
+systemctl enable --now nfs-server
+
+# RHEL/Fedora — ACLs
 dnf install acl nfs4-acl-tools
 ```
 
@@ -346,7 +356,7 @@ sudo make uninstall
 │   ├── acl_set_posix.yml            # Add/modify POSIX ACL entry (setfacl -m)
 │   ├── acl_remove_posix.yml         # Remove POSIX ACL entry (setfacl -x)
 │   ├── acl_set_nfs4.yml             # Add NFSv4 ACL entry (nfs4_setfacl -a)
-│   └── acl_remove_nfs4.yml          # Remove NFSv4 ACL entry (nfs4_setfacl -x)
+│   ├── acl_remove_nfs4.yml          # Remove NFSv4 ACL entry (nfs4_setfacl -x)
 ├── images/                          # Logo source files (SVG, all variants)
 ├── static/
 │   ├── index.html                   # Single-page application shell + dialogs
@@ -532,13 +542,13 @@ The browser UI uses `EventSource` to subscribe to all six topics and falls back 
 
 ## Planned
 
-| Feature                  | Notes                                                                                                                      |
-|--------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| Snapshot rollback        | Roll a dataset back to a snapshot with confirm dialog; destroys newer snapshots                                            |
-| Dataset rename           | Rename a dataset or volume in place                                                                                        |
-| Snapshot clone           | Create a new dataset from an existing snapshot                                                                             |
-| NFS share management     | List, create, and remove NFS exports; platform-aware for Linux and FreeBSD (`/etc/exports` format + reload command differ) |
-| SMB share management     | List, create, and remove Samba shares (`smb.conf`); Linux and FreeBSD service handling                                     |
-| File browser             | Browse dataset contents, set permissions                                                                                   |
-| ZFS send/receive         | Pool replication and off-site backup                                                                                       |
-| Alerts                   | Configurable thresholds for pool health, disk temp, capacity                                                               |
+| Feature                  | Notes                                                                                         |
+|--------------------------|-----------------------------------------------------------------------------------------------|
+| Snapshot rollback        | Roll a dataset back to a snapshot with confirm dialog; destroys newer snapshots               |
+| Dataset rename           | Rename a dataset or volume in place                                                           |
+| Snapshot clone           | Create a new dataset from an existing snapshot                                                |
+| ~~NFS share management~~ | ~~List, create, and remove NFS exports~~ — **done** (ZFS `sharenfs` property; cross-platform) |
+| SMB share management     | List, create, and remove Samba shares (`smb.conf`); Linux and FreeBSD service handling        |
+| File browser             | Browse dataset contents, set permissions                                                      |
+| ZFS send/receive         | Pool replication and off-site backup                                                          |
+| Alerts                   | Configurable thresholds for pool health, disk temp, capacity                                  |

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -165,7 +165,7 @@ func (h *Handler) setDatasetProps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	allowed := []string{"compression", "quota", "mountpoint", "recordsize", "atime", "exec", "sync", "dedup", "copies", "xattr", "readonly", "acltype"}
+	allowed := []string{"compression", "quota", "mountpoint", "recordsize", "atime", "exec", "sync", "dedup", "copies", "xattr", "readonly", "acltype", "sharenfs"}
 	allowedSet := make(map[string]bool, len(allowed))
 	for _, p := range allowed {
 		allowedSet[p] = true
@@ -197,6 +197,7 @@ func (h *Handler) setDatasetProps(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err, steps)
 		return
 	}
+	h.publishDatasets()
 	writeJSON(w, map[string]any{"name": name, "tasks": out.Steps()})
 }
 
@@ -1011,6 +1012,14 @@ func (h *Handler) modifyGroup(w http.ResponseWriter, r *http.Request) {
 	}
 	h.publishUserGroup()
 	writeJSON(w, map[string]any{"groupname": resultName, "tasks": out.Steps()})
+}
+
+// publishDatasets re-reads the dataset list and immediately pushes
+// dataset.query to all SSE subscribers. Called after any dataset property change.
+func (h *Handler) publishDatasets() {
+	if datasets, err := zfs.ListDatasets(); err == nil {
+		h.broker.Publish("dataset.query", datasets)
+	}
 }
 
 // publishUserGroup re-reads /etc/passwd and /etc/group and immediately pushes

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -284,12 +284,23 @@ func detectPkgManager() string {
 	return ""
 }
 
+// probeNFSServer returns "installed" when the platform NFS server tool is present.
+// Linux uses exportfs (from nfs-kernel-server/nfs-utils).
+// FreeBSD ships nfsd in the base system, so we probe mountd instead.
+func probeNFSServer() string {
+	if runtime.GOOS == "freebsd" {
+		return probePresence("mountd")
+	}
+	return probePresence("exportfs")
+}
+
 func softwareVersions() []SoftwareTool {
 	return []SoftwareTool{
 		{Name: "ZFS", Version: probeVersion("zfs", "version")},
 		{Name: "Ansible", Version: probeVersion("ansible-playbook", "--version")},
 		{Name: "Python", Version: probeVersion("python3", "--version")},
 		{Name: "smartctl", Version: probeVersion("smartctl", "--version")},
+		{Name: "NFS server", Version: probeNFSServer()},
 		{Name: "nfs4-acl-tools", Version: probePresence("nfs4_setfacl")},
 		{Name: "setfacl (ACL)", Version: probePresence("setfacl")},
 		{Name: "Package manager", Version: detectPkgManager()},

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -36,6 +36,7 @@ type Dataset struct {
 	Reservation   uint64 `json:"reservation"`
 	Pool          string `json:"pool"`
 	Depth         int    `json:"depth"`
+	ShareNFS      string `json:"sharenfs"`
 }
 
 // Snapshot represents a ZFS snapshot.
@@ -114,14 +115,14 @@ func ListPools() ([]Pool, error) {
 // ListDatasets runs `zfs list` and returns all datasets.
 func ListDatasets() ([]Dataset, error) {
 	out, err := run("zfs", "list", "-H", "-p",
-		"-o", "name,used,avail,refer,mountpoint,type,compressratio,compression,quota,reservation")
+		"-o", "name,used,avail,refer,mountpoint,type,compressratio,compression,quota,reservation,sharenfs")
 	if err != nil {
 		return nil, err
 	}
 	var datasets []Dataset
 	for _, line := range splitLines(out) {
 		f := strings.Split(line, "\t")
-		if len(f) < 10 {
+		if len(f) < 11 {
 			continue
 		}
 		name := f[0]
@@ -139,6 +140,7 @@ func ListDatasets() ([]Dataset, error) {
 			Reservation:   parseUint(f[9]),
 			Pool:          pool,
 			Depth:         strings.Count(name, "/"),
+			ShareNFS:      f[10],
 		})
 	}
 	return datasets, nil
@@ -217,7 +219,7 @@ type DatasetProp struct {
 // returns a map of property name → DatasetProp.
 func GetDatasetProps(name string) (map[string]DatasetProp, error) {
 	out, err := run("zfs", "get", "-H",
-		"compression,quota,mountpoint,recordsize,atime,exec,sync,dedup,copies,xattr,readonly,acltype",
+		"compression,quota,mountpoint,recordsize,atime,exec,sync,dedup,copies,xattr,readonly,acltype,sharenfs",
 		name)
 	if err != nil {
 		return nil, err

--- a/playbooks/zfs_dataset_set.yml
+++ b/playbooks/zfs_dataset_set.yml
@@ -14,6 +14,7 @@
 #   copies       - 1, 2, 3
 #   xattr        - on, sa, off
 #   acltype      - off, posix, nfsv4
+#   sharenfs     - off, on, or NFS options (e.g. rw=@192.168.1.0/24)
 - name: Set ZFS dataset properties
   hosts: localhost
   gather_facts: false
@@ -30,6 +31,7 @@
     xattr: "__skip__"
     readonly: "__skip__"
     acltype: "__skip__"
+    sharenfs: "__skip__"
   tasks:
     - name: Validate input
       ansible.builtin.assert:
@@ -53,7 +55,8 @@
             (['copies='       + copies]      if copies       not in ['', '__skip__'] else []) +
             (['xattr='        + xattr]       if xattr        not in ['', '__skip__'] else []) +
             (['readonly='     + readonly]    if readonly     not in ['', '__skip__'] else []) +
-            (['acltype='      + acltype]     if acltype      not in ['', '__skip__'] else [])
+            (['acltype='      + acltype]     if acltype      not in ['', '__skip__'] else []) +
+            (['sharenfs='     + sharenfs]    if sharenfs     not in ['', '__skip__'] else [])
           }}
         inherit_list: >-
           {{
@@ -68,7 +71,8 @@
             (['copies']      if copies       == '' else []) +
             (['xattr']       if xattr        == '' else []) +
             (['readonly']    if readonly     == '' else []) +
-            (['acltype']     if acltype      == '' else [])
+            (['acltype']     if acltype      == '' else []) +
+            (['sharenfs']    if sharenfs      == '' else [])
           }}
 
     - name: Set properties

--- a/static/app.js
+++ b/static/app.js
@@ -473,6 +473,7 @@ function renderDatasets() {
             <button class="btn-edit" data-ds="${esc(d.name)}" data-type="${esc(d.type)}">Edit</button>
             ${d.type !== 'volume' ? `<button class="btn-acl btn-small" data-ds="${esc(d.name)}">ACL</button>` : ''}
             ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-chown btn-small" data-ds="${esc(d.name)}">Chown</button>` : ''}
+            ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-nfs btn-small${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? ' active' : ''}" data-ds="${esc(d.name)}" title="${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? 'NFS shared: ' + esc(d.sharenfs) : 'Not shared'}">NFS</button>` : ''}
             ${canDelete ? `<button class="btn-del" data-ds="${esc(d.name)}" data-type="${esc(d.type)}">Delete</button>` : ''}
           </div>
         </td>
@@ -516,6 +517,10 @@ function renderDatasets() {
 
   wrap.querySelectorAll('.btn-chown[data-ds]').forEach(btn => {
     btn.addEventListener('click', () => openChownDialog(btn.dataset.ds));
+  });
+
+  wrap.querySelectorAll('.btn-nfs[data-ds]').forEach(btn => {
+    btn.addEventListener('click', () => openNFSDialog(btn.dataset.ds));
   });
 }
 
@@ -1488,6 +1493,65 @@ document.getElementById('chownForm').addEventListener('submit', async e => {
     showOpLog(`Failed to change ownership of ${dataset}`, err.tasks, err.message);
   }
 });
+
+// ── NFS share dialog (sharenfs property) ─────────────────────────────────────
+const nfsDialog = document.getElementById('nfsDialog');
+document.getElementById('nfsDialogClose').addEventListener('click', () => nfsDialog.close());
+
+let _nfsDataset = '';
+
+async function openNFSDialog(dataset) {
+  _nfsDataset = dataset;
+  document.getElementById('nfsDialogTitle').textContent = 'NFS Share — ' + dataset;
+  document.getElementById('nfsDialogPath').textContent = '';
+  document.getElementById('nfs-clients').value = '';
+  document.getElementById('nfsDialogEntries').innerHTML = '<span class="muted">Loading…</span>';
+  nfsDialog.showModal();
+  try {
+    const props = await api('GET', '/api/dataset-props/' + encodeURIComponent(dataset).replace(/%2F/g, '/'));
+    const sharenfs = props.sharenfs?.value ?? 'off';
+    const src = props.sharenfs?.source ?? '';
+    const entriesEl = document.getElementById('nfsDialogEntries');
+    if (sharenfs && sharenfs !== 'off' && sharenfs !== '-') {
+      entriesEl.innerHTML = `
+        <div class="acl-entry" style="display:flex;align-items:center;gap:0.5rem">
+          <code style="flex:1">${esc(sharenfs)}</code>
+          <span class="muted" style="font-size:0.8rem">${esc(src)}</span>
+        </div>`;
+      document.getElementById('nfs-clients').value = sharenfs === 'on' ? '' : sharenfs;
+    } else {
+      entriesEl.innerHTML = '<p class="muted">Not currently shared via NFS.</p>';
+    }
+  } catch (e) {
+    document.getElementById('nfsDialogEntries').innerHTML = `<p class="op-error">${esc(e.message)}</p>`;
+  }
+}
+
+document.getElementById('nfsAddBtn').addEventListener('click', async () => {
+  const options = document.getElementById('nfs-clients').value.trim() || 'on';
+  const dataset = _nfsDataset;
+  nfsDialog.close();
+  try {
+    const result = await api('PATCH', '/api/datasets/' + encodeURIComponent(dataset).replace(/%2F/g, '/'),
+      { sharenfs: options });
+    showOpLog('NFS share enabled: ' + dataset, result.tasks, null);
+  } catch (e) {
+    showOpLog('Failed to set sharenfs', e.tasks, e.message);
+  }
+});
+
+document.getElementById('nfsDisableBtn').addEventListener('click', async () => {
+  const dataset = _nfsDataset;
+  nfsDialog.close();
+  try {
+    const result = await api('PATCH', '/api/datasets/' + encodeURIComponent(dataset).replace(/%2F/g, '/'),
+      { sharenfs: 'off' });
+    showOpLog('NFS share disabled: ' + dataset, result.tasks, null);
+  } catch (e) {
+    showOpLog('Failed to disable sharenfs', e.tasks, e.message);
+  }
+});
+
 
 // ── SSE client ────────────────────────────────────────────────────────────────
 // Maps SSE topic names → state key + render function.

--- a/static/index.html
+++ b/static/index.html
@@ -600,6 +600,24 @@
     </form>
   </dialog>
 
+  <!-- NFS SHARE DIALOG -->
+  <dialog id="nfsDialog">
+    <h3 id="nfsDialogTitle">NFS Share</h3>
+    <p class="muted" id="nfsDialogPath" style="margin:0 0 1rem;font-size:0.85rem"></p>
+    <div id="nfsDialogEntries" style="margin-bottom:1rem"></div>
+    <fieldset class="form-section" id="nfsAddForm">
+      <legend>Set sharenfs</legend>
+      <label>Options <span class="field-note">(blank = "on"; e.g. rw=@192.168.1.0/24,no_root_squash)</span>
+        <input type="text" id="nfs-clients" placeholder="rw=@192.168.1.0/24,no_root_squash" autocomplete="off">
+      </label>
+    </fieldset>
+    <div class="dialog-actions">
+      <button type="button" id="nfsDialogClose" class="btn-secondary">Close</button>
+      <button type="button" id="nfsDisableBtn" class="btn-danger">Disable</button>
+      <button type="button" id="nfsAddBtn" class="btn-primary">Share</button>
+    </div>
+  </dialog>
+
   <!-- OPERATION LOG DIALOG -->
   <dialog id="opLogDialog">
     <h3 id="opLogTitle">Operation Result</h3>

--- a/static/style.css
+++ b/static/style.css
@@ -700,3 +700,7 @@ dialog label select:focus { border-color: var(--accent); }
 .btn-acl:hover { background: var(--surface); color: var(--text); }
 .btn-chown { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer; }
 .btn-chown:hover { background: var(--surface); color: var(--text); }
+.btn-nfs { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer; }
+.btn-nfs:hover { background: var(--surface); color: var(--text); }
+.btn-nfs.active { background: color-mix(in srgb, var(--accent) 15%, var(--surface2)); color: var(--accent); border-color: var(--accent-dim); }
+.btn-nfs.active:hover { background: color-mix(in srgb, var(--accent) 25%, var(--surface2)); }


### PR DESCRIPTION
## Summary

- Adds per-dataset NFS sharing dialog to the Datasets tab
- Uses ZFS `sharenfs` property (`zfs set sharenfs=...`) — cross-platform, works on Linux and FreeBSD without touching `/etc/exports`
- NFS button in dataset row highlights (accent colour) when sharing is active; tooltip shows current options string
- SSE pushes dataset list immediately after any property change via new `publishDatasets()` helper
- Software check on Sysinfo tab is OS-aware: probes `exportfs` on Linux, `mountd` on FreeBSD

## Changes

- `internal/zfs/zfs.go` — `ShareNFS` field on `Dataset`; `sharenfs` column in `zfs list`
- `internal/api/handlers.go` — `sharenfs` in allowed props for `PATCH /api/datasets`; `publishDatasets()` for immediate SSE
- `internal/system/system.go` — OS-aware `probeNFSServer()` for the Installed Software section
- `playbooks/zfs_dataset_set.yml` — `sharenfs` added (set + inherit)
- `static/index.html` — NFS dialog with Share / Disable buttons
- `static/app.js` — `openNFSDialog` reads current `sharenfs` via `GET /api/dataset-props`, writes via `PATCH /api/datasets`
- `static/style.css` — `.btn-nfs` and `.btn-nfs.active` styles
- `README.md` — requirements table, install snippets, feature list, file map updated

## Test plan

- [ ] Dataset with no mountpoint: NFS button absent
- [ ] Dataset with mountpoint, sharenfs=off: NFS button present, not highlighted
- [ ] Click NFS → shows "Not currently shared", enter options, click Share → oplog shown, button highlights, tooltip shows options
- [ ] Click NFS on active share → options pre-filled, click Disable → oplog shown, button un-highlights
- [ ] Sysinfo tab → Installed Software shows "NFS server" row
- [ ] FreeBSD: same flow, `mountd` probed instead of `exportfs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)