### PR TITLE
fix: show data after host reboot / server restart

### DIFF
--- a/contrib/dumpstore.service
+++ b/contrib/dumpstore.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=dumpstore ZFS Web UI
 Documentation=https://github.com/yourorg/dumpstore
-After=network.target zfs-mount.service
-Wants=zfs-mount.service
+After=network.target zfs-import.target zfs-mount.service
+Wants=zfs-import.target zfs-mount.service
 
 [Service]
 Type=simple

--- a/internal/broker/poller.go
+++ b/internal/broker/poller.go
@@ -15,6 +15,10 @@ import (
 // 10s is 3x faster than the previous client-side 30s poll.
 const PollInterval = 10 * time.Second
 
+// startupRetryInterval is the retry cadence used when ZFS is not yet available
+// at startup (e.g. host just rebooted and pool import is still in progress).
+const startupRetryInterval = 2 * time.Second
+
 // StartPoller launches the background polling goroutine and returns immediately.
 // It polls ZFS CLI commands every PollInterval and publishes changed data to b.
 // The goroutine exits when ctx is cancelled.
@@ -43,12 +47,20 @@ func runPoller(ctx context.Context, b *Broker) {
 		slog.Debug("poller: published change", "topic", topic)
 	}
 
+	// At startup, ZFS pool import may still be in progress. Retry every
+	// startupRetryInterval until the first successful ZFS read, then switch
+	// to the normal PollInterval cadence.
+	for !pollOnce(publish) {
+		slog.Info("poller: ZFS not ready at startup, retrying", "in", startupRetryInterval)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(startupRetryInterval):
+		}
+	}
+
 	tick := time.NewTicker(PollInterval)
 	defer tick.Stop()
-
-	// Poll immediately on start so the first SSE client gets data right away
-	// instead of waiting up to PollInterval.
-	pollOnce(publish)
 
 	for {
 		select {
@@ -63,9 +75,14 @@ func runPoller(ctx context.Context, b *Broker) {
 
 // pollOnce runs one full data collection cycle. Each topic is independent:
 // a failure on one does not prevent the others from being published.
-func pollOnce(publish func(string, any)) {
+// Returns true if ZFS data was successfully read (pools/datasets/snapshots),
+// false if all ZFS commands failed (e.g. pools not yet imported at startup).
+func pollOnce(publish func(string, any)) bool {
+	zfsOK := false
+
 	if pools, err := zfs.ListPools(); err == nil {
 		publish("pool.query", pools)
+		zfsOK = true
 	} else {
 		slog.Warn("poller: ListPools failed", "err", err)
 	}
@@ -107,4 +124,6 @@ func pollOnce(publish func(string, any)) {
 	} else {
 		slog.Warn("poller: ListGroups failed", "err", err)
 	}
+
+	return zfsOK
 }

--- a/static/app.js
+++ b/static/app.js
@@ -2101,6 +2101,11 @@ function startSSE() {
   es.onopen = () => {
     stopPolling();
     if (_sseRetryTimer) { clearTimeout(_sseRetryTimer); _sseRetryTimer = null; }
+    // Always re-fetch all REST-only data (sysinfo, version, schema, smb config)
+    // on every SSE (re)connect. SSE topics self-populate from the broker cache,
+    // but endpoints not backed by SSE would otherwise stay stale/empty across
+    // server restarts and post-reboot reconnects.
+    loadAll();
   };
 
   es.addEventListener('ansible.progress', e => {


### PR DESCRIPTION
## Summary

- **Frontend**: `loadAll()` now called on every SSE (re)connect — REST-only endpoints (sysinfo, host info, installed software, version, schema, smb config) were never re-fetched after a reconnect so they stayed empty after reboot
- **Poller**: fast 2 s retry at startup when ZFS commands fail (pool import still in progress), instead of waiting the full 10 s tick
- **Systemd unit**: explicit `zfs-import.target` in `After=`/`Wants=` so dumpstore starts only after all pools are imported, not just mounted

## Test plan

- [ ] Reboot host, open browser — all sections populate within a few seconds
- [ ] Keep browser tab open across reboot — sysinfo, software, host info refresh automatically on reconnect
- [ ] Normal page load (no reboot) — no regression, data loads as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)