### PR TITLE
feat: auto-snapshot scheduling and multi-snapshot delete

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -25,6 +25,8 @@
 | NFS share management     | v0.0.9 | Enable/configure/disable NFS sharing via ZFS `sharenfs` property; cross-platform          |
 | SMB share management     | v0.1.0 | Create/remove Samba usershares; manage Samba users; one-click Samba setup; cross-platform |
 | Pool scrub management    | v0.1.2 | Trigger scrubs, cancel running scrubs, view last scrub time/status/progress per pool      |
+| Pool scrub scheduling    | v0.1.2 | Per-pool schedule via Linux `zfsutils-linux` (2nd Sunday monthly) or FreeBSD `periodic.conf` (configurable threshold) |
+| Auto-snapshot scheduling | v0.1.3 | Manage `com.sun:auto-snapshot*` ZFS properties per dataset; integrates with `zfs-auto-snapshot` (Linux) / `zfstools` (FreeBSD) |
 
 ---
 
@@ -32,8 +34,6 @@
 
 | Feature                  | Priority | Notes                                                                            |
 |--------------------------|----------|----------------------------------------------------------------------------------|
-| Auto-snapshot scheduling | High     | Hourly/daily/weekly/monthly rotation policies; built-in scheduler (sanoid-style) |
-| Pool scrub scheduling    | Medium   | Schedule periodic scrubs (cron-style)                                            |
 | ZFS native encryption    | High     | Load/unload keys, encryption status per dataset, keyformat/keylocation support   |
 | Dataset rename           | Medium   | Rename a dataset or volume in place                                              |
 | Snapshot clone           | Medium   | Create a new dataset from an existing snapshot                                   |

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ DELETE /api/smb-share/{ds}    → smb_usershare_unset.yml   (ansible)
 POST   /api/smb-users/{name}  → smb_user_add.yml          (ansible)
 DELETE /api/smb-users/{name}  → smb_user_remove.yml       (ansible)
 POST   /api/smb-config/pam    → smb_setup.yml             (ansible)
+
+GET    /api/auto-snapshot/{ds} → zfs get com.sun:auto-snapshot* (direct)
+PUT    /api/auto-snapshot/{ds} → zfs_autosnap_set.yml           (ansible)
 ```
 
 ## Requirements
@@ -595,7 +598,7 @@ The browser UI uses `EventSource` to subscribe to all six topics and falls back 
 |--------------------------|-----------------------------------------------------------------------------------------------|
 | Dataset rename           | Rename a dataset or volume in place                                                           |
 | Snapshot clone           | Create a new dataset from an existing snapshot                                                |
-| Auto-snapshot scheduling | Hourly/daily/weekly/monthly rotation policies; built-in scheduler (sanoid-style)              |
+| ~~Auto-snapshot scheduling~~ | ~~Hourly/daily/weekly/monthly rotation policies~~ — **done** (`com.sun:auto-snapshot*` ZFS properties; integrates with `zfs-auto-snapshot` / `zfstools`) |
 | ZFS native encryption    | Load/unload keys, show encryption status per dataset, support keyformat/keylocation           |
 | iSCSI target management  | Expose zvols as iSCSI targets (targetcli on Linux, ctld on FreeBSD)                           |
 | Pool import/export       | Import available pools from attached devices; export pools safely                             |

--- a/docs/index.html
+++ b/docs/index.html
@@ -531,6 +531,13 @@
       </div>
       <div class="pool-card">
         <div class="pool-card-header">
+          <span class="pool-name">auto-snapshot scheduling</span>
+          <span class="health-badge badge-green">com.sun:auto-snapshot</span>
+        </div>
+        <p>Manage <code>com.sun:auto-snapshot*</code> ZFS properties per dataset. Integrates with <strong>zfs-auto-snapshot</strong> (Linux) and <strong>zfstools</strong> (FreeBSD) for automatic snapshot rotation with configurable keep counts.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
           <span class="pool-name">S.M.A.R.T. health</span>
           <span class="health-badge badge-green">smartctl</span>
         </div>

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -123,6 +123,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/snapshots", h.getSnapshots)
 	mux.HandleFunc("GET /api/iostat", h.getIOStat)
 	mux.HandleFunc("POST /api/snapshots", h.createSnapshot)
+	mux.HandleFunc("POST /api/snapshots/delete-batch", h.deleteSnapshotBatch)
 	mux.HandleFunc("DELETE /api/snapshots/{snapshot...}", h.deleteSnapshot)
 	mux.HandleFunc("GET /api/events", h.getEvents)
 	mux.HandleFunc("GET /api/chown/{dataset...}", h.getDatasetOwnership)
@@ -151,6 +152,9 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/scrub-schedules", h.listScrubSchedules)
 	mux.HandleFunc("PUT /api/scrub-schedule/{pool}", h.setScrubSchedule)
 	mux.HandleFunc("DELETE /api/scrub-schedule/{pool}", h.deleteScrubSchedule)
+	mux.HandleFunc("GET /api/auto-snapshot-schedules", h.listAutoSnapshotSchedules)
+	mux.HandleFunc("GET /api/auto-snapshot/{name...}", h.getAutoSnapshotProps)
+	mux.HandleFunc("PUT /api/auto-snapshot/{name...}", h.setAutoSnapshotProps)
 	mux.HandleFunc("GET /api/schema", h.getSchema)
 }
 
@@ -516,6 +520,52 @@ func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, map[string]any{"snapshot": snapshot, "tasks": out.Steps()})
+}
+
+// deleteSnapshotBatch handles POST /api/snapshots/delete-batch
+// Body: {"snapshots": ["tank/data@snap1", "tank/home@snap2"]}
+func (h *Handler) deleteSnapshotBatch(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Snapshots []string `json:"snapshots"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid JSON"), nil)
+		return
+	}
+	if len(body.Snapshots) == 0 {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("snapshots list is empty"), nil)
+		return
+	}
+	if len(body.Snapshots) > 100 {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("too many snapshots (max 100)"), nil)
+		return
+	}
+	for _, snap := range body.Snapshots {
+		parts := strings.SplitN(snap, "@", 2)
+		if len(parts) != 2 || !validZFSName(parts[0]) || !validSnapLabel(parts[1]) {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("invalid snapshot name %q (expected dataset@label)", snap), nil)
+			return
+		}
+	}
+
+	snapsJSON, err := json.Marshal(body.Snapshots)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("encoding snapshots: %w", err), nil)
+		return
+	}
+
+	out, err := h.runOp("zfs_snapshot_destroy_batch.yml", map[string]string{
+		"snapshots_json": string(snapsJSON),
+	})
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(w, map[string]any{"snapshots": body.Snapshots, "tasks": out.Steps()})
 }
 
 // getDatasetOwnership handles GET /api/chown/{dataset...}
@@ -1691,6 +1741,112 @@ func (h *Handler) deleteScrubSchedule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]any{"pool": pool, "tasks": out.Steps()})
+}
+
+// listAutoSnapshotSchedules handles GET /api/auto-snapshot-schedules
+func (h *Handler) listAutoSnapshotSchedules(w http.ResponseWriter, r *http.Request) {
+	props, err := zfs.ListAutoSnapshotProps()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err, nil)
+		return
+	}
+	writeJSON(w, props)
+}
+
+// publishAutoSnapshot re-reads all auto-snapshot props and pushes autosnapshot.query
+// to all SSE subscribers. Called after any auto-snapshot property change.
+func (h *Handler) publishAutoSnapshot() {
+	if props, err := zfs.ListAutoSnapshotProps(); err == nil {
+		h.broker.Publish("autosnapshot.query", props)
+	}
+}
+
+// autoSnapProps maps the 6 com.sun:auto-snapshot* property names to their
+// Ansible-safe variable names (colons and dots replaced with underscores).
+var autoSnapProps = []struct{ prop, varName string }{
+	{"com.sun:auto-snapshot", "com_sun_auto_snapshot"},
+	{"com.sun:auto-snapshot:frequent", "com_sun_auto_snapshot_frequent"},
+	{"com.sun:auto-snapshot:hourly", "com_sun_auto_snapshot_hourly"},
+	{"com.sun:auto-snapshot:daily", "com_sun_auto_snapshot_daily"},
+	{"com.sun:auto-snapshot:weekly", "com_sun_auto_snapshot_weekly"},
+	{"com.sun:auto-snapshot:monthly", "com_sun_auto_snapshot_monthly"},
+}
+
+var reKeepCount = regexp.MustCompile(`^[1-9][0-9]{0,3}$`)
+
+// validAutoSnapValue returns true if val is a valid value for the given
+// com.sun:auto-snapshot* property. Empty string means "inherit".
+func validAutoSnapValue(prop, val string) bool {
+	if val == "" {
+		return true
+	}
+	if prop == "com.sun:auto-snapshot" {
+		return val == "true" || val == "false"
+	}
+	return reKeepCount.MatchString(val)
+}
+
+// getAutoSnapshotProps handles GET /api/auto-snapshot/{name...}
+func (h *Handler) getAutoSnapshotProps(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if !validZFSName(name) {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid dataset name"), nil)
+		return
+	}
+	props, err := zfs.GetAutoSnapshotProps(name)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err, nil)
+		return
+	}
+	writeJSON(w, props)
+}
+
+// setAutoSnapshotProps handles PUT /api/auto-snapshot/{name...}
+func (h *Handler) setAutoSnapshotProps(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if !validZFSName(name) {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid dataset name"), nil)
+		return
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid JSON"), nil)
+		return
+	}
+
+	// Build allowed-prop set for fast lookup.
+	allowed := make(map[string]string, len(autoSnapProps))
+	for _, p := range autoSnapProps {
+		allowed[p.prop] = p.varName
+	}
+
+	vars := map[string]string{"name": name}
+	for _, ap := range autoSnapProps {
+		val, ok := body[ap.prop]
+		if !ok {
+			continue // not provided — playbook default (__skip__) applies
+		}
+		if !validAutoSnapValue(ap.prop, val) {
+			writeError(w, http.StatusBadRequest,
+				fmt.Errorf("invalid value %q for property %s", val, ap.prop), nil)
+			return
+		}
+		vars[ap.varName] = val
+	}
+
+	out, err := h.runOp("zfs_autosnap_set.yml", vars)
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	h.publishDatasets()
+	h.publishAutoSnapshot()
+	writeJSON(w, map[string]any{"name": name, "tasks": out.Steps()})
 }
 
 // getSchema handles GET /api/schema

--- a/internal/broker/poller.go
+++ b/internal/broker/poller.go
@@ -99,6 +99,12 @@ func pollOnce(publish func(string, any)) bool {
 		slog.Warn("poller: ListDatasets failed", "err", err)
 	}
 
+	if autoSnap, err := zfs.ListAutoSnapshotProps(); err == nil {
+		publish("autosnapshot.query", autoSnap)
+	} else {
+		slog.Warn("poller: ListAutoSnapshotProps failed", "err", err)
+	}
+
 	if snaps, err := zfs.ListSnapshots(); err == nil {
 		publish("snapshot.query", snaps)
 	} else {

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -388,6 +388,7 @@ func softwareVersions() []SoftwareTool {
 		{Name: "NFS server", Version: probeNFSServer()},
 		{Name: "nfs4-acl-tools", Version: probePresence("nfs4_setfacl")},
 		{Name: "setfacl (ACL)", Version: probePresence("setfacl")},
+		{Name: "zfs-auto-snapshot", Version: probeVersion("zfs-auto-snapshot", "--version")},
 		{Name: "Samba (smbd)", Version: probeVersion("smbd", "--version")},
 		{Name: "Package manager", Version: detectPkgManager()},
 	}

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -240,6 +240,89 @@ func GetDatasetProps(name string) (map[string]DatasetProp, error) {
 	return result, nil
 }
 
+// AutoSnapshotProps holds the com.sun:auto-snapshot* property values for a dataset.
+type AutoSnapshotProps struct {
+	Master   DatasetProp `json:"com.sun:auto-snapshot"`
+	Frequent DatasetProp `json:"com.sun:auto-snapshot:frequent"`
+	Hourly   DatasetProp `json:"com.sun:auto-snapshot:hourly"`
+	Daily    DatasetProp `json:"com.sun:auto-snapshot:daily"`
+	Weekly   DatasetProp `json:"com.sun:auto-snapshot:weekly"`
+	Monthly  DatasetProp `json:"com.sun:auto-snapshot:monthly"`
+}
+
+// GetAutoSnapshotProps returns the com.sun:auto-snapshot* ZFS property values
+// for the given dataset.
+func GetAutoSnapshotProps(name string) (AutoSnapshotProps, error) {
+	out, err := run("zfs", "get", "-H", autoSnapPropList, name)
+	if err != nil {
+		return AutoSnapshotProps{}, err
+	}
+	m := make(map[string]DatasetProp)
+	for _, line := range splitLines(out) {
+		f := strings.SplitN(line, "\t", 4)
+		if len(f) < 4 {
+			continue
+		}
+		m[f[1]] = DatasetProp{Value: f[2], Source: strings.TrimSpace(f[3])}
+	}
+	return parseAutoSnapProps(m), nil
+}
+
+const autoSnapPropList = "com.sun:auto-snapshot," +
+	"com.sun:auto-snapshot:frequent," +
+	"com.sun:auto-snapshot:hourly," +
+	"com.sun:auto-snapshot:daily," +
+	"com.sun:auto-snapshot:weekly," +
+	"com.sun:auto-snapshot:monthly"
+
+// parseAutoSnapProps builds an AutoSnapshotProps from a property map.
+func parseAutoSnapProps(m map[string]DatasetProp) AutoSnapshotProps {
+	return AutoSnapshotProps{
+		Master:   m["com.sun:auto-snapshot"],
+		Frequent: m["com.sun:auto-snapshot:frequent"],
+		Hourly:   m["com.sun:auto-snapshot:hourly"],
+		Daily:    m["com.sun:auto-snapshot:daily"],
+		Weekly:   m["com.sun:auto-snapshot:weekly"],
+		Monthly:  m["com.sun:auto-snapshot:monthly"],
+	}
+}
+
+// ListAutoSnapshotProps returns com.sun:auto-snapshot* property values for
+// every filesystem and volume in one pair of CLI calls.
+func ListAutoSnapshotProps() (map[string]AutoSnapshotProps, error) {
+	namesOut, err := run("zfs", "list", "-H", "-o", "name", "-t", "filesystem,volume")
+	if err != nil {
+		return nil, err
+	}
+	names := splitLines(namesOut)
+	if len(names) == 0 {
+		return map[string]AutoSnapshotProps{}, nil
+	}
+	args := append([]string{"get", "-H", autoSnapPropList}, names...)
+	out, err := run("zfs", args...)
+	if err != nil {
+		return nil, err
+	}
+	// Accumulate per-dataset property map, then convert.
+	raw := make(map[string]map[string]DatasetProp)
+	for _, line := range splitLines(out) {
+		f := strings.SplitN(line, "\t", 4)
+		if len(f) < 4 {
+			continue
+		}
+		ds := f[0]
+		if raw[ds] == nil {
+			raw[ds] = make(map[string]DatasetProp)
+		}
+		raw[ds][f[1]] = DatasetProp{Value: f[2], Source: strings.TrimSpace(f[3])}
+	}
+	result := make(map[string]AutoSnapshotProps, len(raw))
+	for ds, m := range raw {
+		result[ds] = parseAutoSnapProps(m)
+	}
+	return result, nil
+}
+
 // GetMountpointOwnership returns the owner username and group name of a
 // mountpoint directory by running `stat --format=%U %G <path>`.
 // This is Linux-specific and matches the target platform for the service.

--- a/playbooks/zfs_autosnap_set.yml
+++ b/playbooks/zfs_autosnap_set.yml
@@ -1,0 +1,74 @@
+---
+# Required extra vars:
+#   name  - full dataset path (e.g. tank/data) — must NOT contain '@'
+# Optional (default "__skip__" = leave unchanged; "" = inherit/reset):
+#   com_sun_auto_snapshot          - true, false
+#   com_sun_auto_snapshot_frequent - number of 15-min snapshots to keep (1-9999)
+#   com_sun_auto_snapshot_hourly   - number of hourly snapshots to keep (1-9999)
+#   com_sun_auto_snapshot_daily    - number of daily snapshots to keep (1-9999)
+#   com_sun_auto_snapshot_weekly   - number of weekly snapshots to keep (1-9999)
+#   com_sun_auto_snapshot_monthly  - number of monthly snapshots to keep (1-9999)
+- name: Set ZFS auto-snapshot properties
+  hosts: localhost
+  gather_facts: false
+  vars:
+    com_sun_auto_snapshot: "__skip__"
+    com_sun_auto_snapshot_frequent: "__skip__"
+    com_sun_auto_snapshot_hourly: "__skip__"
+    com_sun_auto_snapshot_daily: "__skip__"
+    com_sun_auto_snapshot_weekly: "__skip__"
+    com_sun_auto_snapshot_monthly: "__skip__"
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - name is defined and name != ""
+          - name is not search("@")
+        fail_msg: name is required and must not be a snapshot path
+
+    - name: Validate property values
+      ansible.builtin.assert:
+        that:
+          - com_sun_auto_snapshot in ['__skip__', '', 'true', 'false']
+          - com_sun_auto_snapshot_frequent  == '__skip__' or com_sun_auto_snapshot_frequent  == '' or (com_sun_auto_snapshot_frequent  | int > 0 and com_sun_auto_snapshot_frequent  | string == com_sun_auto_snapshot_frequent)
+          - com_sun_auto_snapshot_hourly    == '__skip__' or com_sun_auto_snapshot_hourly    == '' or (com_sun_auto_snapshot_hourly    | int > 0 and com_sun_auto_snapshot_hourly    | string == com_sun_auto_snapshot_hourly)
+          - com_sun_auto_snapshot_daily     == '__skip__' or com_sun_auto_snapshot_daily     == '' or (com_sun_auto_snapshot_daily     | int > 0 and com_sun_auto_snapshot_daily     | string == com_sun_auto_snapshot_daily)
+          - com_sun_auto_snapshot_weekly    == '__skip__' or com_sun_auto_snapshot_weekly    == '' or (com_sun_auto_snapshot_weekly    | int > 0 and com_sun_auto_snapshot_weekly    | string == com_sun_auto_snapshot_weekly)
+          - com_sun_auto_snapshot_monthly   == '__skip__' or com_sun_auto_snapshot_monthly   == '' or (com_sun_auto_snapshot_monthly   | int > 0 and com_sun_auto_snapshot_monthly   | string == com_sun_auto_snapshot_monthly)
+        fail_msg: "One or more property values are not valid"
+
+    - name: Build options
+      ansible.builtin.set_fact:
+        set_opts: >-
+          {{
+            (['com.sun:auto-snapshot='          + com_sun_auto_snapshot]         if com_sun_auto_snapshot         not in ['', '__skip__'] else []) +
+            (['com.sun:auto-snapshot:frequent=' + com_sun_auto_snapshot_frequent] if com_sun_auto_snapshot_frequent not in ['', '__skip__'] else []) +
+            (['com.sun:auto-snapshot:hourly='   + com_sun_auto_snapshot_hourly]   if com_sun_auto_snapshot_hourly   not in ['', '__skip__'] else []) +
+            (['com.sun:auto-snapshot:daily='    + com_sun_auto_snapshot_daily]    if com_sun_auto_snapshot_daily    not in ['', '__skip__'] else []) +
+            (['com.sun:auto-snapshot:weekly='   + com_sun_auto_snapshot_weekly]   if com_sun_auto_snapshot_weekly   not in ['', '__skip__'] else []) +
+            (['com.sun:auto-snapshot:monthly='  + com_sun_auto_snapshot_monthly]  if com_sun_auto_snapshot_monthly  not in ['', '__skip__'] else [])
+          }}
+        inherit_list: >-
+          {{
+            (['com.sun:auto-snapshot']          if com_sun_auto_snapshot         == '' else []) +
+            (['com.sun:auto-snapshot:frequent'] if com_sun_auto_snapshot_frequent == '' else []) +
+            (['com.sun:auto-snapshot:hourly']   if com_sun_auto_snapshot_hourly   == '' else []) +
+            (['com.sun:auto-snapshot:daily']    if com_sun_auto_snapshot_daily    == '' else []) +
+            (['com.sun:auto-snapshot:weekly']   if com_sun_auto_snapshot_weekly   == '' else []) +
+            (['com.sun:auto-snapshot:monthly']  if com_sun_auto_snapshot_monthly  == '' else [])
+          }}
+
+    - name: Set properties
+      ansible.builtin.command:
+        argv: "{{ ['zfs', 'set'] + set_opts + [name] }}"
+      when: set_opts | length > 0
+      register: set_result
+      changed_when: set_result.rc == 0
+
+    - name: Inherit properties
+      ansible.builtin.command:
+        argv: ['zfs', 'inherit', '{{ item }}', '{{ name }}']
+      loop: "{{ inherit_list }}"
+      when: inherit_list | length > 0
+      register: inherit_result
+      changed_when: true

--- a/playbooks/zfs_snapshot_destroy_batch.yml
+++ b/playbooks/zfs_snapshot_destroy_batch.yml
@@ -1,0 +1,22 @@
+---
+# Required extra vars:
+#   snapshots_json - JSON-encoded list of full snapshot names (e.g. '["tank/data@snap1","tank/home@snap2"]')
+#                   Each entry must contain '@'.
+- name: Destroy multiple ZFS snapshots
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - snapshots_json is defined and snapshots_json != ""
+          - snapshots_json | from_json | length > 0
+          - snapshots_json | from_json | select('search', '@') | list | length == snapshots_json | from_json | length
+        fail_msg: "snapshots_json must be a non-empty JSON list of snapshot names containing '@'"
+
+    - name: Destroy snapshot
+      ansible.builtin.command:
+        argv: ['zfs', 'destroy', '{{ item }}']
+      loop: "{{ snapshots_json | from_json }}"
+      register: destroy_result
+      changed_when: destroy_result.rc == 0

--- a/static/app.js
+++ b/static/app.js
@@ -25,6 +25,8 @@ const state = {
   scrubSchedules: {},      // pool name → ScrubSchedule
   scrubScheduleMode: 'cron',    // "cron" | "periodic"
   scrubThresholdDays: 35,       // FreeBSD periodic threshold (global)
+  autoSnapshot: {},             // dataset name → AutoSnapshotProps
+  selectedSnaps: new Set(),     // full snapshot names checked for batch delete
   schema: null,                 // GET /api/schema response
 };
 
@@ -184,7 +186,7 @@ function buildFormSelects() {
 async function loadAll() {
   setRefreshing(true);
   try {
-    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, users, groups, smbData, smbShares, scrubSchedules, schema] = await Promise.all([
+    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, users, groups, smbData, smbShares, scrubSchedules, autoSnapshotSchedules, schema] = await Promise.all([
       api('GET', '/api/pools').catch(() => []),
       api('GET', '/api/poolstatus').catch(() => []),
       api('GET', '/api/version').catch(() => null),
@@ -196,6 +198,7 @@ async function loadAll() {
       api('GET', '/api/smb-users').catch(() => null),
       api('GET', '/api/smb-shares').catch(() => []),
       api('GET', '/api/scrub-schedules').catch(() => []),
+      api('GET', '/api/auto-snapshot-schedules').catch(() => ({})),
       api('GET', '/api/schema').catch(() => null),
     ]);
     state.pools = pools || [];
@@ -213,6 +216,7 @@ async function loadAll() {
     state.scrubScheduleMode = schedData.mode || 'cron';
     state.scrubThresholdDays = schedData.threshold_days || 35;
     state.scrubSchedules = Object.fromEntries((schedData.schedules || []).map(s => [s.pool, s]));
+    state.autoSnapshot = autoSnapshotSchedules || {};
     state.schema = schema;
     buildFormSelects();
     renderPools();
@@ -536,6 +540,80 @@ async function removeScrubSchedule() {
   }
 }
 
+// ── Auto-snapshot schedule helpers ────────────────────────────────────────────
+const _autoSnapPeriods = [
+  { prop: 'com.sun:auto-snapshot:frequent', label: 'Frequent (15 min)', id: 'autosnap-frequent' },
+  { prop: 'com.sun:auto-snapshot:hourly',   label: 'Hourly',            id: 'autosnap-hourly'   },
+  { prop: 'com.sun:auto-snapshot:daily',    label: 'Daily',             id: 'autosnap-daily'    },
+  { prop: 'com.sun:auto-snapshot:weekly',   label: 'Weekly',            id: 'autosnap-weekly'   },
+  { prop: 'com.sun:auto-snapshot:monthly',  label: 'Monthly',           id: 'autosnap-monthly'  },
+];
+
+let _autoSnapDataset = '';
+
+async function openAutoSnapDialog(name) {
+  _autoSnapDataset = name;
+  document.getElementById('autoSnapDatasetName').textContent = name;
+  // Reset to blank while loading
+  document.getElementById('autosnap-master').value = '';
+  _autoSnapPeriods.forEach(p => {
+    document.getElementById(p.id).value = '';
+    const hint = document.getElementById(p.id + '-hint');
+    if (hint) hint.textContent = '';
+  });
+  document.getElementById('autoSnapDialog').showModal();
+  try {
+    const encodedName = name.split('/').map(encodeURIComponent).join('/');
+    const props = await api('GET', '/api/auto-snapshot/' + encodedName);
+    state.autoSnapshot[name] = props;
+    _populateAutoSnapDialog(props);
+  } catch (e) {
+    document.getElementById('autoSnapDialog').close();
+    toast('Failed to load auto-snapshot config: ' + e.message, 'err');
+  }
+}
+
+function _populateAutoSnapDialog(props) {
+  const master = props['com.sun:auto-snapshot'];
+  const masterEl = document.getElementById('autosnap-master');
+  masterEl.value = master?.source === 'local' ? master.value : '';
+
+  _autoSnapPeriods.forEach(p => {
+    const dp = props[p.prop];
+    const el = document.getElementById(p.id);
+    const hint = document.getElementById(p.id + '-hint');
+    const isLocal = dp?.source === 'local';
+    el.value = isLocal && dp.value !== '-' ? dp.value : '';
+    if (hint) {
+      if (!isLocal && dp?.value && dp.value !== '-') {
+        hint.textContent = 'inherited: ' + dp.value;
+      } else if (!isLocal) {
+        hint.textContent = 'not set';
+      } else {
+        hint.textContent = '';
+      }
+    }
+  });
+}
+
+async function saveAutoSnapSchedule() {
+  const body = {};
+  body['com.sun:auto-snapshot'] = document.getElementById('autosnap-master').value.trim();
+  _autoSnapPeriods.forEach(p => {
+    body[p.prop] = document.getElementById(p.id).value.trim();
+  });
+  document.getElementById('autoSnapDialog').close();
+  showOpLogRunning(`Auto-snapshot: ${_autoSnapDataset}`);
+  try {
+    const encodedName = _autoSnapDataset.split('/').map(encodeURIComponent).join('/');
+    const result = await api('PUT', '/api/auto-snapshot/' + encodedName, body);
+    showOpLog(`Auto-snapshot saved: ${_autoSnapDataset}`, result.tasks, null);
+    toast('Auto-snapshot config saved', 'ok');
+  } catch (err) {
+    showOpLog(`Auto-snapshot save failed`, err.tasks, err.message);
+  }
+}
+
 // ── Render: I/O Stats ─────────────────────────────────────────────────────────
 function renderIOStat() {
   const wrap = document.getElementById('iostat-table-wrap');
@@ -699,6 +777,7 @@ function renderDatasets() {
             ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-chown btn-small" data-ds="${esc(d.name)}">Chown</button>` : ''}
             ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-nfs btn-small${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? ' active' : ''}" data-ds="${esc(d.name)}" title="${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? 'NFS shared: ' + esc(d.sharenfs) : 'Not shared'}">NFS</button>` : ''}
             ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? (() => { const _sh = state.smbShares.find(s => s.path === d.mountpoint); return `<button class="btn-smb btn-small${_sh ? ' active' : ''}" data-ds="${esc(d.name)}" title="${_sh ? 'SMB shared: ' + esc(_sh.name) : 'Not shared'}">SMB</button>`; })() : ''}
+            <button class="btn-autosnap btn-small${state.autoSnapshot[d.name]?.['com.sun:auto-snapshot']?.value === 'true' ? ' active' : ''}" data-ds="${esc(d.name)}" title="Auto-snapshot schedule">Snap</button>
             ${canDelete ? `<button class="btn-del" data-ds="${esc(d.name)}" data-type="${esc(d.type)}">Delete</button>` : ''}
           </div>
         </td>
@@ -751,6 +830,10 @@ function renderDatasets() {
   wrap.querySelectorAll('.btn-smb[data-ds]').forEach(btn => {
     btn.addEventListener('click', () => openSMBDialog(btn.dataset.ds));
   });
+
+  wrap.querySelectorAll('.btn-autosnap[data-ds]').forEach(btn => {
+    btn.addEventListener('click', () => openAutoSnapDialog(btn.dataset.ds));
+  });
 }
 
 function typeBadge(type) {
@@ -764,6 +847,14 @@ document.getElementById('snap-filter').addEventListener('input', e => {
   renderSnapshots();
 });
 
+function _updateMultiDeleteBtn() {
+  const btn = document.getElementById('deleteMultiSnapBtn');
+  if (!btn) return;
+  const n = state.selectedSnaps.size;
+  btn.style.display = n > 0 ? '' : 'none';
+  btn.textContent = `Delete selected (${n})`;
+}
+
 function renderSnapshots() {
   const wrap = document.getElementById('snapshots-table-wrap');
   let items = state.snapshots;
@@ -772,10 +863,15 @@ function renderSnapshots() {
   }
   if (!items.length) {
     wrap.innerHTML = '<div class="loading">No snapshots found.</div>';
+    _updateMultiDeleteBtn();
     return;
   }
-  const rows = items.map(s => `
-    <tr>
+  const allVisible = items.map(s => s.name);
+  const allChecked = allVisible.length > 0 && allVisible.every(n => state.selectedSnaps.has(n));
+  const rows = items.map(s => {
+    const checked = state.selectedSnaps.has(s.name) ? 'checked' : '';
+    return `<tr>
+      <td style="width:1.5rem"><input type="checkbox" class="snap-check" data-snap="${esc(s.name)}" ${checked}></td>
       <td class="mono">${esc(s.dataset)}</td>
       <td class="mono">${esc(s.snap_label)}</td>
       <td>${fmtBytes(s.used)}</td>
@@ -783,11 +879,13 @@ function renderSnapshots() {
       <td class="muted">${fmtDate(s.creation)}</td>
       <td class="muted">${s.clones && s.clones !== '-' ? esc(s.clones) : '—'}</td>
       <td><button class="btn-del" data-snap="${esc(s.name)}">Delete</button></td>
-    </tr>`).join('');
+    </tr>`;
+  }).join('');
   wrap.innerHTML = `
     <div class="table-wrap">
       <table>
         <thead><tr>
+          <th style="width:1.5rem"><input type="checkbox" id="snapCheckAll" ${allChecked ? 'checked' : ''}></th>
           <th>Dataset</th><th>Snapshot</th><th>Used</th>
           <th>Refer</th><th>Created</th><th>Clones</th><th></th>
         </tr></thead>
@@ -798,6 +896,27 @@ function renderSnapshots() {
   wrap.querySelectorAll('.btn-del').forEach(btn => {
     btn.addEventListener('click', () => deleteSnapshot(btn.dataset.snap));
   });
+
+  wrap.querySelectorAll('.snap-check').forEach(cb => {
+    cb.addEventListener('change', () => {
+      if (cb.checked) state.selectedSnaps.add(cb.dataset.snap);
+      else state.selectedSnaps.delete(cb.dataset.snap);
+      _updateMultiDeleteBtn();
+      // sync select-all state
+      const all = [...wrap.querySelectorAll('.snap-check')];
+      document.getElementById('snapCheckAll').checked = all.length > 0 && all.every(c => c.checked);
+    });
+  });
+
+  document.getElementById('snapCheckAll').addEventListener('change', e => {
+    items.forEach(s => {
+      if (e.target.checked) state.selectedSnaps.add(s.name);
+      else state.selectedSnaps.delete(s.name);
+    });
+    renderSnapshots();
+  });
+
+  _updateMultiDeleteBtn();
 }
 
 const deleteSnapDialog = document.getElementById('deleteSnapDialog');
@@ -823,6 +942,32 @@ function deleteSnapshot(name) {
   document.getElementById('deleteSnapDisplayName').textContent = name;
   deleteSnapDialog.showModal();
 }
+
+function openDeleteMultiSnapDialog() {
+  const names = [...state.selectedSnaps];
+  document.getElementById('deleteMultiSnapCount').textContent = names.length;
+  document.getElementById('deleteMultiSnapPlural').textContent = names.length === 1 ? '' : 's';
+  document.getElementById('deleteMultiSnapList').innerHTML = names.map(n => `<li>${esc(n)}</li>`).join('');
+  document.getElementById('deleteMultiSnapDialog').showModal();
+}
+
+document.getElementById('deleteMultiSnapBtn').addEventListener('click', openDeleteMultiSnapDialog);
+document.getElementById('deleteMultiSnapCancelBtn').addEventListener('click', () =>
+  document.getElementById('deleteMultiSnapDialog').close());
+document.getElementById('deleteMultiSnapConfirmBtn').addEventListener('click', async () => {
+  const snapshots = [...state.selectedSnaps];
+  document.getElementById('deleteMultiSnapDialog').close();
+  showOpLogRunning(`Deleting ${snapshots.length} snapshot${snapshots.length === 1 ? '' : 's'}…`);
+  try {
+    const result = await api('POST', '/api/snapshots/delete-batch', { snapshots });
+    state.selectedSnaps.clear();
+    state.snapshots = state.snapshots.filter(s => !snapshots.includes(s.name));
+    renderSnapshots();
+    showOpLog(`Deleted ${snapshots.length} snapshot${snapshots.length === 1 ? '' : 's'}`, result.tasks, null);
+  } catch (e) {
+    showOpLog('Batch snapshot deletion failed', e.tasks, e.message);
+  }
+});
 
 // ── New Snapshot dialog ───────────────────────────────────────────────────────
 const dialog = document.getElementById('newSnapDialog');
@@ -2072,7 +2217,8 @@ document.getElementById('smbDisableBtn').addEventListener('click', async () => {
 const sseTopicMap = {
   'pool.query':     { key: 'pools',        render: renderPools },
   'poolstatus':     { key: 'poolStatuses', render: renderPools },
-  'dataset.query':  { key: 'datasets',     render: renderDatasets },
+  'dataset.query':      { key: 'datasets',     render: renderDatasets },
+  'autosnapshot.query': { key: 'autoSnapshot', render: renderDatasets },
   'snapshot.query': { key: 'snapshots',    render: renderSnapshots },
   'iostat':         { key: 'iostat',       render: renderIOStat },
   'user.query':     { key: 'users',        render: renderUsers },
@@ -2142,6 +2288,27 @@ function startSSE() {
 document.getElementById('scrubScheduleSaveBtn').addEventListener('click', saveScrubSchedule);
 document.getElementById('scrubScheduleRemoveBtn').addEventListener('click', removeScrubSchedule);
 document.getElementById('scrubScheduleCancelBtn').addEventListener('click', () => document.getElementById('scrubScheduleDialog').close());
+
+async function removeAutoSnapSchedule() {
+  const body = {};
+  body['com.sun:auto-snapshot'] = '';
+  _autoSnapPeriods.forEach(p => { body[p.prop] = ''; });
+  document.getElementById('autoSnapDialog').close();
+  showOpLogRunning(`Remove auto-snapshot: ${_autoSnapDataset}`);
+  try {
+    const encodedName = _autoSnapDataset.split('/').map(encodeURIComponent).join('/');
+    const result = await api('PUT', '/api/auto-snapshot/' + encodedName, body);
+    showOpLog(`Auto-snapshot removed: ${_autoSnapDataset}`, result.tasks, null);
+    toast('Auto-snapshot config removed', 'ok');
+  } catch (err) {
+    showOpLog(`Auto-snapshot remove failed`, err.tasks, err.message);
+  }
+}
+
+// ── Auto-snapshot dialog wiring ───────────────────────────────────────────────
+document.getElementById('autoSnapSaveBtn').addEventListener('click', saveAutoSnapSchedule);
+document.getElementById('autoSnapRemoveBtn').addEventListener('click', removeAutoSnapSchedule);
+document.getElementById('autoSnapCancelBtn').addEventListener('click', () => document.getElementById('autoSnapDialog').close());
 
 // ── Boot ──────────────────────────────────────────────────────────────────────
 // Perform an immediate REST load so the UI is populated on first paint,

--- a/static/index.html
+++ b/static/index.html
@@ -77,6 +77,7 @@
         <label class="filter-wrap">
           <input type="search" id="snap-filter" placeholder="Filter…">
         </label>
+        <button class="btn-danger" id="deleteMultiSnapBtn" style="display:none">Delete selected (0)</button>
         <button class="btn-primary" id="newSnapBtn">+ New Snapshot</button>
       </div>
       <div id="snapshots-table-wrap">
@@ -313,6 +314,21 @@
       <div class="dialog-actions">
         <button type="button" id="deleteSnapCancelBtn" class="btn-secondary">Cancel</button>
         <button type="button" id="deleteSnapConfirmBtn" class="btn-danger">Delete</button>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- DELETE MULTIPLE SNAPSHOTS DIALOG -->
+  <dialog id="deleteMultiSnapDialog">
+    <h3>Delete <span id="deleteMultiSnapCount"></span> Snapshot<span id="deleteMultiSnapPlural"></span></h3>
+    <div class="dialog-body">
+      <div class="delete-warning">
+        <p>Permanently destroy these snapshots? This cannot be undone.</p>
+      </div>
+      <ul id="deleteMultiSnapList" style="max-height:200px;overflow-y:auto;margin:0.75rem 0;padding-left:1.25rem;font-size:0.85rem;font-family:var(--font)"></ul>
+      <div class="dialog-actions">
+        <button type="button" id="deleteMultiSnapCancelBtn" class="btn-secondary">Cancel</button>
+        <button type="button" id="deleteMultiSnapConfirmBtn" class="btn-danger">Delete all</button>
       </div>
     </div>
   </dialog>
@@ -637,6 +653,57 @@
         <button type="button" id="scrubScheduleSaveBtn" class="btn-primary">Enable</button>
         <button type="button" id="scrubScheduleRemoveBtn" class="btn-danger">Remove</button>
         <button type="button" id="scrubScheduleCancelBtn" class="btn-secondary">Cancel</button>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- AUTO-SNAPSHOT SCHEDULE DIALOG -->
+  <dialog id="autoSnapDialog">
+    <h3>Auto-Snapshot &mdash; <span id="autoSnapDatasetName"></span></h3>
+    <div class="dialog-body">
+      <fieldset class="form-section">
+        <legend>Master enable</legend>
+        <label>Auto-snapshot
+          <select id="autosnap-master">
+            <option value="">&mdash; inherit &mdash;</option>
+            <option value="true">true (enabled)</option>
+            <option value="false">false (disabled)</option>
+          </select>
+        </label>
+      </fieldset>
+      <fieldset class="form-section">
+        <legend>Keep counts <span class="field-note">(blank&nbsp;=&nbsp;inherit)</span></legend>
+        <div class="form-grid">
+          <label>Frequent (15 min)
+            <input type="number" id="autosnap-frequent" min="1" max="9999" placeholder="inherit">
+            <span id="autosnap-frequent-hint" class="field-note"></span>
+          </label>
+          <label>Hourly
+            <input type="number" id="autosnap-hourly" min="1" max="9999" placeholder="inherit">
+            <span id="autosnap-hourly-hint" class="field-note"></span>
+          </label>
+          <label>Daily
+            <input type="number" id="autosnap-daily" min="1" max="9999" placeholder="inherit">
+            <span id="autosnap-daily-hint" class="field-note"></span>
+          </label>
+          <label>Weekly
+            <input type="number" id="autosnap-weekly" min="1" max="9999" placeholder="inherit">
+            <span id="autosnap-weekly-hint" class="field-note"></span>
+          </label>
+          <label>Monthly
+            <input type="number" id="autosnap-monthly" min="1" max="9999" placeholder="inherit">
+            <span id="autosnap-monthly-hint" class="field-note"></span>
+          </label>
+        </div>
+      </fieldset>
+      <p class="field-note" style="margin:0 0 0.75rem">
+        Requires <code>zfs-auto-snapshot</code> (Linux) or <code>zfstools</code> (FreeBSD).
+        Check the System Info tab to verify it is installed.
+      </p>
+      <div class="dialog-actions">
+        <button type="button" id="autoSnapCancelBtn" class="btn-secondary">Cancel</button>
+        <button type="button" id="autoSnapRemoveBtn" class="btn-danger">Remove</button>
+        <button type="button" id="autoSnapSaveBtn" class="btn-primary">Save</button>
       </div>
     </div>
   </dialog>

--- a/static/style.css
+++ b/static/style.css
@@ -720,3 +720,7 @@ dialog label select:focus { border-color: var(--accent); }
 .btn-smb:hover { background: var(--surface); color: var(--text); }
 .btn-smb.active { background: color-mix(in srgb, var(--accent) 15%, var(--surface2)); color: var(--accent); border-color: var(--accent-dim); }
 .btn-smb.active:hover { background: color-mix(in srgb, var(--accent) 25%, var(--surface2)); }
+.btn-autosnap { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer; }
+.btn-autosnap:hover { background: var(--surface); color: var(--text); }
+.btn-autosnap.active { background: color-mix(in srgb, var(--accent) 15%, var(--surface2)); color: var(--accent); border-color: var(--accent-dim); }
+.btn-autosnap.active:hover { background: color-mix(in srgb, var(--accent) 25%, var(--surface2)); }

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -48,6 +48,8 @@ All endpoints are served at `http://<host>:8080`. The API is JSON-over-HTTP; all
 | GET    | `/api/scrub-schedules`      | List periodic scrub schedule config |
 | PUT    | `/api/scrub-schedule/{pool}`| Add pool to periodic scrub schedule |
 | DELETE | `/api/scrub-schedule/{pool}`| Remove pool from periodic scrub schedule |
+| GET    | `/api/auto-snapshot/{dataset}` | Get auto-snapshot property values for a dataset |
+| PUT    | `/api/auto-snapshot/{dataset}` | Set auto-snapshot properties for a dataset |
 
 ---
 
@@ -154,6 +156,82 @@ Returns Ansible task steps.
 ### DELETE /api/scrub-schedule/{pool}
 
 Remove a pool from the periodic scrub schedule. Returns Ansible task steps.
+
+---
+
+## Auto-snapshot scheduling
+
+Manages `com.sun:auto-snapshot*` ZFS user properties per dataset. These properties are consumed by `zfs-auto-snapshot` (Linux) or `zfstools` (FreeBSD) to automatically create and rotate snapshots. dumpstore sets/clears the properties; the external daemon handles snapshot creation.
+
+#### Default behaviour — important
+
+`zfs-auto-snapshot` uses an **opt-out** model: any dataset where `com.sun:auto-snapshot` is **not explicitly set** is snapshotted by default. Setting the property to `false` is how you exclude a dataset.
+
+The recommended pattern for snapshotting only specific datasets:
+
+```bash
+# 1. Opt the entire pool out
+zfs set com.sun:auto-snapshot=false tank
+
+# 2. Opt specific datasets back in
+zfs set com.sun:auto-snapshot=true tank/data
+zfs set com.sun:auto-snapshot=true tank/home
+```
+
+#### Inspect current config via CLI
+
+```bash
+# All datasets, all 6 properties
+zfs get com.sun:auto-snapshot,com.sun:auto-snapshot:frequent,com.sun:auto-snapshot:hourly,com.sun:auto-snapshot:daily,com.sun:auto-snapshot:weekly,com.sun:auto-snapshot:monthly -t filesystem,volume
+
+# Recursively from a pool root
+zfs get -r com.sun:auto-snapshot tank
+
+# Only locally-set values (excludes inherited/default)
+zfs get -r -s local com.sun:auto-snapshot tank
+```
+
+### GET /api/auto-snapshot/{dataset}
+
+Returns the current `com.sun:auto-snapshot*` property values and their source (local/inherited/default) for the given dataset.
+
+```json
+{
+  "com.sun:auto-snapshot":          { "value": "true",  "source": "local" },
+  "com.sun:auto-snapshot:frequent": { "value": "4",     "source": "local" },
+  "com.sun:auto-snapshot:hourly":   { "value": "24",    "source": "local" },
+  "com.sun:auto-snapshot:daily":    { "value": "7",     "source": "local" },
+  "com.sun:auto-snapshot:weekly":   { "value": "4",     "source": "local" },
+  "com.sun:auto-snapshot:monthly":  { "value": "-",     "source": "default" }
+}
+```
+
+A `value` of `"-"` with `source` of `"default"` means the property is not set (inherits system default).
+
+### PUT /api/auto-snapshot/{dataset}
+
+Set or clear `com.sun:auto-snapshot*` properties on a dataset. Returns Ansible task steps.
+
+**Request body** — any combination of these keys; omitted keys are left unchanged:
+
+| Key | Values |
+|-----|--------|
+| `com.sun:auto-snapshot` | `"true"`, `"false"`, or `""` (inherit) |
+| `com.sun:auto-snapshot:frequent` | integer 1–9999, or `""` (inherit) |
+| `com.sun:auto-snapshot:hourly` | integer 1–9999, or `""` (inherit) |
+| `com.sun:auto-snapshot:daily` | integer 1–9999, or `""` (inherit) |
+| `com.sun:auto-snapshot:weekly` | integer 1–9999, or `""` (inherit) |
+| `com.sun:auto-snapshot:monthly` | integer 1–9999, or `""` (inherit) |
+
+Empty string (`""`) triggers `zfs inherit` on the property (clears the local value).
+
+```json
+{
+  "com.sun:auto-snapshot": "true",
+  "com.sun:auto-snapshot:daily": "7",
+  "com.sun:auto-snapshot:monthly": "3"
+}
+```
 
 ---
 


### PR DESCRIPTION
Auto-snapshot scheduling:
- Manage com.sun:auto-snapshot* ZFS properties per dataset via GET/PUT /api/auto-snapshot/{dataset} and GET /api/auto-snapshot-schedules
- zfs_autosnap_set.yml playbook sets/inherits all 6 properties in one run
- ListAutoSnapshotProps() fetches all datasets in 2 CLI calls; pushed via SSE as autosnapshot.query so Snap badges stay in sync without page reload
- Per-dataset Snap button in datasets tab; dialog with master enable + keep counts per period (frequent/hourly/daily/weekly/monthly)
- Remove button clears all properties back to inherit
- zfs-auto-snapshot added to installed software inventory

Multi-snapshot delete:
- Checkboxes on each snapshot row + select-all in header
- "Delete selected (N)" button in toolbar; single Ansible run via zfs_snapshot_destroy_batch.yml using from_json loop (no N startups)
- POST /api/snapshots/delete-batch with validation (max 100, each dataset@label)
- Single per-row delete unchanged

## Summary

<!-- 1-3 bullet points describing what changed and why -->

## Test plan

<!-- Bulleted checklist of what to verify -->

## Docs updated

- [ ] `README.md` updated (or change doesn't affect routes/features/architecture)
- [ ] `docs/index.html` updated (or same reason)
- [ ] `wiki/` updated (or same reason)

<!-- If docs don't need updating, briefly explain why: -->
