### PR TITLE
feat: scrub schedule management (Linux zfsutils + FreeBSD periodic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,6 @@ The browser UI uses `EventSource` to subscribe to all six topics and falls back 
 | Dataset rename           | Rename a dataset or volume in place                                                           |
 | Snapshot clone           | Create a new dataset from an existing snapshot                                                |
 | Auto-snapshot scheduling | Hourly/daily/weekly/monthly rotation policies; built-in scheduler (sanoid-style)              |
-| Pool scrub management    | Trigger scrubs, view last scrub time/status/progress, schedule periodic scrubs                |
 | ZFS native encryption    | Load/unload keys, show encryption status per dataset, support keyformat/keylocation           |
 | iSCSI target management  | Expose zvols as iSCSI targets (targetcli on Linux, ctld on FreeBSD)                           |
 | Pool import/export       | Import available pools from attached devices; export pools safely                             |
@@ -596,5 +595,6 @@ The browser UI uses `EventSource` to subscribe to all six topics and falls back 
 | Per-user quota tracking  | Show space usage per user/group (`zfs userspace` / `zfs groupspace`)                          |
 | ZFS send/receive         | Pool replication and off-site backup                                                          |
 | Alerts                   | Configurable thresholds for pool health, disk temp, capacity                                  |
+| ~~Pool scrub management~~| ~~Trigger scrubs, view last scrub time/status/progress, schedule periodic scrubs~~ — **done** (start/cancel + periodic schedule; Linux `zfsutils-linux`, FreeBSD `periodic.conf`) |
 | ~~NFS share management~~ | ~~List, create, and remove NFS exports~~ — **done** (ZFS `sharenfs` property; cross-platform)         |
 | ~~SMB share management~~ | ~~List, create, and remove Samba shares~~ — **done** (`net usershare`; Samba user management; setup playbook) |

--- a/docs/index.html
+++ b/docs/index.html
@@ -468,6 +468,13 @@
       </div>
       <div class="pool-card">
         <div class="pool-card-header">
+          <span class="pool-name">scrub management</span>
+          <span class="health-badge badge-blue">scrub</span>
+        </div>
+        <p>Trigger and cancel pool scrubs. Configure periodic scrub schedules — <code>zfsutils-linux</code> on Linux, <code>periodic.conf</code> on FreeBSD.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
           <span class="pool-name">I/O statistics</span>
           <span class="health-badge badge-blue">live</span>
         </div>

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -145,6 +146,9 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE /api/smb-share/{dataset...}", h.deleteSMBShare)
 	mux.HandleFunc("POST /api/scrub/{pool}", h.startScrub)
 	mux.HandleFunc("DELETE /api/scrub/{pool}", h.cancelScrub)
+	mux.HandleFunc("GET /api/scrub-schedules", h.listScrubSchedules)
+	mux.HandleFunc("PUT /api/scrub-schedule/{pool}", h.setScrubSchedule)
+	mux.HandleFunc("DELETE /api/scrub-schedule/{pool}", h.deleteScrubSchedule)
 }
 
 func (h *Handler) getSysInfo(w http.ResponseWriter, r *http.Request) {
@@ -1587,6 +1591,94 @@ func (h *Handler) cancelScrub(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	out, err := h.runOp("zfs_scrub_cancel.yml", map[string]string{"pool": pool})
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(w, map[string]any{"pool": pool, "tasks": out.Steps()})
+}
+
+// listScrubSchedules handles GET /api/scrub-schedules
+// Returns mode + schedules from the platform cron source (Linux) or
+// /etc/periodic.conf (FreeBSD).
+func (h *Handler) listScrubSchedules(w http.ResponseWriter, r *http.Request) {
+	list, err := zfs.ScrubSchedules()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("reading scrub schedules: %w", err), nil)
+		return
+	}
+	writeJSON(w, list)
+}
+
+// setScrubSchedule handles PUT /api/scrub-schedule/{pool}
+// Linux:   adds pool to ZFS_SCRUB_POOLS in /etc/default/zfs.
+// FreeBSD: adds pool to daily_scrub_zfs_pools in /etc/periodic.conf and sets
+//
+//	the scrub threshold (threshold_days, default 35).
+func (h *Handler) setScrubSchedule(w http.ResponseWriter, r *http.Request) {
+	pool := r.PathValue("pool")
+	if pool == "" || !validZFSName(pool) || strings.Contains(pool, "/") {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid pool name"), nil)
+		return
+	}
+
+	if zfs.OSType() == "freebsd" {
+		var req struct {
+			ThresholdDays int `json:"threshold_days"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req) // threshold_days optional
+		if req.ThresholdDays <= 0 {
+			req.ThresholdDays = 35
+		}
+		out, err := h.runOp("zfs_scrub_periodic_enable.yml", map[string]string{
+			"pool":           pool,
+			"threshold_days": strconv.Itoa(req.ThresholdDays),
+		})
+		if err != nil {
+			var steps []ansible.TaskStep
+			if out != nil {
+				steps = out.Steps()
+			}
+			writeError(w, http.StatusInternalServerError, err, steps)
+			return
+		}
+		writeJSON(w, map[string]any{"pool": pool, "tasks": out.Steps()})
+		return
+	}
+
+	// Linux: add to ZFS_SCRUB_POOLS — no schedule params required.
+	out, err := h.runOp("zfs_scrub_zfsutils_enable.yml", map[string]string{"pool": pool})
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(w, map[string]any{"pool": pool, "tasks": out.Steps()})
+}
+
+// deleteScrubSchedule handles DELETE /api/scrub-schedule/{pool}
+// Linux:   removes pool from ZFS_SCRUB_POOLS in /etc/default/zfs.
+// FreeBSD: removes pool from daily_scrub_zfs_pools in /etc/periodic.conf.
+func (h *Handler) deleteScrubSchedule(w http.ResponseWriter, r *http.Request) {
+	pool := r.PathValue("pool")
+	if pool == "" || !validZFSName(pool) || strings.Contains(pool, "/") {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid pool name"), nil)
+		return
+	}
+
+	playbook := "zfs_scrub_zfsutils_disable.yml"
+	if zfs.OSType() == "freebsd" {
+		playbook = "zfs_scrub_periodic_disable.yml"
+	}
+
+	out, err := h.runOp(playbook, map[string]string{"pool": pool})
 	if err != nil {
 		var steps []ansible.TaskStep
 		if out != nil {

--- a/internal/zfs/cronparse.go
+++ b/internal/zfs/cronparse.go
@@ -1,0 +1,146 @@
+package zfs
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// ScrubScheduleMode indicates which scheduling mechanism is in use.
+type ScrubScheduleMode string
+
+const (
+	// ScrubModeZfsutils is used on Linux: ZFS_SCRUB_POOLS in /etc/default/zfs,
+	// executed by /usr/lib/zfs-linux/scrub on the 2nd Sunday of each month via
+	// /etc/cron.d/zfsutils-linux.
+	ScrubModeZfsutils ScrubScheduleMode = "zfsutils"
+
+	// ScrubModePeriodic is used on FreeBSD: daily_scrub_zfs_pools in
+	// /etc/periodic.conf, executed by /etc/periodic/daily/800.scrub-zfs.
+	ScrubModePeriodic ScrubScheduleMode = "periodic"
+)
+
+// ScrubSchedule represents a pool that has been explicitly added to the
+// platform scrub list.
+type ScrubSchedule struct {
+	Pool string `json:"pool"`
+}
+
+// ScrubScheduleList is the response returned by GET /api/scrub-schedules.
+// When Schedules is empty, the platform default applies (all pools are scrubbed).
+type ScrubScheduleList struct {
+	Mode          ScrubScheduleMode `json:"mode"`
+	ThresholdDays int               `json:"threshold_days,omitempty"` // FreeBSD periodic only
+	Schedules     []ScrubSchedule   `json:"schedules"`
+}
+
+// OSType returns "freebsd" on FreeBSD, "linux" otherwise.
+func OSType() string {
+	if runtime.GOOS == "freebsd" {
+		return "freebsd"
+	}
+	return "linux"
+}
+
+// ScrubSchedules reads the platform-appropriate configuration and returns the
+// full schedule list.
+//
+// Linux:   reads ZFS_SCRUB_POOLS from /etc/default/zfs
+// FreeBSD: reads daily_scrub_zfs_pools from /etc/periodic.conf
+func ScrubSchedules() (ScrubScheduleList, error) {
+	if runtime.GOOS == "freebsd" {
+		return readPeriodicConf("/etc/periodic.conf")
+	}
+	return readZfsDefaults("/etc/default/zfs")
+}
+
+// readZfsDefaults reads /etc/default/zfs and extracts ZFS_SCRUB_POOLS.
+//
+//	ZFS_SCRUB_POOLS="tank backup"   (space-separated pool names)
+//
+// An empty or absent ZFS_SCRUB_POOLS means the package default applies:
+// /usr/lib/zfs-linux/scrub scrubs all pools. In that case Schedules is empty.
+func readZfsDefaults(path string) (ScrubScheduleList, error) {
+	result := ScrubScheduleList{Mode: ScrubModeZfsutils, Schedules: []ScrubSchedule{}}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return result, nil
+		}
+		return result, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if !ok || key != "ZFS_SCRUB_POOLS" {
+			continue
+		}
+		val = strings.Trim(val, `"'`)
+		for _, pool := range strings.Fields(val) {
+			if pool != "" {
+				result.Schedules = append(result.Schedules, ScrubSchedule{Pool: pool})
+			}
+		}
+		break
+	}
+	return result, scanner.Err()
+}
+
+// readPeriodicConf reads /etc/periodic.conf and extracts daily_scrub_zfs_pools
+// and daily_scrub_zfs_default_threshold.
+//
+// An empty or absent daily_scrub_zfs_pools means all pools are scrubbed.
+func readPeriodicConf(path string) (ScrubScheduleList, error) {
+	result := ScrubScheduleList{Mode: ScrubModePeriodic, Schedules: []ScrubSchedule{}}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			result.ThresholdDays = 35
+			return result, nil
+		}
+		return result, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		val = strings.Trim(val, `"'`)
+
+		switch key {
+		case "daily_scrub_zfs_default_threshold":
+			if n, err := strconv.Atoi(val); err == nil {
+				result.ThresholdDays = n
+			}
+		case "daily_scrub_zfs_pools":
+			for _, pool := range strings.Fields(val) {
+				if pool != "" {
+					result.Schedules = append(result.Schedules, ScrubSchedule{Pool: pool})
+				}
+			}
+		}
+	}
+
+	if result.ThresholdDays == 0 {
+		result.ThresholdDays = 35
+	}
+	return result, scanner.Err()
+}

--- a/playbooks/zfs_scrub_periodic_disable.yml
+++ b/playbooks/zfs_scrub_periodic_disable.yml
@@ -1,0 +1,41 @@
+---
+# Required extra vars:
+#   pool - pool name to remove from the scrub list (e.g. tank)
+#
+# Removes pool from daily_scrub_zfs_pools in /etc/periodic.conf.
+# Does not touch daily_scrub_zfs_enable or the threshold.
+- name: Disable periodic ZFS scrub for pool
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pool is defined and pool != ""
+          - pool is not search("/")
+          - pool is not search("@")
+        fail_msg: "pool must be a valid pool name (no slashes or @)"
+
+    - name: Read current pool list
+      ansible.builtin.shell: |
+        if grep -qE '^daily_scrub_zfs_pools=' /etc/periodic.conf 2>/dev/null; then
+          grep -E '^daily_scrub_zfs_pools=' /etc/periodic.conf | \
+            sed 's/^daily_scrub_zfs_pools="\(.*\)"/\1/'
+        else
+          echo ""
+        fi
+      register: current_pools
+      changed_when: false
+
+    - name: Compute new pool list
+      ansible.builtin.set_fact:
+        new_pool_list: >-
+          {{ current_pools.stdout.split() | reject('equalto', pool) | join(' ') }}
+
+    - name: Write updated pool list
+      ansible.builtin.lineinfile:
+        path: /etc/periodic.conf
+        regexp: '^#?daily_scrub_zfs_pools='
+        line: 'daily_scrub_zfs_pools="{{ new_pool_list }}"'
+        create: true
+        mode: '0644'

--- a/playbooks/zfs_scrub_periodic_enable.yml
+++ b/playbooks/zfs_scrub_periodic_enable.yml
@@ -1,0 +1,61 @@
+---
+# Required extra vars:
+#   pool           - pool name to add to the scrub list (e.g. tank)
+#   threshold_days - days between scrubs (e.g. 35)
+#
+# Manages /etc/periodic.conf on FreeBSD:
+#   daily_scrub_zfs_enable="YES"
+#   daily_scrub_zfs_default_threshold="<threshold_days>"
+#   daily_scrub_zfs_pools="<pool> ..."   (space-separated; grows as pools are added)
+- name: Enable periodic ZFS scrub for pool
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pool is defined and pool != ""
+          - pool is not search("/")
+          - pool is not search("@")
+          - threshold_days is defined
+        fail_msg: "pool must be a valid pool name; threshold_days must be set"
+
+    - name: Ensure daily ZFS scrub is enabled
+      ansible.builtin.lineinfile:
+        path: /etc/periodic.conf
+        regexp: '^#?daily_scrub_zfs_enable='
+        line: 'daily_scrub_zfs_enable="YES"'
+        create: true
+        mode: '0644'
+
+    - name: Set scrub threshold
+      ansible.builtin.lineinfile:
+        path: /etc/periodic.conf
+        regexp: '^#?daily_scrub_zfs_default_threshold='
+        line: 'daily_scrub_zfs_default_threshold="{{ threshold_days }}"'
+        create: true
+        mode: '0644'
+
+    - name: Read current pool list
+      ansible.builtin.shell: |
+        if grep -qE '^daily_scrub_zfs_pools=' /etc/periodic.conf 2>/dev/null; then
+          grep -E '^daily_scrub_zfs_pools=' /etc/periodic.conf | \
+            sed 's/^daily_scrub_zfs_pools="\(.*\)"/\1/'
+        else
+          echo ""
+        fi
+      register: current_pools
+      changed_when: false
+
+    - name: Compute new pool list
+      ansible.builtin.set_fact:
+        new_pool_list: >-
+          {{ ([pool] + current_pools.stdout.split()) | unique | join(' ') }}
+
+    - name: Write updated pool list
+      ansible.builtin.lineinfile:
+        path: /etc/periodic.conf
+        regexp: '^#?daily_scrub_zfs_pools='
+        line: 'daily_scrub_zfs_pools="{{ new_pool_list }}"'
+        create: true
+        mode: '0644'

--- a/playbooks/zfs_scrub_zfsutils_disable.yml
+++ b/playbooks/zfs_scrub_zfsutils_disable.yml
@@ -1,0 +1,38 @@
+---
+# Required extra vars:
+#   pool  - pool name to remove from ZFS_SCRUB_POOLS (e.g. tank)
+- name: Remove pool from zfsutils-linux scrub list
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pool is defined and pool != ""
+          - pool is not search("/")
+          - pool is not search("@")
+        fail_msg: "pool must be a valid pool name (no slashes or @)"
+
+    - name: Read current ZFS_SCRUB_POOLS
+      ansible.builtin.shell: |
+        if grep -qE '^ZFS_SCRUB_POOLS=' /etc/default/zfs 2>/dev/null; then
+          grep -E '^ZFS_SCRUB_POOLS=' /etc/default/zfs | \
+            sed 's/^ZFS_SCRUB_POOLS="\(.*\)"/\1/'
+        else
+          echo ""
+        fi
+      register: current_pools
+      changed_when: false
+
+    - name: Compute new pool list
+      ansible.builtin.set_fact:
+        new_pool_list: >-
+          {{ current_pools.stdout.split() | reject('equalto', pool) | join(' ') }}
+
+    - name: Write updated ZFS_SCRUB_POOLS
+      ansible.builtin.lineinfile:
+        path: /etc/default/zfs
+        regexp: '^#?ZFS_SCRUB_POOLS='
+        line: 'ZFS_SCRUB_POOLS="{{ new_pool_list }}"'
+        create: true
+        mode: '0644'

--- a/playbooks/zfs_scrub_zfsutils_enable.yml
+++ b/playbooks/zfs_scrub_zfsutils_enable.yml
@@ -1,0 +1,43 @@
+---
+# Required extra vars:
+#   pool  - pool name to add to ZFS_SCRUB_POOLS (e.g. tank)
+#
+# Manages ZFS_SCRUB_POOLS in /etc/default/zfs.
+# zfsutils-linux scrubs every pool in that list on the 2nd Sunday of each
+# month via /etc/cron.d/zfsutils-linux → /usr/lib/zfs-linux/scrub.
+# An empty ZFS_SCRUB_POOLS means all pools are scrubbed (package default).
+- name: Add pool to zfsutils-linux scrub list
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pool is defined and pool != ""
+          - pool is not search("/")
+          - pool is not search("@")
+        fail_msg: "pool must be a valid pool name (no slashes or @)"
+
+    - name: Read current ZFS_SCRUB_POOLS
+      ansible.builtin.shell: |
+        if grep -qE '^ZFS_SCRUB_POOLS=' /etc/default/zfs 2>/dev/null; then
+          grep -E '^ZFS_SCRUB_POOLS=' /etc/default/zfs | \
+            sed 's/^ZFS_SCRUB_POOLS="\(.*\)"/\1/'
+        else
+          echo ""
+        fi
+      register: current_pools
+      changed_when: false
+
+    - name: Compute new pool list
+      ansible.builtin.set_fact:
+        new_pool_list: >-
+          {{ ([pool] + current_pools.stdout.split()) | unique | join(' ') }}
+
+    - name: Write updated ZFS_SCRUB_POOLS
+      ansible.builtin.lineinfile:
+        path: /etc/default/zfs
+        regexp: '^#?ZFS_SCRUB_POOLS='
+        line: 'ZFS_SCRUB_POOLS="{{ new_pool_list }}"'
+        create: true
+        mode: '0644'

--- a/static/app.js
+++ b/static/app.js
@@ -22,6 +22,9 @@ const state = {
   aclStatus: {},
   hideSystemUsers: true,
   hideSystemGroups: true,
+  scrubSchedules: {},      // pool name → ScrubSchedule
+  scrubScheduleMode: 'cron',    // "cron" | "periodic"
+  scrubThresholdDays: 35,       // FreeBSD periodic threshold (global)
 };
 
 // ── API helpers ───────────────────────────────────────────────────────────────
@@ -149,7 +152,7 @@ function setRefreshing(v) {
 async function loadAll() {
   setRefreshing(true);
   try {
-    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, users, groups, smbData, smbShares] = await Promise.all([
+    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, users, groups, smbData, smbShares, scrubSchedules] = await Promise.all([
       api('GET', '/api/pools').catch(() => []),
       api('GET', '/api/poolstatus').catch(() => []),
       api('GET', '/api/version').catch(() => null),
@@ -160,6 +163,7 @@ async function loadAll() {
       api('GET', '/api/groups').catch(() => []),
       api('GET', '/api/smb-users').catch(() => null),
       api('GET', '/api/smb-shares').catch(() => []),
+      api('GET', '/api/scrub-schedules').catch(() => []),
     ]);
     state.pools = pools || [];
     state.poolStatuses = poolStatuses || [];
@@ -172,6 +176,10 @@ async function loadAll() {
     state.sambaAvailable = smbData?.available ?? false;
     state.sambaUsers = smbData?.users || [];
     state.smbShares = smbShares || [];
+    const schedData = scrubSchedules || { mode: 'cron', schedules: [] };
+    state.scrubScheduleMode = schedData.mode || 'cron';
+    state.scrubThresholdDays = schedData.threshold_days || 35;
+    state.scrubSchedules = Object.fromEntries((schedData.schedules || []).map(s => [s.pool, s]));
     renderPools();
     renderSysInfo();
     renderSoftware();
@@ -297,12 +305,21 @@ if (!state.pools.length) {
       ? `<div class="pool-scan">${esc(detail.scan)}</div>`
       : '';
 
+    const sched = state.scrubSchedules[p.name];
+    const allDefault = Object.keys(state.scrubSchedules).length === 0;
+    const badgeText = fmtScrubScheduleBadge(state.scrubScheduleMode, !!sched, allDefault, state.scrubThresholdDays);
+    const schedBadge = badgeText
+      ? `<span class="scrub-schedule-badge">${esc(badgeText)}</span>`
+      : `<span class="scrub-schedule-badge muted">No schedule</span>`;
+
     const scrubActions = `
       <div class="pool-scrub-actions">
         ${scrubState === 'in_progress' || scrubState === 'paused'
           ? `<button class="btn-secondary btn-sm" onclick="cancelScrub('${p.name}')">Cancel Scrub</button>`
           : `<button class="btn-secondary btn-sm" onclick="startScrub('${p.name}')">Start Scrub</button>`
         }
+        <button class="btn-secondary btn-sm" onclick="openScrubScheduleDialog('${p.name}')">Schedule&hellip;</button>
+        ${schedBadge}
       </div>`;
 
     const statusLine = detail?.status
@@ -402,6 +419,85 @@ async function cancelScrub(pool) {
     await loadAll();
   } catch (err) {
     showOpLog(`Cancel scrub: ${pool}`, err.tasks, err.message);
+  }
+}
+
+// ── Scrub schedule helpers ────────────────────────────────────────────────────
+// Returns badge text, or null if pool has no schedule.
+// allDefault = the pools list is empty (platform scrubs all pools by default).
+function fmtScrubScheduleBadge(mode, inList, allDefault, thresholdDays) {
+  if (!inList && !allDefault) return null;
+  if (mode === 'periodic') return `Scrub: every ${thresholdDays ?? 35}d`;
+  return 'Scrub: 2nd Sun'; // zfsutils-linux
+}
+
+let _scrubSchedulePool = '';
+
+function openScrubScheduleDialog(pool) {
+  _scrubSchedulePool = pool;
+  const sched = state.scrubSchedules[pool];
+  const periodic = state.scrubScheduleMode === 'periodic';
+  const allDefault = Object.keys(state.scrubSchedules).length === 0;
+  document.getElementById('scrubSchedulePool').textContent = pool;
+
+  document.getElementById('scrubCronRows').style.display = 'none'; // unused
+  document.getElementById('scrubPeriodicRow').style.display = periodic ? '' : 'none';
+  document.getElementById('scrubZfsutilsRow').style.display = periodic ? 'none' : '';
+
+  if (periodic) {
+    document.getElementById('scrubScheduleThreshold').value = state.scrubThresholdDays ?? 35;
+  } else {
+    const statusEl = document.getElementById('scrubZfsutilsStatus');
+    if (allDefault) {
+      statusEl.textContent = 'All pools are scrubbed on the 2nd Sunday monthly (ZFS_SCRUB_POOLS is empty — package default).';
+    } else if (sched) {
+      statusEl.textContent = 'Pool is explicitly listed in ZFS_SCRUB_POOLS.';
+    } else {
+      statusEl.textContent = 'Pool is not in ZFS_SCRUB_POOLS and will not be scrubbed automatically.';
+    }
+  }
+
+  document.getElementById('scrubScheduleSaveBtn').textContent = sched ? 'Update' : 'Enable';
+  document.getElementById('scrubScheduleRemoveBtn').style.display = sched ? '' : 'none';
+  document.getElementById('scrubScheduleDialog').showModal();
+}
+
+async function _refreshScrubSchedules() {
+  const data = await api('GET', '/api/scrub-schedules').catch(() => null);
+  if (data) {
+    state.scrubScheduleMode = data.mode || 'zfsutils';
+    state.scrubThresholdDays = data.threshold_days || 35;
+    state.scrubSchedules = Object.fromEntries((data.schedules || []).map(s => [s.pool, s]));
+    renderPools();
+  }
+}
+
+async function saveScrubSchedule() {
+  const body = state.scrubScheduleMode === 'periodic'
+    ? { threshold_days: parseInt(document.getElementById('scrubScheduleThreshold').value, 10) || 35 }
+    : {};
+  document.getElementById('scrubScheduleDialog').close();
+  showOpLogRunning(`Enable scrub: ${_scrubSchedulePool}`);
+  try {
+    const data = await api('PUT', `/api/scrub-schedule/${encodeURIComponent(_scrubSchedulePool)}`, body);
+    showOpLog(`Enable scrub: ${_scrubSchedulePool}`, data.tasks, null);
+    toast(`Scrub enabled for ${_scrubSchedulePool}`, 'ok');
+    await _refreshScrubSchedules();
+  } catch (err) {
+    showOpLog(`Enable scrub: ${_scrubSchedulePool}`, err.tasks, err.message);
+  }
+}
+
+async function removeScrubSchedule() {
+  document.getElementById('scrubScheduleDialog').close();
+  showOpLogRunning(`Remove scrub: ${_scrubSchedulePool}`);
+  try {
+    const data = await api('DELETE', `/api/scrub-schedule/${encodeURIComponent(_scrubSchedulePool)}`);
+    showOpLog(`Remove scrub: ${_scrubSchedulePool}`, data.tasks, null);
+    toast(`Scrub schedule removed for ${_scrubSchedulePool}`, 'ok');
+    await _refreshScrubSchedules();
+  } catch (err) {
+    showOpLog(`Remove scrub: ${_scrubSchedulePool}`, err.tasks, err.message);
   }
 }
 
@@ -1999,6 +2095,11 @@ function startSSE() {
     }
   };
 }
+
+// ── Scrub schedule dialog wiring ──────────────────────────────────────────────
+document.getElementById('scrubScheduleSaveBtn').addEventListener('click', saveScrubSchedule);
+document.getElementById('scrubScheduleRemoveBtn').addEventListener('click', removeScrubSchedule);
+document.getElementById('scrubScheduleCancelBtn').addEventListener('click', () => document.getElementById('scrubScheduleDialog').close());
 
 // ── Boot ──────────────────────────────────────────────────────────────────────
 // Perform an immediate REST load so the UI is populated on first paint,

--- a/static/index.html
+++ b/static/index.html
@@ -724,6 +724,39 @@
     </form>
   </dialog>
 
+  <!-- SCRUB SCHEDULE DIALOG -->
+  <dialog id="scrubScheduleDialog">
+    <h3>Scrub Schedule &mdash; <span id="scrubSchedulePool"></span></h3>
+    <div class="dialog-body">
+      <!-- unused placeholder; kept so JS getElementById calls don't throw -->
+      <div id="scrubCronRows" style="display:none"></div>
+      <!-- Linux (zfsutils-linux): status text only, no configurable schedule -->
+      <div id="scrubZfsutilsRow">
+        <p id="scrubZfsutilsStatus" class="muted" style="margin:0 0 0.5rem"></p>
+        <p class="muted" style="margin:0 0 1rem;font-size:0.85rem">
+          Managed via <code>ZFS_SCRUB_POOLS</code> in <code>/etc/default/zfs</code>.
+          Scrubs run on the 2nd Sunday of each month via <code>zfsutils-linux</code>.
+        </p>
+      </div>
+      <!-- FreeBSD: periodic threshold field -->
+      <div id="scrubPeriodicRow" style="display:none">
+        <div class="form-row">
+          <label for="scrubScheduleThreshold">Scrub every (days)</label>
+          <input type="number" id="scrubScheduleThreshold" min="1" max="365" value="35">
+        </div>
+        <p class="muted" style="margin:0 0 1rem;font-size:0.85rem">
+          Managed via <code>daily_scrub_zfs_pools</code> in <code>/etc/periodic.conf</code>.
+          The periodic task runs daily and scrubs if the threshold has elapsed.
+        </p>
+      </div>
+      <div class="dialog-actions">
+        <button type="button" id="scrubScheduleSaveBtn" class="btn-primary">Enable</button>
+        <button type="button" id="scrubScheduleRemoveBtn" class="btn-danger">Remove</button>
+        <button type="button" id="scrubScheduleCancelBtn" class="btn-secondary">Cancel</button>
+      </div>
+    </div>
+  </dialog>
+
   <!-- OPERATION LOG DIALOG -->
   <dialog id="opLogDialog">
     <h3 id="opLogTitle">Operation Result</h3>

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,31 @@
+# Lessons
+
+## 1. Always stay compatible with FreeBSD
+
+**Rule:** This project targets both Linux and FreeBSD. Any code touching the OS layer must work on both platforms.
+
+Checklist:
+- Go: use `runtime.GOOS` guards (`"freebsd"` vs `"linux"`) for platform-specific paths, commands, and config files. Never assume Linux-only paths like `/etc/default/zfs` without a FreeBSD fallback.
+- Shell/Ansible: avoid Linux-only tools (`systemctl`, `useradd`, `groupadd`) without FreeBSD equivalents (`service`, `pw useradd`, `pw groupadd`). Use `ansible_os_family` / `ansible_system` vars when needed.
+- File paths: `/etc/periodic.conf` (FreeBSD) vs `/etc/default/zfs` (Linux), `/etc/login.defs` may not exist on FreeBSD — guard with `errors.Is(err, os.ErrNotExist)`.
+- When adding a new write operation, check if the playbook command differs on FreeBSD and add a `when: ansible_system == "FreeBSD"` / `"Linux"` split if so.
+
+## 2. Verify top-level JS wiring against the HTML before committing
+
+**Mistake:** Added `document.getElementById('scrubScheduleFreq').addEventListener(...)` at the top level of `app.js` referencing an element that was removed from `index.html`, and calling `updateScrubScheduleRows` which was never defined. This crashed the entire script on load, leaving the UI stuck on "Loading".
+
+**Rule:** After writing any top-level `document.getElementById(...).addEventListener(...)` wiring in `app.js`, confirm:
+1. The element ID exists in `index.html`.
+2. The callback function is defined somewhere in `app.js`.
+
+A quick `grep -n '<id>' static/index.html` and `grep -n 'function <cb>' static/app.js` before finishing is enough to catch this class of bug.
+
+## 3. Always update docs, wiki, and homepage when features change
+
+**Rule:** After every feature addition or change, update ALL four of these before considering the task done:
+1. **`README.md`** — feature list, planned table (mark done with strikethrough), API route table
+2. **`wiki/Home.md`** — features bullet list
+3. **`wiki/API-Reference.md`** — quick-reference table + detailed endpoint section
+4. **`docs/index.html`** — features card grid (add a card for each new feature)
+
+Never leave these out of sync. If a feature moves from planned → done, strike it through in README and add the card to docs/index.html.

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -45,6 +45,9 @@ All endpoints are served at `http://<host>:8080`. The API is JSON-over-HTTP; all
 | POST   | `/api/smb-config/pam`       | Run Samba setup playbook |
 | POST   | `/api/scrub/{pool}`         | Start a pool scrub |
 | DELETE | `/api/scrub/{pool}`         | Cancel a running pool scrub |
+| GET    | `/api/scrub-schedules`      | List periodic scrub schedule config |
+| PUT    | `/api/scrub-schedule/{pool}`| Add pool to periodic scrub schedule |
+| DELETE | `/api/scrub-schedule/{pool}`| Remove pool from periodic scrub schedule |
 
 ---
 
@@ -122,6 +125,35 @@ Start a scrub on the named pool. Returns Ansible task steps.
 ### DELETE /api/scrub/{pool}
 
 Cancel a running scrub on the named pool. Returns Ansible task steps.
+
+### GET /api/scrub-schedules
+
+Returns the current periodic scrub configuration for all pools.
+
+```json
+{
+  "mode": "zfsutils",
+  "schedules": [
+    { "pool": "tank" }
+  ]
+}
+```
+
+`mode` is `"zfsutils"` on Linux (managed via `ZFS_SCRUB_POOLS` in `/etc/default/zfs`) or `"periodic"` on FreeBSD (managed via `daily_scrub_zfs_pools` in `/etc/periodic.conf`). On FreeBSD, `threshold_days` is also returned (default 35). An empty `schedules` array means all pools are scrubbed by the platform default.
+
+### PUT /api/scrub-schedule/{pool}
+
+Add a pool to the periodic scrub schedule. On FreeBSD, an optional `threshold_days` body field sets how many days must elapse before a scrub is triggered.
+
+```json
+{ "threshold_days": 35 }
+```
+
+Returns Ansible task steps.
+
+### DELETE /api/scrub-schedule/{pool}
+
+Remove a pool from the periodic scrub schedule. Returns Ansible task steps.
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,7 +8,7 @@ No container runtime, no database, no Node.js. Just a single compiled binary, so
 
 - **System info** — hostname, OS, kernel, CPU, uptime, load averages, process stats
 - **Pool overview** — health badges, usage bars, fragmentation, deduplication ratio, vdev tree
-- **Pool scrub management** — trigger scrubs, cancel running scrubs, view last scrub time/status/progress per pool
+- **Pool scrub management** — trigger scrubs, cancel running scrubs, view last scrub time/status/progress per pool; configure periodic scrub schedules (Linux: `zfsutils-linux`; FreeBSD: `periodic.conf`)
 - **I/O statistics** — live read/write IOPS and bandwidth per pool
 - **Disk health** — S.M.A.R.T. data per drive (temperature, power-on hours, reallocated sectors, pending sectors, uncorrectable errors)
 - **Dataset browser** — depth-indented collapsible tree, compression, quota, mountpoint; ACL, NFS, and SMB buttons light up when configured


### PR DESCRIPTION
## Summary

- Add `GET /api/scrub-schedules`, `PUT /api/scrub-schedule/{pool}`, `DELETE /api/scrub-schedule/{pool}` endpoints
- New playbooks for Linux (`zfsutils-linux`) and FreeBSD (`periodic.conf`) schedule enable/disable
- Per-pool "Schedule" button in the UI with platform-aware dialog
- Fix page-crash bug: stale `scrubScheduleFreq` addEventListener referenced a missing HTML element and undefined function, preventing `loadAll()` from ever running
- Docs updated: README, wiki/Home, wiki/API-Reference, docs/index.html

## Test plan

- [ ] UI renders on page load (no more stuck "Loading")
- [ ] "Schedule" button opens dialog per pool
- [ ] Enable/disable scrub schedule writes correct config on Linux (`/etc/default/zfs`)
- [ ] Enable/disable scrub schedule writes correct config on FreeBSD (`/etc/periodic.conf`)
- [ ] `GET /api/scrub-schedules` returns correct mode + schedules
- [ ] `go build ./...` and `go vet ./...` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)