### PR TITLE
ci: enforce docs updates on every PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- 1-3 bullet points describing what changed and why -->
+
+## Test plan
+
+<!-- Bulleted checklist of what to verify -->
+
+## Docs updated
+
+- [ ] `README.md` updated (or change doesn't affect routes/features/architecture)
+- [ ] `docs/index.html` updated (or same reason)
+- [ ] `wiki/` updated (or same reason)
+
+<!-- If docs don't need updating, briefly explain why: -->

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,55 @@
+name: Docs check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    # Skip if the PR is labeled 'skip-docs-check' (for pure refactors, bug fixes, etc.)
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-docs-check') }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for code changes without doc updates
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+
+          # Detect if any code/playbook/frontend files changed
+          CODE_CHANGED=$(echo "$CHANGED" | grep -E \
+            '^(main\.go|internal/|static/|playbooks/|install\.sh|Makefile)' \
+            || true)
+
+          if [ -z "$CODE_CHANGED" ]; then
+            echo "No code files changed — docs check skipped."
+            exit 0
+          fi
+
+          echo "Code files changed:"
+          echo "$CODE_CHANGED"
+          echo ""
+
+          MISSING=()
+
+          echo "$CHANGED" | grep -q '^README\.md$'      || MISSING+=("README.md")
+          echo "$CHANGED" | grep -q '^docs/index\.html$' || MISSING+=("docs/index.html")
+
+          if [ ${#MISSING[@]} -eq 0 ]; then
+            echo "All required doc files updated."
+            exit 0
+          fi
+
+          echo "ERROR: Code changed but the following doc files were not updated:"
+          for f in "${MISSING[@]}"; do
+            echo "  - $f"
+          done
+          echo ""
+          echo "Update these files, or add the 'skip-docs-check' label if docs don't need changing (e.g. bug fix, refactor)."
+          exit 1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/check-docs.yml`: fails any PR where code/playbook/frontend files change but `README.md` or `docs/index.html` are not updated
- Adds `.github/PULL_REQUEST_TEMPLATE.md`: explicit docs checklist in every PR description
- Escape hatch: add the `skip-docs-check` label for pure refactors or bug fixes that don't affect docs

## Test plan

- [ ] Open a PR that changes code without updating docs — CI check should fail
- [ ] Open a PR that changes code and updates docs — CI check should pass
- [ ] Open a PR with `skip-docs-check` label — CI check should be skipped

## Docs updated

- [ ] `README.md` updated (or change doesn't affect routes/features/architecture)
- [ ] `docs/index.html` updated (or same reason)
- [ ] `wiki/` updated (or same reason)

This PR only adds CI config and a PR template — no docs update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)