### PR TITLE
feat: ui overhaul — ACL button status, dataset table cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 - **Pool overview** — health badges, usage bars, fragmentation, deduplication ratio, vdev tree
 - **I/O statistics** — live read/write IOPS and bandwidth per pool
 - **Disk health** — S.M.A.R.T. data per drive (temperature, power-on hours, reallocated sectors, pending sectors, uncorrectable errors)
-- **Dataset browser** — depth-indented collapsible tree, compression, quota, mountpoint
+- **Dataset browser** — depth-indented collapsible tree, compression, quota, mountpoint; ACL and NFS buttons light up when configured
 - **Dataset creation** — create filesystems and volumes with any combination of ZFS properties
 - **Dataset editing** — update properties in place (set or inherit)
 - **Dataset deletion** — destroy datasets and volumes with recursive option and confirm-by-typing dialog
@@ -31,7 +31,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 - **User management** — list, create, edit (shell, password, primary/supplementary groups), and delete local users; system users (uid < 1000) are visible but protected
 - **Group management** — list, create, edit (name, GID, members), and delete local groups; system groups (gid < 1000) are protected
 - **NFS share management** — enable, configure, and disable NFS sharing per dataset via the ZFS `sharenfs` property; cross-platform (Linux and FreeBSD)
-- **ACL management** — view, add, and remove POSIX ACL entries (`getfacl`/`setfacl`, requires `acl` package) and NFSv4 ACL entries (`nfs4_getfacl`/`nfs4_setfacl`, requires `nfs4-acl-tools`) per dataset; one-click enable for datasets with `acltype=off`; recursive apply supported for POSIX
+- **ACL management** — view, add, and remove POSIX ACL entries (`getfacl`/`setfacl`, requires `acl` package) and NFSv4 ACL entries (`nfs4_getfacl`/`nfs4_setfacl`, requires `nfs4-acl-tools`) per dataset; setting an ACL entry automatically sets the correct `acltype` ZFS property; one-click enable for datasets with `acltype=off`; recursive apply supported for POSIX
 - **Live updates** — Server-Sent Events push pool, dataset, snapshot, I/O, user and group changes; server polls every 10 s and pushes only on change; falls back to 30 s REST polling if SSE is unavailable
 - **Prometheus metrics** — `GET /metrics` exposes Go runtime and process stats, HTTP request counters and latency histograms (`http_requests_total`, `http_request_duration_seconds`), and Ansible playbook metrics (`ansible_runs_total`, `ansible_run_duration_seconds`)
 
@@ -195,6 +195,7 @@ POST   /api/groups            → group_create.yml          (ansible)
 PUT    /api/groups/{name}     → group_modify.yml          (ansible)
 DELETE /api/groups/{name}     → group_delete.yml          (ansible)
 
+GET    /api/acl-status         → getfacl / acltype         (direct)
 GET    /api/acl/{dataset}     → getfacl / nfs4_getfacl    (direct)
 POST   /api/acl/{dataset}     → acl_set_posix.yml         (ansible)
                                 acl_set_nfs4.yml
@@ -398,6 +399,7 @@ sudo make uninstall
 | POST   | `/api/groups`               | Create a local group                  |
 | PUT    | `/api/groups/{name}`        | Edit group (name, GID, members)       |
 | DELETE | `/api/groups/{name}`        | Delete a local group                  |
+| GET    | `/api/acl-status`           | ACL presence map (dataset → bool)     |
 | GET    | `/api/acl/{dataset}`        | Get ACL entries for a dataset         |
 | POST   | `/api/acl/{dataset}`        | Add or modify an ACL entry            |
 | DELETE | `/api/acl/{dataset}`        | Remove an ACL entry                   |

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -58,6 +58,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/events", h.getEvents)
 	mux.HandleFunc("GET /api/chown/{dataset...}", h.getDatasetOwnership)
 	mux.HandleFunc("POST /api/chown/{dataset...}", h.setDatasetOwnership)
+	mux.HandleFunc("GET /api/acl-status", h.getACLStatus)
 	mux.HandleFunc("GET /api/acl/{dataset...}", h.getDatasetACL)
 	mux.HandleFunc("POST /api/acl/{dataset...}", h.setACLEntry)
 	mux.HandleFunc("DELETE /api/acl/{dataset...}", h.removeACLEntry)
@@ -1050,6 +1051,31 @@ var aclSafeRe = func() func(string) bool {
 	}
 }()
 
+// getACLStatus handles GET /api/acl-status
+// Returns a map of dataset name → bool indicating whether the dataset has
+// non-trivial ACL entries on its mountpoint.
+func (h *Handler) getACLStatus(w http.ResponseWriter, r *http.Request) {
+	datasets, err := zfs.ListDatasets()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err, nil)
+		return
+	}
+	status := make(map[string]bool, len(datasets))
+	for _, d := range datasets {
+		if d.Type != "filesystem" || d.Mountpoint == "none" || d.Mountpoint == "-" || d.Mountpoint == "" {
+			continue
+		}
+		// DatasetHasACL checks actual getfacl output; fall back to acltype
+		// when getfacl / nfs4_getfacl are not available.
+		hasACL := zfs.DatasetHasACL(d.Mountpoint)
+		if !hasACL {
+			hasACL = d.ACLType != "" && d.ACLType != "off"
+		}
+		status[d.Name] = hasACL
+	}
+	writeJSON(w, status)
+}
+
 // getDatasetACL handles GET /api/acl/{dataset...}
 func (h *Handler) getDatasetACL(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("dataset")
@@ -1122,6 +1148,7 @@ func (h *Handler) setACLEntry(w http.ResponseWriter, r *http.Request) {
 
 	var playbook string
 	vars := map[string]string{
+		"dataset":    name,
 		"mountpoint": acl.Mountpoint,
 		"ace":        req.ACE,
 		"recursive":  recursive,

--- a/internal/zfs/acl.go
+++ b/internal/zfs/acl.go
@@ -64,6 +64,33 @@ func GetDatasetACL(dataset string) (*DatasetACL, error) {
 	return acl, nil
 }
 
+// DatasetHasACL returns true if the mountpoint has non-trivial POSIX ACL
+// entries (more than the base user/group/other entries), or any NFSv4 ACL
+// entries. It calls getfacl or nfs4_getfacl directly, so it works regardless
+// of whether the ZFS acltype property is set.
+func DatasetHasACL(mountpoint string) bool {
+	out, err := run("getfacl", "-c", mountpoint)
+	if err == nil {
+		n := 0
+		for _, line := range splitLines(out) {
+			if line != "" && !strings.HasPrefix(line, "#") {
+				n++
+			}
+		}
+		return n > 3
+	}
+	// Fall back to NFSv4.
+	out, err = run("nfs4_getfacl", mountpoint)
+	if err == nil {
+		for _, line := range splitLines(out) {
+			if line != "" && !strings.HasPrefix(line, "#") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func normalizeACLType(s string) string {
 	switch strings.ToLower(s) {
 	case "posix", "posixacl":

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -37,6 +37,7 @@ type Dataset struct {
 	Pool          string `json:"pool"`
 	Depth         int    `json:"depth"`
 	ShareNFS      string `json:"sharenfs"`
+	ACLType       string `json:"acltype"`
 }
 
 // Snapshot represents a ZFS snapshot.
@@ -115,14 +116,14 @@ func ListPools() ([]Pool, error) {
 // ListDatasets runs `zfs list` and returns all datasets.
 func ListDatasets() ([]Dataset, error) {
 	out, err := run("zfs", "list", "-H", "-p",
-		"-o", "name,used,avail,refer,mountpoint,type,compressratio,compression,quota,reservation,sharenfs")
+		"-o", "name,used,avail,refer,mountpoint,type,compressratio,compression,quota,reservation,sharenfs,acltype")
 	if err != nil {
 		return nil, err
 	}
 	var datasets []Dataset
 	for _, line := range splitLines(out) {
 		f := strings.Split(line, "\t")
-		if len(f) < 11 {
+		if len(f) < 12 {
 			continue
 		}
 		name := f[0]
@@ -141,6 +142,7 @@ func ListDatasets() ([]Dataset, error) {
 			Pool:          pool,
 			Depth:         strings.Count(name, "/"),
 			ShareNFS:      f[10],
+			ACLType:       normalizeACLType(f[11]),
 		})
 	}
 	return datasets, nil

--- a/playbooks/acl_set_nfs4.yml
+++ b/playbooks/acl_set_nfs4.yml
@@ -2,6 +2,7 @@
 # Add an NFSv4 ACL entry to a dataset mountpoint.
 #
 # Required extra vars:
+#   dataset     - ZFS dataset name (e.g. tank/data)
 #   mountpoint  - absolute path of the dataset mountpoint (e.g. /tank/data)
 #   ace         - full NFSv4 ACE string (e.g. "A::alice@localdomain:rwaDxtTnNcCoy")
 #                 Format: type:flags:principal:perms
@@ -13,11 +14,19 @@
     - name: Assert required vars
       ansible.builtin.assert:
         that:
+          - dataset is defined and dataset != ""
           - mountpoint is defined and mountpoint != ""
           - ace is defined and ace != ""
+          - dataset is not search('[;|&$`]')
           - mountpoint is not search('[;|&$`]')
           - ace is not search('[;|&$`]')
-        fail_msg: "mountpoint and ace are required and must not contain shell-special characters"
+        fail_msg: "dataset, mountpoint and ace are required and must not contain shell-special characters"
+
+    - name: Ensure acltype is set to nfsv4acls
+      ansible.builtin.command:
+        argv: ["zfs", "set", "acltype=nfsv4acls", "{{ dataset }}"]
+      register: acltype_result
+      changed_when: acltype_result.rc == 0
 
     - name: Add NFSv4 ACL entry
       ansible.builtin.command:

--- a/playbooks/acl_set_posix.yml
+++ b/playbooks/acl_set_posix.yml
@@ -2,6 +2,7 @@
 # Add or modify a POSIX ACL entry on a dataset mountpoint.
 #
 # Required extra vars:
+#   dataset     - ZFS dataset name (e.g. tank/data)
 #   mountpoint  - absolute path of the dataset mountpoint (e.g. /tank/data)
 #   ace         - setfacl entry spec (e.g. "user:alice:rwx", "group:storage:r-x",
 #                 "default:user:alice:rwx")
@@ -17,11 +18,19 @@
     - name: Assert required vars
       ansible.builtin.assert:
         that:
+          - dataset is defined and dataset != ""
           - mountpoint is defined and mountpoint != ""
           - ace is defined and ace != ""
+          - dataset is not search('[;|&$`]')
           - mountpoint is not search('[;|&$`]')
           - ace is not search('[;|&$`]')
-        fail_msg: "mountpoint and ace are required and must not contain shell-special characters"
+        fail_msg: "dataset, mountpoint and ace are required and must not contain shell-special characters"
+
+    - name: Ensure acltype is set to posixacl
+      ansible.builtin.command:
+        argv: ["zfs", "set", "acltype=posixacl", "{{ dataset }}"]
+      register: acltype_result
+      changed_when: acltype_result.rc == 0
 
     - name: Set POSIX ACL entry (non-recursive)
       ansible.builtin.command:

--- a/static/app.js
+++ b/static/app.js
@@ -16,6 +16,7 @@ const state = {
   collapsedDatasets: new Set(),
   aclDataset: '',
   aclData: null,
+  aclStatus: {},
 };
 
 // ── API helpers ───────────────────────────────────────────────────────────────
@@ -148,6 +149,7 @@ async function loadAll() {
   } finally {
     setRefreshing(false);
   }
+  refreshACLStatus();
 }
 
 // ── Formatting: uptime ────────────────────────────────────────────────────────
@@ -461,7 +463,6 @@ function renderDatasets() {
     return `
       <tr>
         <td class="dataset-indent" ${indent}>${toggle}${typeBadge(d.depth === 0 ? 'pool' : d.type)} ${esc(shortName)}</td>
-        <td class="muted">${esc(d.name)}</td>
         <td>${fmtBytes(d.used)}</td>
         <td>${fmtBytes(d.avail)}</td>
         <td>${fmtBytes(d.refer)}</td>
@@ -471,7 +472,7 @@ function renderDatasets() {
         <td>
           <div class="row-actions">
             <button class="btn-edit" data-ds="${esc(d.name)}" data-type="${esc(d.type)}">Edit</button>
-            ${d.type !== 'volume' ? `<button class="btn-acl btn-small" data-ds="${esc(d.name)}">ACL</button>` : ''}
+            ${d.type !== 'volume' ? `<button class="btn-acl btn-small${state.aclStatus[d.name] ? ' active' : ''}" data-ds="${esc(d.name)}" title="${state.aclStatus[d.name] ? 'ACL entries configured' : 'No ACL'}">ACL</button>` : ''}
             ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-chown btn-small" data-ds="${esc(d.name)}">Chown</button>` : ''}
             ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-nfs btn-small${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? ' active' : ''}" data-ds="${esc(d.name)}" title="${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? 'NFS shared: ' + esc(d.sharenfs) : 'Not shared'}">NFS</button>` : ''}
             ${canDelete ? `<button class="btn-del" data-ds="${esc(d.name)}" data-type="${esc(d.type)}">Delete</button>` : ''}
@@ -484,7 +485,7 @@ function renderDatasets() {
     <div class="table-wrap">
       <table>
         <thead><tr>
-          <th>Name</th><th>Full Path</th><th>Used</th><th>Avail</th>
+          <th>Name</th><th>Used</th><th>Avail</th>
           <th>Refer</th><th>Compress</th><th>Ratio</th><th>Mount</th><th></th>
         </tr></thead>
         <tbody>${rows}</tbody>
@@ -1381,6 +1382,13 @@ function renderNFSv4AddForm(d) {
   });
 }
 
+async function refreshACLStatus() {
+  try {
+    state.aclStatus = await api('GET', '/api/acl-status') || {};
+    renderDatasets();
+  } catch (_) { /* best-effort */ }
+}
+
 async function addACLEntry(ace, recursive) {
   const dataset = state.aclDataset;
   try {
@@ -1389,6 +1397,7 @@ async function addACLEntry(ace, recursive) {
     showOpLog(`ACL entry added — ${dataset}`, res.tasks, null);
     state.aclData = await api('GET', `/api/acl/${encodeURIComponent(dataset).replace(/%2F/g, '/')}`);
     renderACLDialog();
+    refreshACLStatus();
   } catch (err) {
     showOpLog(`Failed to add ACL entry`, err.tasks, err.message);
   }
@@ -1402,6 +1411,7 @@ async function removeACLEntry(entry, recursive) {
     showOpLog(`ACL entry removed — ${dataset}`, res.tasks, null);
     state.aclData = await api('GET', `/api/acl/${encodeURIComponent(dataset).replace(/%2F/g, '/')}`);
     renderACLDialog();
+    refreshACLStatus();
   } catch (err) {
     showOpLog(`Failed to remove ACL entry`, err.tasks, err.message);
   }
@@ -1414,6 +1424,7 @@ async function enableACLs(dataset, acltype) {
     showOpLog(`Enabled ${acltype} ACLs — ${dataset}`, res.tasks, null);
     state.aclData = await api('GET', `/api/acl/${encodeURIComponent(dataset).replace(/%2F/g, '/')}`);
     renderACLDialog();
+    refreshACLStatus();
   } catch (err) {
     showOpLog(`Failed to enable ACLs`, err.tasks, err.message);
   }
@@ -1430,6 +1441,7 @@ document.getElementById('disableACLConfirmBtn').addEventListener('click', async 
     showOpLog(`Disabled ACLs — ${dataset}`, res.tasks, null);
     state.aclData = await api('GET', `/api/acl/${encodeURIComponent(dataset).replace(/%2F/g, '/')}`);
     renderACLDialog();
+    refreshACLStatus();
   } catch (err) {
     showOpLog(`Failed to disable ACLs`, err.tasks, err.message);
   }

--- a/static/style.css
+++ b/static/style.css
@@ -698,6 +698,8 @@ dialog label select:focus { border-color: var(--accent); }
 .btn-small { font-size: 11px; padding: 2px 7px; }
 .btn-acl { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer; }
 .btn-acl:hover { background: var(--surface); color: var(--text); }
+.btn-acl.active { background: color-mix(in srgb, var(--accent) 15%, var(--surface2)); color: var(--accent); border-color: var(--accent-dim); }
+.btn-acl.active:hover { background: color-mix(in srgb, var(--accent) 25%, var(--surface2)); }
 .btn-chown { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer; }
 .btn-chown:hover { background: var(--surface); color: var(--text); }
 .btn-nfs { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer; }


### PR DESCRIPTION
- Remove redundant "Full Path" column from dataset table (tree indentation already makes the hierarchy clear)
- Add GET /api/acl-status endpoint: returns map[dataset]bool by running getfacl per mounted filesystem; falls back to acltype ZFS property when getfacl/nfs4_getfacl are unavailable
- ACL button in dataset table now lights up (active class + CSS) when the dataset has non-trivial ACL entries configured
- acl_set_posix.yml / acl_set_nfs4.yml now set acltype=posixacl / nfsv4acls before calling setfacl, keeping the ZFS property in sync with actual ACL state
- Decouple /api/acl-status fetch from main Promise.all so a failure does not break the initial page load
- Add .btn-acl.active CSS rule (was missing; NFS button had it)
- refreshACLStatus() called after every ACL mutation and on load