### PR TITLE
feat: pool scrub management + wiki sync + loadAll fast/slow split

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,28 @@
+name: Sync wiki
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'wiki/**'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push wiki pages
+        run: |
+          git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" wiki-repo
+          cp wiki/*.md wiki-repo/
+          cd wiki-repo
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "docs: sync wiki from main @ ${{ github.sha }}"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,18 +87,58 @@ Do not change this split without a good reason — it exists to avoid Ansible's 
 
 ## File map
 
+### Core
+
 | File | Responsibility |
 |------|---------------|
 | `main.go` | Server setup, flag parsing, dependency check (`ansible-playbook` in PATH, `playbooks/` and `static/` dirs exist) |
 | `internal/zfs/zfs.go` | `ListPools`, `ListDatasets`, `ListSnapshots`, `IOStats` — all direct CLI calls |
+| `internal/zfs/acl.go` | ACL helpers for POSIX and NFSv4 — `GetPosixACL`, `GetNFS4ACL` |
 | `internal/ansible/runner.go` | `Runner.Run` — executes a playbook and returns parsed `PlaybookOutput`; `RunAndGetStdout` — convenience wrapper |
+| `internal/ansible/metrics.go` | Prometheus counters/histograms for Ansible playbook runs |
 | `internal/api/handlers.go` | All HTTP handlers + input validation + `writeJSON` / `writeError` helpers |
+| `internal/api/httpmetrics.go` | HTTP middleware for request count/latency metrics |
+| `internal/api/metrics.go` | `/metrics` handler (Prometheus exposition) |
+| `internal/system/system.go` | `ListUsers`, `ListGroups`, `UIDMin` — parses `/etc/passwd`, `/etc/group`, `/etc/login.defs` |
+| `internal/smart/smart.go` | `ListDrives` — calls `smartctl` for disk health data |
+| `internal/broker/broker.go` | SSE broker — fan-out of events to connected clients |
+| `internal/broker/poller.go` | Background poller that pushes pool/dataset/snapshot/iostat updates to the broker |
+
+### Playbooks
+
+| File | Responsibility |
+|------|---------------|
 | `playbooks/zfs_dataset_create.yml` | Creates filesystem or volume; vars: `name`, `type`, `volsize`, `compression`, `quota`, `mountpoint` |
+| `playbooks/zfs_dataset_destroy.yml` | Destroys dataset/volume; vars: `name`, optional `recursive` |
+| `playbooks/zfs_dataset_set.yml` | Updates dataset properties; vars: `name`, optional `compression`, `quota`, `mountpoint`, `sharenfs`, `sharesmb` |
 | `playbooks/zfs_snapshot_create.yml` | Creates snapshot; vars: `dataset`, `snapname`, `recursive` |
 | `playbooks/zfs_snapshot_destroy.yml` | Destroys snapshot; vars: `snapshot`, `recursive` |
+| `playbooks/zfs_scrub_start.yml` | Starts pool scrub; vars: `pool` |
+| `playbooks/zfs_scrub_cancel.yml` | Cancels running pool scrub; vars: `pool` |
+| `playbooks/acl_set_posix.yml` | Adds/updates a POSIX ACL entry; vars: `dataset`, `entry`, `recursive` |
+| `playbooks/acl_remove_posix.yml` | Removes a POSIX ACL entry; vars: `mountpoint`, `entry`, `recursive` |
+| `playbooks/acl_set_nfs4.yml` | Adds an NFSv4 ACL entry; vars: `dataset`, `entry`, `recursive` |
+| `playbooks/acl_remove_nfs4.yml` | Removes an NFSv4 ACL entry; vars: `mountpoint`, `entry`, `recursive` |
+| `playbooks/dataset_chown.yml` | Sets owner/group on a dataset mountpoint; vars: `mountpoint`, `owner`, `group` |
+| `playbooks/user_create.yml` | Creates local Unix user; vars: `username`, `shell`, optional `uid`, `group`, `groups`, `password`, `create_group` |
+| `playbooks/user_modify.yml` | Modifies local Unix user; vars: `username`, `uid`, optional `shell`, `groups`, `password` |
+| `playbooks/user_delete.yml` | Deletes local Unix user; vars: `username`, `uid` |
+| `playbooks/group_create.yml` | Creates local Unix group; vars: `groupname`, optional `gid` |
+| `playbooks/group_modify.yml` | Modifies local Unix group; vars: `groupname`, `gid`, optional `new_groupname`, `new_gid` |
+| `playbooks/group_delete.yml` | Deletes local Unix group; vars: `groupname`, `gid` |
+| `playbooks/smb_setup.yml` | One-time Samba setup (usershares dir, smb.conf patch); no vars |
+| `playbooks/smb_usershare_set.yml` | Creates/updates a Samba usershare via `net usershare`; vars: `sharename`, `mountpoint` |
+| `playbooks/smb_usershare_unset.yml` | Removes a Samba usershare; vars: `sharename` |
+| `playbooks/smb_user_add.yml` | Registers user in Samba tdbsam; vars: `username`, `smb_password` |
+| `playbooks/smb_user_remove.yml` | Removes user from Samba tdbsam; vars: `username` |
 | `playbooks/inventory/localhost` | `ansible_connection=local`, `ansible_python_interpreter=auto_silent` |
-| `static/index.html` | Page shell, dialogs (new dataset, new snapshot) |
-| `static/app.js` | State, fetch, render functions for pools/datasets/snapshots/iostat, dialog wiring |
+
+### Frontend & install
+
+| File | Responsibility |
+|------|---------------|
+| `static/index.html` | Page shell, all dialogs (dataset, snapshot, user, group, ACL, SMB, etc.) |
+| `static/app.js` | State, fetch, render functions for all tabs; dialog wiring; SSE client |
 | `static/style.css` | Dark monospace theme, CSS variables in `:root` |
 | `contrib/dumpstore.service` | systemd unit; binary at `/usr/local/lib/dumpstore/dumpstore` |
 | `contrib/dumpstore.rc` | FreeBSD rc.d script |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,6 +24,7 @@
 | Software inventory | v0.0.7 | Versions of all runtime tools shown in Sysinfo tab |
 | NFS share management | v0.0.9 | Enable/configure/disable NFS sharing via ZFS `sharenfs` property; cross-platform |
 | SMB share management | v0.1.0 | Create/remove Samba usershares; manage Samba users; one-click Samba setup; cross-platform |
+| Pool scrub management | v0.1.1 | Trigger scrubs, cancel running scrubs, view last scrub time/status/progress per pool |
 
 ---
 
@@ -32,7 +33,7 @@
 | Feature | Priority | Notes |
 |---------|----------|-------|
 | Auto-snapshot scheduling | High | Hourly/daily/weekly/monthly rotation policies; built-in scheduler (sanoid-style) |
-| Pool scrub management | High | Trigger scrubs, view last scrub time/status/progress, schedule periodic scrubs |
+| Pool scrub scheduling | Medium | Schedule periodic scrubs (cron-style) |
 | ZFS native encryption | High | Load/unload keys, encryption status per dataset, keyformat/keylocation support |
 | Dataset rename | Medium | Rename a dataset or volume in place |
 | Snapshot clone | Medium | Create a new dataset from an existing snapshot |

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -143,6 +143,8 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/smb-shares", h.getSMBShares)
 	mux.HandleFunc("POST /api/smb-share/{dataset...}", h.setSMBShare)
 	mux.HandleFunc("DELETE /api/smb-share/{dataset...}", h.deleteSMBShare)
+	mux.HandleFunc("POST /api/scrub/{pool}", h.startScrub)
+	mux.HandleFunc("DELETE /api/scrub/{pool}", h.cancelScrub)
 }
 
 func (h *Handler) getSysInfo(w http.ResponseWriter, r *http.Request) {
@@ -1546,4 +1548,52 @@ func writeError(w http.ResponseWriter, code int, err error, steps []ansible.Task
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_ = json.NewEncoder(w).Encode(apiError{Error: err.Error(), Tasks: steps})
+}
+
+// startScrub handles POST /api/scrub/{pool}
+// Initiates a scrub on the named pool via `zpool scrub`.
+func (h *Handler) startScrub(w http.ResponseWriter, r *http.Request) {
+	pool := r.PathValue("pool")
+	if pool == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("pool name required"), nil)
+		return
+	}
+	if !validZFSName(pool) || strings.Contains(pool, "/") {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid pool name"), nil)
+		return
+	}
+	out, err := h.runOp("zfs_scrub_start.yml", map[string]string{"pool": pool})
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(w, map[string]any{"pool": pool, "tasks": out.Steps()})
+}
+
+// cancelScrub handles DELETE /api/scrub/{pool}
+// Cancels a running scrub on the named pool via `zpool scrub -s`.
+func (h *Handler) cancelScrub(w http.ResponseWriter, r *http.Request) {
+	pool := r.PathValue("pool")
+	if pool == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("pool name required"), nil)
+		return
+	}
+	if !validZFSName(pool) || strings.Contains(pool, "/") {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid pool name"), nil)
+		return
+	}
+	out, err := h.runOp("zfs_scrub_cancel.yml", map[string]string{"pool": pool})
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(w, map[string]any{"pool": pool, "tasks": out.Steps()})
 }

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -10,6 +10,7 @@ import (
 // Unknown topic names in client query params are silently ignored.
 var ValidTopics = map[string]bool{
 	"pool.query":       true,
+	"poolstatus":       true,
 	"dataset.query":    true,
 	"snapshot.query":   true,
 	"iostat":           true,

--- a/internal/broker/poller.go
+++ b/internal/broker/poller.go
@@ -70,6 +70,12 @@ func pollOnce(publish func(string, any)) {
 		slog.Warn("poller: ListPools failed", "err", err)
 	}
 
+	if statuses, err := zfs.PoolStatuses(); err == nil {
+		publish("poolstatus", statuses)
+	} else {
+		slog.Warn("poller: PoolStatuses failed", "err", err)
+	}
+
 	if datasets, err := zfs.ListDatasets(); err == nil {
 		publish("dataset.query", datasets)
 	} else {

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -282,6 +282,7 @@ func parsePoolStatuses(out string) []PoolDetail {
 	var pools []PoolDetail
 	var cur *PoolDetail
 	inConfig := false
+	inScan := false
 
 	for _, line := range strings.Split(out, "\n") {
 		// ── New pool entry ───────────────────────────────────────────────
@@ -291,6 +292,7 @@ func parsePoolStatuses(out string) []PoolDetail {
 			}
 			cur = &PoolDetail{Name: strings.TrimSpace(strings.TrimPrefix(line, "  pool:"))}
 			inConfig = false
+			inScan = false
 			continue
 		}
 		if cur == nil {
@@ -300,23 +302,37 @@ func parsePoolStatuses(out string) []PoolDetail {
 		// ── Top-level keyword lines ──────────────────────────────────────
 		if strings.HasPrefix(line, " state: ") {
 			cur.State = strings.TrimSpace(strings.TrimPrefix(line, " state:"))
+			inScan = false
 			continue
 		}
 		if strings.HasPrefix(line, "status: ") {
 			cur.Status = strings.TrimSpace(strings.TrimPrefix(line, "status:"))
+			inScan = false
 			continue
 		}
 		if strings.HasPrefix(line, "  scan: ") {
 			cur.Scan = strings.TrimSpace(strings.TrimPrefix(line, "  scan:"))
+			inScan = true
 			continue
 		}
 		if strings.HasPrefix(line, "errors: ") {
 			cur.Errors = strings.TrimSpace(strings.TrimPrefix(line, "errors:"))
+			inScan = false
 			continue
 		}
 		if strings.TrimSpace(line) == "config:" {
 			inConfig = true
+			inScan = false
 			continue
+		}
+
+		// ── Scan continuation lines (tab-prefixed, before config:) ───────
+		if inScan && !inConfig && strings.HasPrefix(line, "\t") {
+			cur.Scan += "\n" + strings.TrimSpace(line)
+			continue
+		}
+		if inScan && !strings.HasPrefix(line, "\t") {
+			inScan = false
 		}
 
 		if !inConfig {

--- a/playbooks/zfs_scrub_cancel.yml
+++ b/playbooks/zfs_scrub_cancel.yml
@@ -1,0 +1,20 @@
+---
+# Required extra vars:
+#   pool  - pool name (e.g. tank)
+- name: Cancel ZFS pool scrub
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pool is defined and pool != ""
+          - pool is not search("/")
+          - pool is not search("@")
+        fail_msg: "pool must be a valid pool name (no slashes or @)"
+
+    - name: Cancel scrub
+      ansible.builtin.command:
+        cmd: zpool scrub -s {{ pool }}
+      register: cancel_result
+      changed_when: cancel_result.rc == 0

--- a/playbooks/zfs_scrub_start.yml
+++ b/playbooks/zfs_scrub_start.yml
@@ -1,0 +1,20 @@
+---
+# Required extra vars:
+#   pool  - pool name (e.g. tank)
+- name: Start ZFS pool scrub
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pool is defined and pool != ""
+          - pool is not search("/")
+          - pool is not search("@")
+        fail_msg: "pool must be a valid pool name (no slashes or @)"
+
+    - name: Start scrub
+      ansible.builtin.command:
+        cmd: zpool scrub {{ pool }}
+      register: scrub_result
+      changed_when: scrub_result.rc == 0

--- a/static/app.js
+++ b/static/app.js
@@ -143,20 +143,21 @@ function setRefreshing(v) {
 }
 
 // ── Load all ──────────────────────────────────────────────────────────────────
+// Fast path: all endpoints that respond in <100 ms. Rendered immediately.
+// Slow path: iostat (~1 s sampling) and SMART (drive scans) load separately
+// so they never block the initial page render.
 async function loadAll() {
   setRefreshing(true);
   try {
-    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, iostat, smart, users, groups, smbData, smbShares] = await Promise.all([
-      api('GET', '/api/pools'),
-      api('GET', '/api/poolstatus'),
-      api('GET', '/api/version'),
-      api('GET', '/api/sysinfo'),
-      api('GET', '/api/datasets'),
-      api('GET', '/api/snapshots'),
-      api('GET', '/api/iostat'),
-      api('GET', '/api/smart'),
-      api('GET', '/api/users'),
-      api('GET', '/api/groups'),
+    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, users, groups, smbData, smbShares] = await Promise.all([
+      api('GET', '/api/pools').catch(() => []),
+      api('GET', '/api/poolstatus').catch(() => []),
+      api('GET', '/api/version').catch(() => null),
+      api('GET', '/api/sysinfo').catch(() => null),
+      api('GET', '/api/datasets').catch(() => []),
+      api('GET', '/api/snapshots').catch(() => []),
+      api('GET', '/api/users').catch(() => []),
+      api('GET', '/api/groups').catch(() => []),
       api('GET', '/api/smb-users').catch(() => null),
       api('GET', '/api/smb-shares').catch(() => []),
     ]);
@@ -166,8 +167,6 @@ async function loadAll() {
     state.sysinfo = sysinfo || null;
     state.datasets = datasets || [];
     state.snapshots = snapshots || [];
-    state.iostat = iostat || [];
-    state.smart = smart || null;
     state.users = users || [];
     state.groups = groups || [];
     state.sambaAvailable = smbData?.available ?? false;
@@ -178,8 +177,6 @@ async function loadAll() {
     renderSoftware();
     renderDatasets();
     renderSnapshots();
-    renderIOStat();
-    renderSMART();
     renderUsers();
     renderGroups();
     renderSambaUsers();
@@ -190,6 +187,19 @@ async function loadAll() {
     setRefreshing(false);
   }
   refreshACLStatus();
+  loadSlowMetrics();
+}
+
+// Loads iostat (~1 s) and SMART (drive scans) without blocking the main render.
+async function loadSlowMetrics() {
+  const [iostat, smart] = await Promise.all([
+    api('GET', '/api/iostat').catch(() => []),
+    api('GET', '/api/smart').catch(() => null),
+  ]);
+  state.iostat = iostat || [];
+  state.smart = smart || null;
+  renderIOStat();
+  renderSMART();
 }
 
 // ── Formatting: uptime ────────────────────────────────────────────────────────
@@ -282,9 +292,18 @@ if (!state.pools.length) {
     const barClass = pct > 90 ? 'crit' : pct > 75 ? 'warn' : '';
     const detail = statusMap[p.name];
 
+    const scrubState = detail?.scan ? scrubStateOf(detail.scan) : 'idle';
     const scanLine = detail?.scan
       ? `<div class="pool-scan">${esc(detail.scan)}</div>`
       : '';
+
+    const scrubActions = `
+      <div class="pool-scrub-actions">
+        ${scrubState === 'in_progress' || scrubState === 'paused'
+          ? `<button class="btn-secondary btn-sm" onclick="cancelScrub('${p.name}')">Cancel Scrub</button>`
+          : `<button class="btn-secondary btn-sm" onclick="startScrub('${p.name}')">Start Scrub</button>`
+        }
+      </div>`;
 
     const statusLine = detail?.status
       ? `<div class="pool-status-msg">${esc(detail.status)}</div>`
@@ -348,9 +367,42 @@ if (!state.pools.length) {
             <div class="stat-value">${esc(p.dedup)}</div>
           </div>
         </div>
-        ${scanLine}${statusLine}${errLine}${vdevSection}
+        ${scanLine}${scrubActions}${statusLine}${errLine}${vdevSection}
       </div>`;
   }).join('');
+}
+
+// ── Pool scrub helpers ────────────────────────────────────────────────────────
+// Returns 'in_progress', 'paused', or 'idle' based on the raw scan string.
+function scrubStateOf(scan) {
+  if (!scan) return 'idle';
+  if (scan.startsWith('scrub in progress')) return 'in_progress';
+  if (scan.startsWith('scrub paused')) return 'paused';
+  return 'idle';
+}
+
+async function startScrub(pool) {
+  showOpLogRunning(`Start scrub: ${pool}`);
+  try {
+    const data = await api('POST', `/api/scrub/${encodeURIComponent(pool)}`);
+    showOpLog(`Start scrub: ${pool}`, data.tasks, null);
+    toast(`Scrub started on ${pool}`, 'ok');
+    await loadAll();
+  } catch (err) {
+    showOpLog(`Start scrub: ${pool}`, err.tasks, err.message);
+  }
+}
+
+async function cancelScrub(pool) {
+  showOpLogRunning(`Cancel scrub: ${pool}`);
+  try {
+    const data = await api('DELETE', `/api/scrub/${encodeURIComponent(pool)}`);
+    showOpLog(`Cancel scrub: ${pool}`, data.tasks, null);
+    toast(`Scrub cancelled on ${pool}`, 'ok');
+    await loadAll();
+  } catch (err) {
+    showOpLog(`Cancel scrub: ${pool}`, err.tasks, err.message);
+  }
 }
 
 // ── Render: I/O Stats ─────────────────────────────────────────────────────────
@@ -1885,12 +1937,13 @@ document.getElementById('smbDisableBtn').addEventListener('click', async () => {
 // ── SSE client ────────────────────────────────────────────────────────────────
 // Maps SSE topic names → state key + render function.
 const sseTopicMap = {
-  'pool.query':     { key: 'pools',     render: renderPools },
-  'dataset.query':  { key: 'datasets',  render: renderDatasets },
-  'snapshot.query': { key: 'snapshots', render: renderSnapshots },
-  'iostat':         { key: 'iostat',    render: renderIOStat },
-  'user.query':     { key: 'users',     render: renderUsers },
-  'group.query':    { key: 'groups',    render: renderGroups },
+  'pool.query':     { key: 'pools',        render: renderPools },
+  'poolstatus':     { key: 'poolStatuses', render: renderPools },
+  'dataset.query':  { key: 'datasets',     render: renderDatasets },
+  'snapshot.query': { key: 'snapshots',    render: renderSnapshots },
+  'iostat':         { key: 'iostat',       render: renderIOStat },
+  'user.query':     { key: 'users',        render: renderUsers },
+  'group.query':    { key: 'groups',       render: renderGroups },
 };
 
 let _pollInterval = null;  // setInterval handle; null when SSE is active

--- a/static/style.css
+++ b/static/style.css
@@ -230,9 +230,15 @@ main {
   margin-top: 0.6rem;
   font-size: 10px;
   color: var(--text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.pool-scrub-actions {
+  margin-top: 0.6rem;
+}
+.btn-sm {
+  padding: 0.2rem 0.6rem;
+  font-size: 11px;
 }
 .pool-status-msg {
   margin-top: 0.4rem;

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1,0 +1,228 @@
+# API Reference
+
+All endpoints are served at `http://<host>:8080`. The API is JSON-over-HTTP; all request and response bodies are `application/json`.
+
+## Endpoint overview
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET    | `/api/sysinfo`              | Host and process info |
+| GET    | `/api/version`              | OpenZFS version string |
+| GET    | `/api/pools`                | List all pools with usage stats |
+| GET    | `/api/poolstatus`           | Detailed pool status with vdev tree |
+| GET    | `/api/datasets`             | List all datasets and volumes |
+| GET    | `/api/dataset-props/{name}` | Editable properties for a dataset |
+| GET    | `/api/snapshots`            | List all snapshots |
+| GET    | `/api/iostat`               | Pool I/O statistics (1-second sample) |
+| GET    | `/api/smart`                | S.M.A.R.T. health per disk |
+| GET    | `/api/events`               | Server-Sent Events stream |
+| GET    | `/metrics`                  | Prometheus text exposition |
+| POST   | `/api/datasets`             | Create a dataset or volume |
+| PATCH  | `/api/datasets/{name}`      | Update dataset properties |
+| DELETE | `/api/datasets/{name}`      | Destroy a dataset or volume |
+| POST   | `/api/snapshots`            | Create a snapshot |
+| DELETE | `/api/snapshots/{name}`     | Destroy a snapshot |
+| GET    | `/api/users`                | List local users |
+| POST   | `/api/users`                | Create a local user |
+| PUT    | `/api/users/{name}`         | Edit user (shell, groups, password) |
+| DELETE | `/api/users/{name}`         | Delete user and home directory |
+| GET    | `/api/groups`               | List local groups |
+| POST   | `/api/groups`               | Create a local group |
+| PUT    | `/api/groups/{name}`        | Edit group (name, GID, members) |
+| DELETE | `/api/groups/{name}`        | Delete a local group |
+| GET    | `/api/chown/{dataset}`      | Get mountpoint owner and group |
+| POST   | `/api/chown/{dataset}`      | Set mountpoint owner and/or group |
+| GET    | `/api/acl-status`           | ACL presence map (dataset → bool) |
+| GET    | `/api/acl/{dataset}`        | Get ACL entries for a dataset |
+| POST   | `/api/acl/{dataset}`        | Add or modify an ACL entry |
+| DELETE | `/api/acl/{dataset}`        | Remove an ACL entry |
+| GET    | `/api/smb-shares`           | List active Samba usershares |
+| POST   | `/api/smb-share/{dataset}`  | Create or update a Samba usershare |
+| DELETE | `/api/smb-share/{dataset}`  | Remove a Samba usershare |
+| GET    | `/api/smb-users`            | List users registered in smbpasswd |
+| POST   | `/api/smb-users/{name}`     | Add a user to smbpasswd |
+| DELETE | `/api/smb-users/{name}`     | Remove a user from smbpasswd |
+| POST   | `/api/smb-config/pam`       | Run Samba setup playbook |
+| POST   | `/api/scrub/{pool}`         | Start a pool scrub |
+| DELETE | `/api/scrub/{pool}`         | Cancel a running pool scrub |
+
+---
+
+## Datasets
+
+### POST /api/datasets
+
+Create a filesystem or volume.
+
+```json
+{
+  "name": "tank/data",
+  "type": "filesystem",
+  "compression": "lz4",
+  "quota": "50G",
+  "mountpoint": "/mnt/data",
+  "recordsize": "128K",
+  "atime": "off",
+  "exec": "on",
+  "sync": "standard",
+  "dedup": "off",
+  "copies": "1",
+  "xattr": "sa"
+}
+```
+
+For volumes, use `"type": "volume"` and add `"volsize": "10G"`. Optional: `"volblocksize"`, `"sparse": true`.
+
+### PATCH /api/datasets/{name}
+
+Update dataset properties. Any subset of editable properties may be sent. An empty string value resets the property to inherited; a non-empty value sets it explicitly. Unknown properties are ignored.
+
+```json
+{
+  "compression": "zstd",
+  "quota": "",
+  "readonly": "on"
+}
+```
+
+Editable properties: `compression`, `quota`, `mountpoint`, `recordsize`, `atime`, `exec`, `sync`, `dedup`, `copies`, `xattr`, `readonly`, `acltype`, `sharenfs`, `sharesmb`.
+
+### DELETE /api/datasets/{name}
+
+Destroy a dataset or volume. Append `?recursive=true` to also destroy all child datasets and snapshots.
+
+Pool roots (e.g. `tank`) cannot be deleted via this endpoint — use `zpool destroy`.
+
+---
+
+## Snapshots
+
+### POST /api/snapshots
+
+```json
+{
+  "dataset": "tank/data",
+  "snapname": "2024-01-15_backup",
+  "recursive": false
+}
+```
+
+### DELETE /api/snapshots/{dataset}@{snapname}
+
+Append `?recursive=true` to also destroy clones.
+
+---
+
+## Pool scrub
+
+### POST /api/scrub/{pool}
+
+Start a scrub on the named pool. Returns Ansible task steps.
+
+### DELETE /api/scrub/{pool}
+
+Cancel a running scrub on the named pool. Returns Ansible task steps.
+
+---
+
+## ACLs
+
+### GET /api/acl/{dataset}
+
+Returns the ACL type and entries for the dataset's mountpoint.
+
+```json
+{
+  "dataset": "tank/data",
+  "mountpoint": "/mnt/data",
+  "acl_type": "posix",
+  "entries": [
+    { "tag": "user",  "qualifier": "",      "perms": "rwx", "default": false },
+    { "tag": "user",  "qualifier": "alice", "perms": "r-x", "default": false },
+    { "tag": "group", "qualifier": "",      "perms": "r-x", "default": false },
+    { "tag": "mask",  "qualifier": "",      "perms": "rwx", "default": false },
+    { "tag": "other", "qualifier": "",      "perms": "---", "default": false }
+  ]
+}
+```
+
+`acl_type` is one of `"posix"`, `"nfsv4"`, or `"off"`.
+
+For NFSv4 datasets each entry has the form:
+```json
+{ "tag": "A", "flags": "fd", "qualifier": "OWNER@", "perms": "rwaDxtTnNcCoy" }
+```
+
+### POST /api/acl/{dataset}
+
+Add or modify an ACL entry. The `ace` string format depends on the dataset's `acltype`:
+
+- **POSIX**: `setfacl -m` spec — `"user:alice:rwx"`, `"group:storage:r-x"`, `"default:user:alice:rwx"`
+- **NFSv4**: full ACE string — `"A::alice@localdomain:rwaDxtTnNcCoy"`
+
+```json
+{ "ace": "user:alice:rwx", "recursive": false }
+```
+
+`recursive` (POSIX only) applies `setfacl -R` to all files inside the mountpoint.
+
+### DELETE /api/acl/{dataset}?entry=\<spec\>
+
+Remove an ACL entry. The `entry` query parameter:
+
+- **POSIX**: `user:alice`, `default:group:storage`
+- **NFSv4**: full ACE string to match
+
+Append `&recursive=true` (POSIX only) to remove recursively.
+
+---
+
+## Server-Sent Events
+
+### GET /api/events
+
+Subscribe to live data updates. The server pushes named events whenever data changes.
+
+**Query parameter:** `topics` — comma-separated list of topics to subscribe to.
+
+**Available topics:**
+
+| Topic            | Data                              | Cadence                     |
+|------------------|-----------------------------------|-----------------------------|
+| `pool.query`     | Same JSON as `GET /api/pools`     | Every 10 s on change        |
+| `poolstatus`     | Same JSON as `GET /api/poolstatus`| Every 10 s on change        |
+| `dataset.query`  | Same JSON as `GET /api/datasets`  | Every 10 s on change        |
+| `snapshot.query` | Same JSON as `GET /api/snapshots` | Every 10 s on change        |
+| `iostat`         | Same JSON as `GET /api/iostat`    | Every 10 s                  |
+| `user.query`     | Same JSON as `GET /api/users`     | Every 10 s on change + after writes |
+| `group.query`    | Same JSON as `GET /api/groups`    | Every 10 s on change + after writes |
+| `ansible.progress` | Single `TaskStep` object        | Streamed during playbook run |
+
+```
+event: pool.query
+data: [{"name":"tank","health":"ONLINE",...}]
+
+event: iostat
+data: [{"pool":"tank","read_ops":0,"write_ops":443,...}]
+```
+
+Example — watch pool health and I/O live:
+
+```bash
+curl -N 'http://localhost:8080/api/events?topics=pool.query,iostat'
+```
+
+---
+
+## Error responses
+
+Non-2xx responses return:
+
+```json
+{
+  "error": "human-readable message",
+  "tasks": [ ... ]
+}
+```
+
+`tasks` is populated for Ansible-backed operations and contains the step results up to the point of failure.

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,146 @@
+# Architecture
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                     Browser  (vanilla JS SPA)                       │
+│  state object → render functions → api() helper                     │
+│                                                                     │
+│  ┌─ boot ──────────────────────────────────────────────────────┐    │
+│  │  loadAll() → parallel REST fetches (fast path first)        │    │
+│  │  startSSE() → EventSource /api/events?topics=…              │    │
+│  │    on message: state[key] = data; render()                  │    │
+│  │    on close:   fallback to setInterval(loadAll, 30 000)     │    │
+│  └─────────────────────────────────────────────────────────────┘    │
+└──────────────────────────┬──────────────────────────────────────────┘
+                           │ HTTP :8080  (REST + SSE)
+                           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                          main.go                                    │
+│  • flag: -addr  -dir  -debug                                        │
+│  • startup: checks ansible-playbook in PATH,                        │
+│             playbooks/ and static/ dirs exist                       │
+│  • signal.NotifyContext → graceful shutdown on SIGTERM/SIGINT       │
+│  • GET /      → http.FileServer  (static/)                          │
+│  • /api/*     → api.Handler                                         │
+└───────────────────┬─────────────────────────────────────────────────┘
+                    │
+      ┌─────────────┼───────────────────────────────┐
+      │             │                               │
+      │     ┌───────┴──────────────────┐            │
+      │     │  internal/broker         │            │
+      │     │                          │            │
+      │     │  Broker — pub/sub core   │◄── StartPoller() goroutine
+      │     │    Subscribe(topic)      │    polls ZFS + users/groups every 10 s
+      │     │    Publish(topic, data)  │    publishes only on change
+      │     │    Unsubscribe(topic,ch) │
+      │     │                          │
+      │     │  GET /api/events         │──► streams SSE to browsers
+      │     └──────────────────────────┘
+      │
+      ├─── READ requests                    WRITE requests ───────────┐
+      │  pools, datasets, snapshots,      create / edit / destroy     │
+      │  iostat, status, props,           datasets, snapshots,        │
+      │  sysinfo, SMART, metrics,         users, groups, ACLs,        │
+      │  users, groups, ACLs,             SMB users/shares/config,    │
+      │  SMB users/shares, chown          dataset chown, scrub        │
+      │                                                               │
+      ▼                                                               ▼
+┌───────────────────────┐                        ┌────────────────────────────┐
+│  internal/zfs/zfs.go  │                        │ internal/ansible/runner.go │
+│  internal/system/     │                        │                            │
+│  internal/smart/      │                        │  Run(playbook, extraVars)  │
+│                       │                        │                            │
+│  ListPools()          │                        │  exec: ansible-playbook    │
+│  ListDatasets()       │                        │    -i inventory/localhost  │
+│  ListSnapshots()      │                        │    --extra-vars '{...}'    │
+│  IOStats()            │                        │  env: ANSIBLE_STDOUT_      │
+│  GetDatasetProps()    │                        │    CALLBACK=ndjson         │
+│  GetDatasetACL()      │                        │                            │
+│  GetMountpointOwner() │                        │  parse ndjson output       │
+│  PoolStatuses()       │                        │  → []TaskStep              │
+│  Version()            │                        │  streams live via SSE      │
+│  system.Get()         │                        │                            │
+│  system.ListUsers()   │                        │                            │
+│  system.ListGroups()  │                        │                            │
+│  smart.Collect()      │                        │                            │
+│                       │                        │                            │
+│  exec: zpool / zfs /  │                        │                            │
+│  smartctl / sysctl /  │                        │                            │
+│  pdbedit / net        │                        │                            │
+│  (no Python startup)  │                        │                            │
+└──────────┬────────────┘                        └────────────┬───────────────┘
+           │                                                  │
+           ▼                                                  ▼
+     ZFS kernel                                       playbooks/*.yml
+     subsystem                                        ┌──────────────────────┐
+                                                      │  targets: localhost  │
+                                                      │  gather_facts: false │
+                                                      │  1. assert vars      │
+                                                      │  2. mutating command │
+                                                      └──────────────────────┘
+```
+
+## Read/write split
+
+All read operations call ZFS/system CLI tools directly via `exec.Command`. All write operations go through Ansible playbooks.
+
+| Concern         | Reads                              | Writes                               |
+|-----------------|------------------------------------|--------------------------------------|
+| **Mechanism**   | `exec.Command(zpool/zfs/smartctl)` | `exec.Command(ansible-playbook)`     |
+| **Latency**     | Fast — no Python startup           | ~1–2 s — acceptable for mutations    |
+| **Output**      | Parsed from tab-separated stdout   | Parsed from ndjson callback output   |
+| **Audit trail** | None needed                        | Task names + changed/failed per step |
+| **Idempotency** | N/A                                | Enforced by playbook `assert` tasks  |
+
+This split exists to avoid Ansible's Python startup overhead on every read. Do not change it without a good reason.
+
+## Write operation request flow
+
+```
+Browser
+  │  POST /api/snapshots  {"dataset":"tank/data","snapname":"bkp"}
+  ▼
+handlers.go: createSnapshot()
+  │  validate input (no @;|&$` chars)
+  │  build extraVars map
+  ▼
+runner.go: Run("zfs_snapshot_create.yml", vars)
+  │  marshal vars → --extra-vars '{"dataset":"tank/data",...}'
+  │  set ANSIBLE_STDOUT_CALLBACK=ndjson
+  ▼
+ansible-playbook (subprocess)
+  │  assert: dataset defined, no bad chars
+  │  command: zfs snapshot tank/data@bkp
+  ▼
+runner.go: parse JSON stdout → PlaybookOutput → []TaskStep
+  ▼
+handlers.go: return 201 {"snapshot":"tank/data@bkp","tasks":[...]}
+  ▼
+Browser: showOpLog() renders task steps in modal
+```
+
+## Frontend
+
+The frontend is vanilla JS with no build step. All data lives in a single `state` object. Render functions are pure — they read from `state` and write `innerHTML`.
+
+On boot:
+1. `loadAll()` fetches all fast endpoints in parallel and renders immediately
+2. `loadSlowMetrics()` fires in parallel for `/api/iostat` (~1 s) and `/api/smart` (drive scans), updating the I/O and disk health sections when ready
+3. `startSSE()` opens a persistent `EventSource` connection; on each message `state[key] = data; render()`
+4. If SSE drops, the client falls back to `setInterval(loadAll, 30_000)` and retries SSE after 5 s
+
+## Playbook conventions
+
+All playbooks target `localhost` with `gather_facts: false`. Each playbook:
+
+1. Declares required extra vars in a header comment
+2. Has an `assert` task that validates all inputs before any mutation
+3. Has stable task names (the runner looks them up by name for `RunAndGetStdout`)
+
+## Security
+
+- Input to Ansible extra-vars is validated for shell-special characters (`@;|&$\``) before the playbook call
+- `static/` is served by `http.FileServer` — do not put secrets there
+- The service runs as root (required for ZFS); do not expose it on a public interface without authentication in front of it

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,43 @@
+# dumpstore
+
+A lightweight NAS management UI written in Go — built for Linux and FreeBSD, designed to stay out of the way of a vanilla system.
+
+No container runtime, no database, no Node.js. Just a single compiled binary, some Ansible playbooks, and a handful of static files.
+
+## Features
+
+- **System info** — hostname, OS, kernel, CPU, uptime, load averages, process stats
+- **Pool overview** — health badges, usage bars, fragmentation, deduplication ratio, vdev tree
+- **Pool scrub management** — trigger scrubs, cancel running scrubs, view last scrub time/status/progress per pool
+- **I/O statistics** — live read/write IOPS and bandwidth per pool
+- **Disk health** — S.M.A.R.T. data per drive (temperature, power-on hours, reallocated sectors, pending sectors, uncorrectable errors)
+- **Dataset browser** — depth-indented collapsible tree, compression, quota, mountpoint; ACL, NFS, and SMB buttons light up when configured
+- **Dataset creation** — create filesystems and volumes with any combination of ZFS properties
+- **Dataset editing** — update properties in place (set or inherit)
+- **Dataset deletion** — destroy datasets and volumes with recursive option and confirm-by-typing dialog
+- **Snapshot management** — list, create (recursive), and delete snapshots
+- **User management** — list, create, edit, and delete local users; system users (uid < 1000) hidden by default
+- **Group management** — list, create, edit, and delete local groups; system groups hidden by default
+- **NFS share management** — enable, configure, and disable NFS sharing per dataset via the ZFS `sharenfs` property; cross-platform
+- **SMB share management** — create and remove Samba usershares; manage Samba users; one-click Samba setup
+- **ACL management** — POSIX ACL and NFSv4 ACL entries per dataset; recursive apply supported
+- **Live updates** — Server-Sent Events push changes every 10 s; falls back to 30 s REST polling
+- **Prometheus metrics** — Go runtime, HTTP request counters/latency, Ansible playbook metrics at `GET /metrics`
+
+## Quick start
+
+```bash
+git clone https://github.com/langerma/dumpstore.git
+cd dumpstore
+sudo ./install.sh
+```
+
+The service starts automatically and listens on `http://localhost:8080`.
+
+See [[Installation]] for detailed instructions, requirements, and configuration.
+
+## Pages
+
+- [[Installation]] — requirements, install script, make, manual build, service configuration
+- [[API Reference]] — full REST API documentation with request/response examples
+- [[Architecture]] — design overview, read/write split, SSE stream, request flow

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,0 +1,152 @@
+# Installation
+
+## Requirements
+
+|                        | Linux                                                     | FreeBSD                                      |
+|------------------------|-----------------------------------------------------------|----------------------------------------------|
+| ZFS                    | `zfsutils-linux` or equivalent                            | built-in (`zfsutils` pkg for older releases) |
+| Ansible                | `ansible` package (Python 3)                              | `py311-ansible` or equivalent                |
+| Service manager        | systemd                                                   | rc.d (via `daemon(8)`)                       |
+| S.M.A.R.T. (optional)  | `smartmontools`                                           | `smartmontools` pkg                          |
+| POSIX ACLs (optional)  | `acl` pkg (`getfacl`/`setfacl`)                           | `py311-pylibacl` or `acl` port               |
+| NFS sharing (optional) | `nfs-kernel-server` (Debian) or `nfs-utils` (RHEL/Fedora) | built-in base system                         |
+| SMB sharing (optional) | `samba` (`smbd`, `net`, `pdbedit`)                        | `samba` pkg                                  |
+| NFSv4 ACLs (optional)  | `nfs4-acl-tools` pkg                                      | `nfs4-acl-tools` port                        |
+| Build                  | Go 1.22+                                                  | Go 1.22+                                     |
+
+Go and Ansible are the only hard requirements. ZFS must be available on the target machine.
+
+### Optional packages
+
+Install only what you need:
+
+```bash
+# Debian/Ubuntu — POSIX ACLs
+apt install acl
+
+# Debian/Ubuntu — NFS sharing
+apt install nfs-kernel-server
+systemctl enable --now nfs-server
+
+# Debian/Ubuntu — NFSv4 ACLs
+apt install nfs4-acl-tools
+
+# Debian/Ubuntu — SMB sharing
+apt install samba
+
+# RHEL/Fedora — NFS sharing
+dnf install nfs-utils
+systemctl enable --now nfs-server
+
+# RHEL/Fedora — ACLs
+dnf install acl nfs4-acl-tools
+```
+
+After installing Samba, run **Configure Samba** from the dumpstore UI (Users & Groups → Configure Samba) or manually:
+
+```bash
+ansible-playbook playbooks/smb_setup.yml
+```
+
+---
+
+## Install script (recommended)
+
+Clone the repository and run `install.sh` as root. It checks prerequisites, builds the binary, installs everything to `/usr/local/lib/dumpstore/`, and registers the service.
+
+```bash
+git clone https://github.com/langerma/dumpstore.git
+cd dumpstore
+sudo ./install.sh
+```
+
+To remove dumpstore completely:
+
+```bash
+sudo ./install.sh --uninstall
+```
+
+---
+
+## Using make
+
+```bash
+# Optional: tag a release (omitting gives "dev" as version)
+git tag v0.1.0
+
+make build
+sudo make install
+```
+
+`make install` detects the OS automatically and registers the appropriate service. The service will be available at `http://localhost:8080`.
+
+---
+
+## Run without installing
+
+```bash
+go build -o dumpstore .
+sudo ./dumpstore -addr :8080 -dir .
+```
+
+`-dir` must point to the directory that contains `playbooks/` and `static/`. It defaults to the directory of the executable.
+
+---
+
+## Service configuration
+
+### Linux (systemd)
+
+The unit file is installed to `/etc/systemd/system/dumpstore.service`.
+
+To change the listen address, edit `ExecStart` in the unit file:
+
+```bash
+sudo systemctl edit dumpstore
+# add:
+# [Service]
+# ExecStart=
+# ExecStart=/usr/local/lib/dumpstore/dumpstore -addr :9090
+sudo systemctl daemon-reload && sudo systemctl restart dumpstore
+```
+
+### FreeBSD (rc.d)
+
+The rc script is installed to `/usr/local/etc/rc.d/dumpstore`. To customise, add to `/etc/rc.conf`:
+
+```
+dumpstore_enable="YES"
+dumpstore_addr=":9090"
+dumpstore_dir="/usr/local/lib/dumpstore"
+```
+
+Then restart: `service dumpstore restart`
+
+---
+
+## Uninstall
+
+```bash
+sudo make uninstall
+# or
+sudo ./install.sh --uninstall
+```
+
+---
+
+## Versioning
+
+Releases are tagged with semver (`v0.1.0`, `v0.2.0`, …). The version is injected at build time via ldflags:
+
+```
+v0.1.0                 ← exact tag
+v0.1.0-3-gabcdef       ← 3 commits after tag
+v0.1.0-3-gabcdef-dirty ← uncommitted changes present
+dev                    ← built outside git
+```
+
+The version appears in:
+- `./dumpstore -version`
+- `GET /api/sysinfo` → `app_version` field
+- `GET /metrics` → `dumpstore_build_info{version="..."}` label
+- UI version badge


### PR DESCRIPTION
- Add Start/Cancel scrub buttons per pool (POST/DELETE /api/scrub/{pool})
- Playbooks: zfs_scrub_start.yml, zfs_scrub_cancel.yml
- Parse scrub state from zpool status scan line (in_progress/paused/idle)
- Fix scrub button onclick: JSON.stringify broke HTML attributes, use single quotes
- Split loadAll into fast path + loadSlowMetrics (iostat/SMART) to avoid ~1s iostat blocking initial render; add .catch() on every api() call
- Add wiki/ directory (Home, Installation, API Reference, Architecture)
- Add .github/workflows/wiki-sync.yml to auto-push wiki/ to GitHub Wiki on main
- Update CLAUDE.md file map and workflow rules