### PR TITLE
chore: add community health files (CoC, contributing, issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Something is broken or behaving unexpectedly
+labels: bug
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include any error messages from the UI or server logs.
+
+## Environment
+
+- OS / distro:
+- ZFS version (`zfs version`):
+- Ansible version (`ansible --version`):
+- dumpstore version or commit:
+- Browser (if UI issue):
+
+## Logs
+
+```
+Paste relevant server output here (run with -v if available).
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## What problem does this solve?
+
+A clear description of the problem or gap this feature addresses.
+
+## Proposed solution
+
+Describe what you'd like to see added or changed.
+
+## Alternatives considered
+
+Any other approaches you considered and why you ruled them out.
+
+## Additional context
+
+Any other context, screenshots, or references that would help.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when an individual is representing the project or its community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting the maintainers directly via GitHub. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to dumpstore
+
+Thanks for your interest in contributing. dumpstore is a focused project with a clear philosophy — please read this before opening a PR.
+
+## Philosophy
+
+- **No external Go dependencies.** Standard library only. If you think you need a dependency, find a way without it.
+- **No frameworks on the frontend.** Vanilla JS, no build step, no bundler.
+- **Minimal footprint on the host.** Reads go through direct CLI calls; writes go through Ansible playbooks. Don't blur that line.
+
+## Getting started
+
+```bash
+git clone https://github.com/langerma/dumpstore
+cd dumpstore
+go build ./...   # must pass
+go vet ./...     # must pass
+```
+
+You need `ansible-playbook` in your PATH and a machine with ZFS to test write operations end-to-end. Read-only development can be done on any Linux box.
+
+## Workflow
+
+1. **Open an issue first** for anything non-trivial. Alignment before code saves everyone time.
+2. **Create a feature branch**: `git checkout -b feat/<name>` or `fix/<name>`.
+3. Make your changes. Keep them focused — one concern per PR.
+4. Update docs if your change affects routes, features, or architecture:
+   - `README.md`
+   - `docs/index.html`
+   - relevant page in `wiki/`
+5. Open a PR against `main` using the pull request template.
+
+## Adding a new operation
+
+| Type | What to do |
+|------|-----------|
+| Read | Add a function to `internal/zfs/zfs.go` + handler in `internal/api/handlers.go` |
+| Write | Add a playbook in `playbooks/` + handler wired via `h.runner.Run(...)` |
+| Both | Register the route in `handlers.go:RegisterRoutes` |
+| UI | Render function in `static/app.js`, markup in `static/index.html` |
+
+See [CLAUDE.md](CLAUDE.md) for detailed conventions on playbooks and the frontend.
+
+## Playbook conventions
+
+- Target `localhost`, `gather_facts: false`.
+- Always include an `assert` task before any mutating command.
+- Task names must be stable — the Go runner looks them up by name.
+- Required extra vars must be documented in a header comment.
+
+## Frontend conventions
+
+- All data lives in the `state` object.
+- Render functions are pure: read `state`, write `innerHTML`.
+- Always escape user-controlled strings via `esc()` before inserting into HTML.
+- Always show the Ansible op-log dialog (`showOpLog`) after every write operation — never `toast()` alone.
+
+## Code review bar
+
+PRs are merged when they are correct, simple, and consistent with the existing style. "Works on my machine" is not enough — explain how you tested it.
+
+## Reporting issues
+
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) for bugs and the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md) for ideas.

--- a/README.md
+++ b/README.md
@@ -284,6 +284,14 @@ apt install samba
 # or manually: ansible-playbook playbooks/smb_setup.yml
 ```
 
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR — it covers the no-external-dependencies rule, the read/write split convention, playbook and frontend standards, and the docs update requirement.
+
+Bug reports and feature requests go through the [issue tracker](https://github.com/langerma/dumpstore/issues) using the provided templates.
+
+This project follows a [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Versioning
 
 Releases are tagged with semver (`v0.1.0`, `v0.2.0`, …). The version is injected at build time via ldflags from `git describe`:

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -40,6 +40,10 @@ See [[Installation]] for detailed instructions, requirements, and configuration.
 
 dumpstore has no built-in authentication and runs as root. It is designed for trusted, private networks. Several endpoints accept passwords in the request body — without TLS these travel in plaintext. See [SECURITY.md](https://github.com/langerma/dumpstore/blob/main/SECURITY.md) for recommended mitigations (reverse proxy with TLS, SSH tunnel, VPN) and rate-limiting guidance.
 
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](https://github.com/langerma/dumpstore/blob/main/CONTRIBUTING.md) for the workflow, conventions, and docs update requirements. This project follows a [Code of Conduct](https://github.com/langerma/dumpstore/blob/main/CODE_OF_CONDUCT.md).
+
 ## Pages
 
 - [[Installation]] — requirements, install script, make, manual build, service configuration


### PR DESCRIPTION
Adds CODE_OF_CONDUCT.md, CONTRIBUTING.md, and GitHub issue templates (bug report + feature request) to bring the community health score to 100%. README.md and wiki/Home.md updated with Contributing sections.

## Summary

<!-- 1-3 bullet points describing what changed and why -->

## Test plan

<!-- Bulleted checklist of what to verify -->

## Docs updated

- [*] `README.md` updated (or change doesn't affect routes/features/architecture)
- [*] `docs/index.html` updated (or same reason)
- [*] `wiki/` updated (or same reason)

<!-- If docs don't need updating, briefly explain why: -->
