### PR TITLE
Add unit tests and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test -race ./...

--- a/TODO.md
+++ b/TODO.md
@@ -27,9 +27,17 @@
 
 ## High (round 2)
 
+- [ ] **No test coverage** — Zero `*_test.go` files exist. Add unit tests for regex validators (`reZFSName`, `reUnixName`, `reSnapLabel`), NDJSON parser in `runner.go`, and ZFS CLI output parsing in `zfs.go`. Then add integration tests for at least one create/delete cycle (dataset or user). This is the single biggest quality gap.
+
+- [ ] **No CI build/lint pipeline** — Only `check-docs.yml` runs in CI. Add a workflow that runs `go build ./...`, `go vet ./...`, and optionally `golangci-lint`. Prevents broken merges and catches issues early.
+
 - [ ] **`handlers.go`: Password fields bypass `safePropertyValue`** — `createUser`, `modifyUser`, and `setSMBPassword` pass the `password` field directly to Ansible extra-vars without calling `safePropertyValue`. A password containing newlines corrupts the `smbpasswd` stdin input (`playbooks/user_create.yml:79`) because the `stdin:` field splits on newlines. Validate password fields reject `\n` / `\r` before use.
 
 ## Medium (round 2)
+
+- [ ] **`handlers.go`: Split into domain-specific files** — At 2,150 LOC with 54 handlers, `handlers.go` is a monolith. Split into `zfs_handlers.go`, `user_handlers.go`, `acl_handlers.go`, `smb_handlers.go`, `iscsi_handlers.go` etc. No logic changes — just file boundaries for navigability.
+
+- [ ] **`app.js`: Split into per-tab modules** — At 2,460 LOC with 77 functions, `app.js` is hard to navigate. Group render functions and event handlers by tab/feature into separate files or ES modules.
 
 - [ ] **Request ID correlation in logs** — HTTP middleware generates a UUID per request and stores it in context; all `slog` calls inside handlers use `slog.InfoContext` so every log line carries `req_id`. Lets you reconstruct a full request lifecycle from logs when concurrent requests overlap. No new dependencies — stdlib `context` + `log/slog` only.
 
@@ -46,3 +54,4 @@
 - [ ] **`handlers.go`: No upper-bound validation on numeric ZFS properties** — `quota`, `recordsize`, etc. accept arbitrary strings like `"99999999999T"` that are syntactically valid but fail at the ZFS layer with a cryptic error. Parse and range-check numeric property values before sending to the playbook.
 - [ ] **`app.js`: No client-side name validation in create dialogs** — Dataset and snapshot create dialogs send the name to the backend without checking it against the allowed regex first. Results in a round-trip error instead of immediate inline feedback. Mirror `reZFSName` / `reSnapLabel` in the JS dialog submit handler.
 - [ ] **`app.js`: No visual indicator when SSE degrades to polling** — When `EventSource` fails and the client falls back to 30 s REST polling (`startSSE` fallback path), there is no UI indicator. Users see stale data with no explanation. Add a subtle status badge (e.g. "live" vs "polling") in the header.
+- [ ] **Consistent dataset pre-checks across handlers** — Some handlers call `datasetExists()` before the playbook, others let Ansible surface the error. Standardize so all mutating handlers pre-check and return a clear 404.

--- a/internal/api/validators_test.go
+++ b/internal/api/validators_test.go
@@ -1,0 +1,455 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestValidZFSName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple pool", "tank", true},
+		{"pool with dataset", "tank/data", true},
+		{"nested dataset", "tank/data/child", true},
+		{"with dots", "tank/my.data", true},
+		{"with colons", "tank/my:data", true},
+		{"with dashes", "tank/my-data", true},
+		{"with underscores", "tank/my_data", true},
+		{"numeric after first char", "tank1/data2", true},
+		{"empty string", "", false},
+		{"starts with number", "1tank", false},
+		{"starts with dot", ".tank", false},
+		{"starts with slash", "/tank", false},
+		{"trailing slash", "tank/", false},
+		{"double slash", "tank//data", false},
+		{"component starts with number", "tank/1data", false},
+		{"contains space", "tank/my data", false},
+		{"contains at sign", "tank/d@ta", false},
+		{"contains semicolon", "tank/d;ta", false},
+		{"single char", "t", true},
+		{"single char dataset", "t/d", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validZFSName(tt.input); got != tt.want {
+				t.Errorf("validZFSName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidSnapLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple label", "daily", true},
+		{"with numbers", "snap2024", true},
+		{"starts with number", "2024snap", true},
+		{"with dots", "auto.2024", true},
+		{"with colons", "snap:v1", true},
+		{"with dashes", "snap-daily", true},
+		{"with underscores", "snap_daily", true},
+		{"empty string", "", false},
+		{"starts with dot", ".snap", false},
+		{"starts with dash", "-snap", false},
+		{"contains space", "my snap", false},
+		{"contains slash", "snap/label", false},
+		{"contains at sign", "snap@label", false},
+		{"single char alpha", "s", true},
+		{"single digit", "1", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validSnapLabel(tt.input); got != tt.want {
+				t.Errorf("validSnapLabel(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidUnixName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple name", "alice", true},
+		{"starts with underscore", "_svc", true},
+		{"with numbers", "user01", true},
+		{"with dots", "user.name", true},
+		{"with dashes", "user-name", true},
+		{"with underscores", "user_name", true},
+		{"single char", "a", true},
+		{"single underscore", "_", true},
+		{"max length 32 chars", "abcdefghijklmnopqrstuvwxyz012345", true},
+		{"too long 33 chars", "abcdefghijklmnopqrstuvwxyz0123456", false},
+		{"empty string", "", false},
+		{"starts with number", "1user", false},
+		{"starts with dash", "-user", false},
+		{"starts with dot", ".user", false},
+		{"contains space", "my user", false},
+		{"contains slash", "user/name", false},
+		{"contains colon", "user:name", false},
+		{"contains at sign", "user@host", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validUnixName(tt.input); got != tt.want {
+				t.Errorf("validUnixName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidSMBShare(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple name", "myshare", true},
+		{"with numbers", "share01", true},
+		{"with dots", "my.share", true},
+		{"with dashes", "my-share", true},
+		{"with underscores", "my_share", true},
+		{"single char", "s", true},
+		{"starts with number", "1share", true},
+		{"starts with dot", ".share", true},
+		{"starts with dash", "-share", true},
+		{"80 chars", strings.Repeat("a", 80), true},
+		{"81 chars too long", strings.Repeat("a", 81), false},
+		{"empty string", "", false},
+		{"contains space", "my share", false},
+		{"contains slash", "my/share", false},
+		{"contains at sign", "my@share", false},
+		{"contains colon", "my:share", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validSMBShare(tt.input); got != tt.want {
+				t.Errorf("validSMBShare(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidShellPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"bash", "/bin/bash", true},
+		{"zsh", "/usr/bin/zsh", true},
+		{"nologin", "/usr/sbin/nologin", true},
+		{"false", "/bin/false", true},
+		{"with dots", "/usr/local/bin/my.shell", true},
+		{"with dashes", "/usr/local/bin/my-shell", true},
+		{"with underscores", "/usr/local/bin/my_shell", true},
+		{"empty string", "", false},
+		{"no leading slash", "bin/bash", false},
+		{"just slash", "/", false},
+		{"trailing slash", "/bin/", true},
+		{"double slash", "/bin//bash", true},
+		{"path with dots", "/bin/../bash", true},
+		{"contains space", "/bin/my shell", false},
+		{"contains semicolon", "/bin/bash;rm", false},
+		{"contains backtick", "/bin/`bash`", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validShellPath(tt.input); got != tt.want {
+				t.Errorf("validShellPath(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidIQN(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"standard iqn", "iqn.2024-01.com.example:target0", true},
+		{"with dots in domain", "iqn.2024-01.com.example.storage:lun1", true},
+		{"with colons in target", "iqn.2024-12.org.myhost:disk:0", true},
+		{"with dashes in target", "iqn.2024-01.com.example:my-target", true},
+		{"with dots in target", "iqn.2024-01.com.example:my.target", true},
+		{"with underscores in target", "iqn.2024-01.com.example:my_target", true},
+		{"empty string", "", false},
+		{"no iqn prefix", "2024-01.com.example:target0", false},
+		{"wrong date format", "iqn.24-01.com.example:target0", false},
+		{"missing month", "iqn.2024.com.example:target0", false},
+		{"missing colon separator", "iqn.2024-01.com.example.target0", false},
+		{"uppercase domain", "iqn.2024-01.COM.EXAMPLE:target0", false},
+		{"empty target after colon", "iqn.2024-01.com.example:", false},
+		{"spaces in iqn", "iqn.2024-01.com.example:my target", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validIQN(tt.input); got != tt.want {
+				t.Errorf("validIQN(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSafePropertyValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple value", "on", true},
+		{"numeric value", "1024", true},
+		{"path-like value", "/mnt/data", true},
+		{"with equals", "rw=@10.0.0.0/24", true},
+		{"with comma", "rw=@10.0.0.0/24,rw=@192.168.1.0/24", true},
+		{"empty string", "", true},
+		{"with colon", "lz4:on", true},
+		{"with at sign", "rw=@host", true},
+		{"contains semicolon", "on;rm -rf", false},
+		{"contains backtick", "on`cmd`", false},
+		{"contains pipe", "on|cmd", false},
+		{"contains ampersand", "on&cmd", false},
+		{"contains dollar", "on$VAR", false},
+		{"contains newline", "on\ncmd", false},
+		{"contains carriage return", "on\rcmd", false},
+		{"contains backslash", "on\\n", false},
+		{"contains double quote", `on"cmd"`, false},
+		{"contains single quote", "on'cmd'", false},
+		{"contains asterisk", "on*", false},
+		{"contains open paren", "on(", false},
+		{"contains close paren", "on)", false},
+		{"contains question mark", "on?", false},
+		{"contains exclamation", "on!", false},
+		{"contains tilde", "on~", false},
+		{"contains open brace", "on{", false},
+		{"contains close brace", "on}", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := safePropertyValue(tt.input); got != tt.want {
+				t.Errorf("safePropertyValue(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidUnixNameList(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty string", "", true},
+		{"single name", "wheel", true},
+		{"two names", "wheel,audio", true},
+		{"three names", "wheel,audio,video", true},
+		{"with spaces around commas", "wheel, audio, video", true},
+		{"name with underscore", "_svc,users", true},
+		{"name with dash", "my-group,users", true},
+		{"invalid name in list", "wheel,1bad,audio", false},
+		{"empty element", "wheel,,audio", false},
+		{"trailing comma", "wheel,audio,", false},
+		{"leading comma", ",wheel,audio", false},
+		{"name too long", strings.Repeat("a", 33), false},
+		{"single invalid name", "1bad", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validUnixNameList(tt.input); got != tt.want {
+				t.Errorf("validUnixNameList(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidAutoSnapValue(t *testing.T) {
+	tests := []struct {
+		name string
+		prop string
+		val  string
+		want bool
+	}{
+		{"main prop true", "com.sun:auto-snapshot", "true", true},
+		{"main prop false", "com.sun:auto-snapshot", "false", true},
+		{"main prop empty", "com.sun:auto-snapshot", "", true},
+		{"main prop invalid", "com.sun:auto-snapshot", "yes", false},
+		{"main prop numeric", "com.sun:auto-snapshot", "1", false},
+		{"keep count 1", "com.sun:auto-snapshot:daily", "1", true},
+		{"keep count 10", "com.sun:auto-snapshot:hourly", "10", true},
+		{"keep count 9999", "com.sun:auto-snapshot:weekly", "9999", true},
+		{"keep count empty", "com.sun:auto-snapshot:daily", "", true},
+		{"keep count 0 invalid", "com.sun:auto-snapshot:daily", "0", false},
+		{"keep count 10000 too long", "com.sun:auto-snapshot:daily", "10000", false},
+		{"keep count negative", "com.sun:auto-snapshot:daily", "-1", false},
+		{"keep count non-numeric", "com.sun:auto-snapshot:daily", "abc", false},
+		{"keep count leading zero", "com.sun:auto-snapshot:daily", "01", false},
+		{"keep count true invalid", "com.sun:auto-snapshot:frequent", "true", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validAutoSnapValue(tt.prop, tt.val); got != tt.want {
+				t.Errorf("validAutoSnapValue(%q, %q) = %v, want %v", tt.prop, tt.val, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidPortalIP(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"ipv4 localhost", "127.0.0.1", true},
+		{"ipv4 private", "192.168.1.1", true},
+		{"ipv4 all zeros", "0.0.0.0", true},
+		{"ipv6 loopback", "::1", true},
+		{"ipv6 full", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", true},
+		{"ipv6 shortened", "2001:db8::1", true},
+		{"empty string", "", false},
+		{"hostname", "example.com", false},
+		{"ipv4 too many octets", "1.2.3.4.5", false},
+		{"ipv4 octet too large", "256.1.1.1", false},
+		{"garbage", "not-an-ip", false},
+		{"ipv4 with port", "192.168.1.1:3260", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validPortalIP(tt.input); got != tt.want {
+				t.Errorf("validPortalIP(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidPort(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"port 1", "1", true},
+		{"port 80", "80", true},
+		{"port 443", "443", true},
+		{"port 3260", "3260", true},
+		{"port 65535", "65535", true},
+		{"port 0 invalid", "0", false},
+		{"port 65536 too high", "65536", false},
+		{"negative port", "-1", false},
+		{"empty string", "", false},
+		{"non-numeric", "abc", false},
+		{"float", "80.5", false},
+		{"with spaces", " 80", false},
+		{"very large number", "999999", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validPort(tt.input); got != tt.want {
+				t.Errorf("validPort(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeJSON(t *testing.T) {
+	type payload struct {
+		Name string `json:"name"`
+		Size int    `json:"size"`
+	}
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+		wantVal payload
+	}{
+		{
+			name:    "valid object",
+			body:    `{"name":"tank/data","size":100}`,
+			wantErr: false,
+			wantVal: payload{Name: "tank/data", Size: 100},
+		},
+		{
+			name:    "valid object with whitespace",
+			body:    `  { "name": "tank/data", "size": 100 }  `,
+			wantErr: false,
+			wantVal: payload{Name: "tank/data", Size: 100},
+		},
+		{
+			name:    "empty body",
+			body:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			body:    `{name: invalid}`,
+			wantErr: true,
+		},
+		{
+			name:    "two json objects",
+			body:    `{"name":"a","size":1}{"name":"b","size":2}`,
+			wantErr: true,
+		},
+		{
+			name:    "json with trailing garbage",
+			body:    `{"name":"a","size":1} extra`,
+			wantErr: true,
+		},
+		{
+			name:    "partial fields",
+			body:    `{"name":"tank/data"}`,
+			wantErr: false,
+			wantVal: payload{Name: "tank/data", Size: 0},
+		},
+		{
+			name:    "null body",
+			body:    `null`,
+			wantErr: false,
+			wantVal: payload{},
+		},
+		{
+			name:    "wrong type value",
+			body:    `{"name":123}`,
+			wantErr: true,
+		},
+		{
+			name:    "array instead of object",
+			body:    `[1,2,3]`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "/test", io.NopCloser(bytes.NewBufferString(tt.body)))
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			var got payload
+			err = decodeJSON(req, &got)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("decodeJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.Name != tt.wantVal.Name || got.Size != tt.wantVal.Size {
+					t.Errorf("decodeJSON() got = %+v, want %+v", got, tt.wantVal)
+				}
+			}
+		})
+	}
+}

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -1,0 +1,460 @@
+package broker
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	b := New()
+	if b == nil {
+		t.Fatal("New() returned nil")
+	}
+	if b.subs == nil {
+		t.Fatal("subs map not initialized")
+	}
+	if b.cache == nil {
+		t.Fatal("cache map not initialized")
+	}
+}
+
+func TestSubscribeReturnsChannel(t *testing.T) {
+	b := New()
+	ch := b.Subscribe("pool.query")
+	if ch == nil {
+		t.Fatal("Subscribe returned nil channel")
+	}
+}
+
+func TestSubscribeDeliversCachedValue(t *testing.T) {
+	b := New()
+	b.Publish("dataset.query", map[string]string{"key": "value"})
+
+	ch := b.Subscribe("dataset.query")
+	select {
+	case msg := <-ch:
+		var got map[string]string
+		if err := json.Unmarshal(msg, &got); err != nil {
+			t.Fatalf("unmarshal cached value: %v", err)
+		}
+		if got["key"] != "value" {
+			t.Fatalf("cached value = %v, want key=value", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cached value")
+	}
+}
+
+func TestSubscribeNoCacheNothingDelivered(t *testing.T) {
+	b := New()
+	ch := b.Subscribe("pool.query")
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no message, got %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestPublishDeliversToAllSubscribers(t *testing.T) {
+	tests := []struct {
+		name       string
+		numSubs    int
+		topic      string
+		payload    any
+		wantString string
+	}{
+		{
+			name:       "two subscribers",
+			numSubs:    2,
+			topic:      "pool.query",
+			payload:    "hello",
+			wantString: `"hello"`,
+		},
+		{
+			name:       "three subscribers with object payload",
+			numSubs:    3,
+			topic:      "iostat",
+			payload:    map[string]int{"ops": 42},
+			wantString: `{"ops":42}`,
+		},
+		{
+			name:       "single subscriber",
+			numSubs:    1,
+			topic:      "snapshot.query",
+			payload:    []int{1, 2, 3},
+			wantString: `[1,2,3]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := New()
+			channels := make([]chan []byte, tt.numSubs)
+			for i := range channels {
+				channels[i] = b.Subscribe(tt.topic)
+			}
+
+			b.Publish(tt.topic, tt.payload)
+
+			for i, ch := range channels {
+				select {
+				case msg := <-ch:
+					if string(msg) != tt.wantString {
+						t.Errorf("subscriber %d: got %s, want %s", i, msg, tt.wantString)
+					}
+				case <-time.After(time.Second):
+					t.Errorf("subscriber %d: timed out", i)
+				}
+			}
+		})
+	}
+}
+
+func TestPublishUpdatesCache(t *testing.T) {
+	b := New()
+	b.Publish("pool.query", "first")
+	b.Publish("pool.query", "second")
+
+	ch := b.Subscribe("pool.query")
+	select {
+	case msg := <-ch:
+		if string(msg) != `"second"` {
+			t.Fatalf("cache not updated: got %s, want %q", msg, `"second"`)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cached value")
+	}
+}
+
+func TestPublishNoCacheDoesNotUpdateCache(t *testing.T) {
+	b := New()
+
+	// Publish a cached value first
+	b.Publish("ansible.progress", "cached-value")
+
+	// PublishNoCache should NOT overwrite the cache
+	b.PublishNoCache("ansible.progress", "nocache-value")
+
+	// New subscriber should get the original cached value, not the nocache one
+	ch := b.Subscribe("ansible.progress")
+	select {
+	case msg := <-ch:
+		if string(msg) != `"cached-value"` {
+			t.Fatalf("PublishNoCache overwrote cache: got %s, want %q", msg, `"cached-value"`)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cached value")
+	}
+}
+
+func TestPublishNoCacheDeliversToSubscribers(t *testing.T) {
+	b := New()
+	ch := b.Subscribe("ansible.progress")
+
+	b.PublishNoCache("ansible.progress", "progress-msg")
+
+	select {
+	case msg := <-ch:
+		if string(msg) != `"progress-msg"` {
+			t.Fatalf("got %s, want %q", msg, `"progress-msg"`)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+func TestPublishNoCacheEmptyCache(t *testing.T) {
+	b := New()
+
+	// Only PublishNoCache, never Publish — cache should remain empty
+	b.PublishNoCache("iostat", "data")
+
+	ch := b.Subscribe("iostat")
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no cached message, got %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected: no cache entry
+	}
+}
+
+func TestUnsubscribeRemovesAndCloses(t *testing.T) {
+	b := New()
+	ch := b.Subscribe("pool.query")
+
+	b.Unsubscribe("pool.query", ch)
+
+	// Channel should be closed
+	_, ok := <-ch
+	if ok {
+		t.Fatal("expected channel to be closed after Unsubscribe")
+	}
+
+	// Publishing after unsubscribe should not panic or deliver
+	b.Publish("pool.query", "after-unsub")
+
+	b.mu.Lock()
+	subCount := len(b.subs["pool.query"])
+	b.mu.Unlock()
+	if subCount != 0 {
+		t.Fatalf("expected 0 subscribers after Unsubscribe, got %d", subCount)
+	}
+}
+
+func TestUnsubscribeUnknownChannelIsNoop(t *testing.T) {
+	b := New()
+	realCh := b.Subscribe("pool.query")
+	unknownCh := make(chan []byte, 8)
+
+	// Should not panic or affect existing subscribers
+	b.Unsubscribe("pool.query", unknownCh)
+
+	b.mu.Lock()
+	subCount := len(b.subs["pool.query"])
+	b.mu.Unlock()
+	if subCount != 1 {
+		t.Fatalf("expected 1 subscriber after no-op Unsubscribe, got %d", subCount)
+	}
+
+	// Real channel should still work
+	b.Publish("pool.query", "still-works")
+	select {
+	case msg := <-realCh:
+		if string(msg) != `"still-works"` {
+			t.Fatalf("got %s, want %q", msg, `"still-works"`)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out: real subscriber should still receive")
+	}
+}
+
+func TestUnsubscribeUnknownTopicIsNoop(t *testing.T) {
+	b := New()
+	ch := make(chan []byte, 8)
+
+	// Should not panic
+	b.Unsubscribe("nonexistent.topic", ch)
+}
+
+func TestSlowSubscriberDoesNotBlockPublisher(t *testing.T) {
+	b := New()
+	slowCh := b.Subscribe("iostat")
+	fastCh := b.Subscribe("iostat")
+
+	// Fill the slow subscriber's buffer (capacity 8)
+	for i := 0; i < 8; i++ {
+		b.Publish("iostat", i)
+	}
+	// Drain fast channel
+	for i := 0; i < 8; i++ {
+		<-fastCh
+	}
+
+	// This publish should not block even though slowCh is full
+	done := make(chan struct{})
+	go func() {
+		b.Publish("iostat", "overflow")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// expected: Publish returned without blocking
+	case <-time.After(time.Second):
+		t.Fatal("Publish blocked on slow subscriber")
+	}
+
+	// Fast subscriber should still get the message
+	select {
+	case msg := <-fastCh:
+		if string(msg) != `"overflow"` {
+			t.Fatalf("fast subscriber got %s, want %q", msg, `"overflow"`)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fast subscriber did not receive message")
+	}
+
+	// Drain slow channel to clean up
+	for len(slowCh) > 0 {
+		<-slowCh
+	}
+}
+
+func TestMultipleTopicsIndependent(t *testing.T) {
+	b := New()
+	chPool := b.Subscribe("pool.query")
+	chSnap := b.Subscribe("snapshot.query")
+
+	b.Publish("pool.query", "pool-data")
+	b.Publish("snapshot.query", "snap-data")
+
+	select {
+	case msg := <-chPool:
+		if string(msg) != `"pool-data"` {
+			t.Fatalf("pool subscriber got %s", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pool subscriber timed out")
+	}
+
+	select {
+	case msg := <-chSnap:
+		if string(msg) != `"snap-data"` {
+			t.Fatalf("snapshot subscriber got %s", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("snapshot subscriber timed out")
+	}
+
+	// Pool subscriber should NOT receive snapshot topic data
+	select {
+	case msg := <-chPool:
+		t.Fatalf("pool subscriber received unexpected message: %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestPublishMarshalError(t *testing.T) {
+	b := New()
+	ch := b.Subscribe("pool.query")
+
+	// Channels and functions cannot be marshaled to JSON
+	b.Publish("pool.query", make(chan int))
+
+	// No message should be delivered
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no message on marshal error, got %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestPublishNoCacheMarshalError(t *testing.T) {
+	b := New()
+	ch := b.Subscribe("pool.query")
+
+	b.PublishNoCache("pool.query", make(chan int))
+
+	select {
+	case msg := <-ch:
+		t.Fatalf("expected no message on marshal error, got %s", msg)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestConcurrentSubscribePublish(t *testing.T) {
+	b := New()
+	const goroutines = 50
+	const messages = 20
+
+	// Phase 1: concurrent subscribe + publish (no unsubscribe during publish).
+	var channels []chan []byte
+	var chMu sync.Mutex
+
+	var wg sync.WaitGroup
+
+	// Concurrent subscribers
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch := b.Subscribe("pool.query")
+			chMu.Lock()
+			channels = append(channels, ch)
+			chMu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	// Concurrent publishers (subscribers stay open)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < messages; j++ {
+				b.Publish("pool.query", map[string]int{"id": id, "seq": j})
+			}
+		}(i)
+	}
+
+	// Concurrent PublishNoCache
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < messages; j++ {
+				b.PublishNoCache("pool.query", map[string]int{"id": id, "seq": j})
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Phase 2: unsubscribe after all publishers are done.
+	for _, ch := range channels {
+		b.Unsubscribe("pool.query", ch)
+	}
+}
+
+func TestValidTopics(t *testing.T) {
+	expected := []string{
+		"pool.query", "poolstatus", "dataset.query",
+		"autosnapshot.query", "snapshot.query", "iostat",
+		"user.query", "group.query", "ansible.progress",
+	}
+	for _, topic := range expected {
+		t.Run(topic, func(t *testing.T) {
+			if !ValidTopics[topic] {
+				t.Fatalf("expected %q to be a valid topic", topic)
+			}
+		})
+	}
+
+	if ValidTopics["nonexistent"] {
+		t.Fatal("nonexistent topic should not be valid")
+	}
+}
+
+func TestPayloadJSONIntegrity(t *testing.T) {
+	type payload struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+
+	tests := []struct {
+		name string
+		data payload
+	}{
+		{"simple", payload{Name: "test", Count: 1}},
+		{"empty name", payload{Name: "", Count: 0}},
+		{"large count", payload{Name: "big", Count: 999999}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := New()
+			ch := b.Subscribe("dataset.query")
+
+			b.Publish("dataset.query", tt.data)
+
+			select {
+			case msg := <-ch:
+				var got payload
+				if err := json.Unmarshal(msg, &got); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if got != tt.data {
+					t.Fatalf("got %+v, want %+v", got, tt.data)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out")
+			}
+		})
+	}
+}

--- a/internal/zfs/acl_test.go
+++ b/internal/zfs/acl_test.go
@@ -1,0 +1,204 @@
+package zfs
+
+import "testing"
+
+func TestNormalizeACLType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"posix", "posix"},
+		{"posixacl", "posix"},
+		{"POSIX", "posix"},
+		{"PosixAcl", "posix"},
+		{"nfsv4", "nfsv4"},
+		{"nfsv4acls", "nfsv4"},
+		{"NFSv4", "nfsv4"},
+		{"off", "off"},
+		{"", "off"},
+		{"unknown", "off"},
+		{"disabled", "off"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeACLType(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeACLType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePOSIXACLLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  ACLEntry
+		ok    bool
+	}{
+		{
+			name:  "owner no qualifier",
+			input: "user::rwx",
+			want:  ACLEntry{Tag: "user", Qualifier: "", Perms: "rwx", Default: false},
+			ok:    true,
+		},
+		{
+			name:  "named user",
+			input: "user:alice:r-x",
+			want:  ACLEntry{Tag: "user", Qualifier: "alice", Perms: "r-x", Default: false},
+			ok:    true,
+		},
+		{
+			name:  "owning group",
+			input: "group::r--",
+			want:  ACLEntry{Tag: "group", Qualifier: "", Perms: "r--", Default: false},
+			ok:    true,
+		},
+		{
+			name:  "named group",
+			input: "group:devs:rwx",
+			want:  ACLEntry{Tag: "group", Qualifier: "devs", Perms: "rwx", Default: false},
+			ok:    true,
+		},
+		{
+			name:  "mask 2-part",
+			input: "mask::r-x",
+			want:  ACLEntry{Tag: "mask", Qualifier: "", Perms: "r-x", Default: false},
+			ok:    true,
+		},
+		{
+			name:  "other",
+			input: "other::---",
+			want:  ACLEntry{Tag: "other", Qualifier: "", Perms: "---", Default: false},
+			ok:    true,
+		},
+		{
+			name:  "default entry",
+			input: "default:user::rwx",
+			want:  ACLEntry{Tag: "user", Qualifier: "", Perms: "rwx", Default: true},
+			ok:    true,
+		},
+		{
+			name:  "default named user",
+			input: "default:user:alice:rwx",
+			want:  ACLEntry{Tag: "user", Qualifier: "alice", Perms: "rwx", Default: true},
+			ok:    true,
+		},
+		{
+			name:  "effective rights comment stripped",
+			input: "user:alice:rwx\t#effective:r--",
+			want:  ACLEntry{Tag: "user", Qualifier: "alice", Perms: "rwx", Default: false},
+			ok:    true,
+		},
+		{
+			name:  "empty line",
+			input: "",
+			want:  ACLEntry{},
+			ok:    false,
+		},
+		{
+			name:  "single field",
+			input: "single",
+			want:  ACLEntry{},
+			ok:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parsePOSIXACLLine(tt.input)
+			if ok != tt.ok {
+				t.Fatalf("parsePOSIXACLLine(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			}
+			if !tt.ok {
+				return
+			}
+			if got.Tag != tt.want.Tag {
+				t.Errorf("Tag = %q, want %q", got.Tag, tt.want.Tag)
+			}
+			if got.Qualifier != tt.want.Qualifier {
+				t.Errorf("Qualifier = %q, want %q", got.Qualifier, tt.want.Qualifier)
+			}
+			if got.Perms != tt.want.Perms {
+				t.Errorf("Perms = %q, want %q", got.Perms, tt.want.Perms)
+			}
+			if got.Default != tt.want.Default {
+				t.Errorf("Default = %v, want %v", got.Default, tt.want.Default)
+			}
+		})
+	}
+}
+
+func TestParseNFSv4ACLLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  ACLEntry
+		ok    bool
+	}{
+		{
+			name:  "allow no flags",
+			input: "A::OWNER@:rwaDxtTnNcCoy",
+			want:  ACLEntry{Tag: "A", Flags: "", Qualifier: "OWNER@", Perms: "rwaDxtTnNcCoy"},
+			ok:    true,
+		},
+		{
+			name:  "allow with flags",
+			input: "A:fd:GROUP@:rwaDxtTnNcCoy",
+			want:  ACLEntry{Tag: "A", Flags: "fd", Qualifier: "GROUP@", Perms: "rwaDxtTnNcCoy"},
+			ok:    true,
+		},
+		{
+			name:  "deny",
+			input: "D::alice@localdomain:x",
+			want:  ACLEntry{Tag: "D", Flags: "", Qualifier: "alice@localdomain", Perms: "x"},
+			ok:    true,
+		},
+		{
+			name:  "everyone",
+			input: "A::EVERYONE@:rtncy",
+			want:  ACLEntry{Tag: "A", Flags: "", Qualifier: "EVERYONE@", Perms: "rtncy"},
+			ok:    true,
+		},
+		{
+			name:  "invalid single token",
+			input: "bad",
+			want:  ACLEntry{},
+			ok:    false,
+		},
+		{
+			name:  "only three parts",
+			input: "only:three:parts",
+			want:  ACLEntry{},
+			ok:    false,
+		},
+		{
+			name:  "extra colons captured in perms via SplitN",
+			input: "A:fd:user@dom:perms:extra",
+			want:  ACLEntry{Tag: "A", Flags: "fd", Qualifier: "user@dom", Perms: "perms:extra"},
+			ok:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseNFSv4ACLLine(tt.input)
+			if ok != tt.ok {
+				t.Fatalf("parseNFSv4ACLLine(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			}
+			if !tt.ok {
+				return
+			}
+			if got.Tag != tt.want.Tag {
+				t.Errorf("Tag = %q, want %q", got.Tag, tt.want.Tag)
+			}
+			if got.Flags != tt.want.Flags {
+				t.Errorf("Flags = %q, want %q", got.Flags, tt.want.Flags)
+			}
+			if got.Qualifier != tt.want.Qualifier {
+				t.Errorf("Qualifier = %q, want %q", got.Qualifier, tt.want.Qualifier)
+			}
+			if got.Perms != tt.want.Perms {
+				t.Errorf("Perms = %q, want %q", got.Perms, tt.want.Perms)
+			}
+		})
+	}
+}

--- a/internal/zfs/zfs_test.go
+++ b/internal/zfs/zfs_test.go
@@ -1,0 +1,426 @@
+package zfs
+
+import (
+	"testing"
+)
+
+func TestParseUint(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want uint64
+	}{
+		{"dash", "-", 0},
+		{"empty", "", 0},
+		{"none", "none", 0},
+		{"zero", "0", 0},
+		{"positive", "12345", 12345},
+		{"large", "18446744073709551615", 18446744073709551615},
+		{"leading_space", "  42  ", 42},
+		{"tab_space", "\t 100 \t", 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseUint(tt.in)
+			if got != tt.want {
+				t.Errorf("parseUint(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseInt64(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int64
+	}{
+		{"dash", "-", 0},
+		{"empty", "", 0},
+		{"zero", "0", 0},
+		{"positive", "1710000000", 1710000000},
+		{"negative", "-100", -100},
+		{"leading_space", "  999  ", 999},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseInt64(tt.in)
+			if got != tt.want {
+				t.Errorf("parseInt64(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFloat(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want float64
+	}{
+		{"dash", "-", 0},
+		{"empty", "", 0},
+		{"zero", "0", 0},
+		{"integer", "42", 42},
+		{"decimal", "3.14", 3.14},
+		{"leading_space", "  1.5  ", 1.5},
+		{"large", "1000000.5", 1000000.5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFloat(tt.in)
+			if got != tt.want {
+				t.Errorf("parseFloat(%q) = %f, want %f", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitLines(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int // expected number of lines
+	}{
+		{"empty", "", 0},
+		{"single_line", "hello", 1},
+		{"trailing_newline", "hello\n", 1},
+		{"multiple_trailing_newlines", "hello\n\n\n", 1},
+		{"blank_lines_between", "hello\n\n\nworld\n", 2},
+		{"whitespace_only_lines", "hello\n   \n\t\nworld", 2},
+		{"three_lines", "a\nb\nc", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitLines(tt.in)
+			if len(got) != tt.want {
+				t.Errorf("splitLines(%q) returned %d lines, want %d; got %v", tt.in, len(got), tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSplitLinesContent(t *testing.T) {
+	got := splitLines("alpha\nbeta\ngamma\n")
+	if len(got) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(got))
+	}
+	if got[0] != "alpha" || got[1] != "beta" || got[2] != "gamma" {
+		t.Errorf("unexpected content: %v", got)
+	}
+}
+
+func TestParsePoolStatuses_Empty(t *testing.T) {
+	pools := parsePoolStatuses("")
+	if len(pools) != 0 {
+		t.Errorf("expected 0 pools for empty input, got %d", len(pools))
+	}
+}
+
+func TestParsePoolStatuses_SingleHealthyPool(t *testing.T) {
+	input := `  pool: tank
+ state: ONLINE
+  scan: scrub repaired 0B in 00:01:23 with 0 errors on Sun Mar 15 00:24:00 2026
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+	  mirror-0  ONLINE       0     0     0
+	    sda     ONLINE       0     0     0
+	    sdb     ONLINE       0     0     0
+
+errors: No known data errors
+`
+	pools := parsePoolStatuses(input)
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool, got %d", len(pools))
+	}
+
+	p := pools[0]
+	t.Run("name", func(t *testing.T) {
+		if p.Name != "tank" {
+			t.Errorf("Name = %q, want %q", p.Name, "tank")
+		}
+	})
+	t.Run("state", func(t *testing.T) {
+		if p.State != "ONLINE" {
+			t.Errorf("State = %q, want %q", p.State, "ONLINE")
+		}
+	})
+	t.Run("scan", func(t *testing.T) {
+		want := "scrub repaired 0B in 00:01:23 with 0 errors on Sun Mar 15 00:24:00 2026"
+		if p.Scan != want {
+			t.Errorf("Scan = %q, want %q", p.Scan, want)
+		}
+	})
+	t.Run("errors", func(t *testing.T) {
+		if p.Errors != "No known data errors" {
+			t.Errorf("Errors = %q, want %q", p.Errors, "No known data errors")
+		}
+	})
+	t.Run("status_empty", func(t *testing.T) {
+		if p.Status != "" {
+			t.Errorf("Status = %q, want empty", p.Status)
+		}
+	})
+	t.Run("vdev_count", func(t *testing.T) {
+		if len(p.Vdevs) != 4 {
+			t.Fatalf("expected 4 vdevs, got %d: %+v", len(p.Vdevs), p.Vdevs)
+		}
+	})
+	t.Run("vdev_root", func(t *testing.T) {
+		v := p.Vdevs[0]
+		if v.Name != "tank" || v.State != "ONLINE" || v.Depth != 0 {
+			t.Errorf("root vdev = %+v", v)
+		}
+	})
+	t.Run("vdev_mirror", func(t *testing.T) {
+		v := p.Vdevs[1]
+		if v.Name != "mirror-0" || v.State != "ONLINE" || v.Depth != 1 {
+			t.Errorf("mirror vdev = %+v", v)
+		}
+	})
+	t.Run("vdev_disk", func(t *testing.T) {
+		v := p.Vdevs[2]
+		if v.Name != "sda" || v.State != "ONLINE" || v.Depth != 2 {
+			t.Errorf("disk vdev = %+v", v)
+		}
+	})
+}
+
+func TestParsePoolStatuses_DegradedWithErrors(t *testing.T) {
+	input := `  pool: rpool
+ state: DEGRADED
+status: One or more devices has been removed by the administrator.
+  scan: scrub repaired 0B in 00:05:00 with 0 errors on Sun Mar 15 00:24:00 2026
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	rpool       DEGRADED     0     0     0
+	  mirror-0  DEGRADED     0     0     0
+	    sda1    ONLINE       0     0     0
+	    sdb1    REMOVED      3     5     1
+
+errors: 12 data errors, use '-v' for a list
+`
+	pools := parsePoolStatuses(input)
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool, got %d", len(pools))
+	}
+
+	p := pools[0]
+	t.Run("state", func(t *testing.T) {
+		if p.State != "DEGRADED" {
+			t.Errorf("State = %q, want %q", p.State, "DEGRADED")
+		}
+	})
+	t.Run("status", func(t *testing.T) {
+		want := "One or more devices has been removed by the administrator."
+		if p.Status != want {
+			t.Errorf("Status = %q, want %q", p.Status, want)
+		}
+	})
+	t.Run("errors", func(t *testing.T) {
+		want := "12 data errors, use '-v' for a list"
+		if p.Errors != want {
+			t.Errorf("Errors = %q, want %q", p.Errors, want)
+		}
+	})
+	t.Run("removed_disk_errors", func(t *testing.T) {
+		if len(p.Vdevs) < 4 {
+			t.Fatalf("expected 4 vdevs, got %d", len(p.Vdevs))
+		}
+		v := p.Vdevs[3] // sdb1
+		if v.Name != "sdb1" {
+			t.Errorf("Name = %q, want sdb1", v.Name)
+		}
+		if v.State != "REMOVED" {
+			t.Errorf("State = %q, want REMOVED", v.State)
+		}
+		if v.Read != 3 {
+			t.Errorf("Read = %d, want 3", v.Read)
+		}
+		if v.Write != 5 {
+			t.Errorf("Write = %d, want 5", v.Write)
+		}
+		if v.Cksum != 1 {
+			t.Errorf("Cksum = %d, want 1", v.Cksum)
+		}
+	})
+}
+
+func TestParsePoolStatuses_MultiplePools(t *testing.T) {
+	input := `  pool: tank
+ state: ONLINE
+  scan: none requested
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+	  sda       ONLINE       0     0     0
+
+errors: No known data errors
+
+  pool: backup
+ state: ONLINE
+  scan: scrub in progress since Mon Mar 16 01:00:00 2026
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	backup      ONLINE       0     0     0
+	  sdc       ONLINE       0     0     0
+
+errors: No known data errors
+`
+	pools := parsePoolStatuses(input)
+	if len(pools) != 2 {
+		t.Fatalf("expected 2 pools, got %d", len(pools))
+	}
+
+	t.Run("first_pool_name", func(t *testing.T) {
+		if pools[0].Name != "tank" {
+			t.Errorf("first pool Name = %q, want %q", pools[0].Name, "tank")
+		}
+	})
+	t.Run("second_pool_name", func(t *testing.T) {
+		if pools[1].Name != "backup" {
+			t.Errorf("second pool Name = %q, want %q", pools[1].Name, "backup")
+		}
+	})
+	t.Run("first_pool_vdevs", func(t *testing.T) {
+		if len(pools[0].Vdevs) != 2 {
+			t.Errorf("first pool has %d vdevs, want 2", len(pools[0].Vdevs))
+		}
+	})
+	t.Run("second_pool_vdevs", func(t *testing.T) {
+		if len(pools[1].Vdevs) != 2 {
+			t.Errorf("second pool has %d vdevs, want 2", len(pools[1].Vdevs))
+		}
+	})
+	t.Run("first_pool_scan", func(t *testing.T) {
+		if pools[0].Scan != "none requested" {
+			t.Errorf("first pool Scan = %q, want %q", pools[0].Scan, "none requested")
+		}
+	})
+}
+
+func TestParsePoolStatuses_ScrubInProgress_MultiLineScan(t *testing.T) {
+	input := `  pool: tank
+ state: ONLINE
+  scan: scrub in progress since Mon Mar 16 01:00:00 2026
+	1.23T scanned at 456M/s, 789G issued at 123M/s, 2.00T total
+	0B repaired, 38.67% done, 03:45:12 to go
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE       0     0     0
+	  raidz1-0  ONLINE       0     0     0
+	    sda     ONLINE       0     0     0
+	    sdb     ONLINE       0     0     0
+	    sdc     ONLINE       0     0     0
+
+errors: No known data errors
+`
+	pools := parsePoolStatuses(input)
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool, got %d", len(pools))
+	}
+
+	p := pools[0]
+	t.Run("scan_multiline", func(t *testing.T) {
+		wantPrefix := "scrub in progress since Mon Mar 16 01:00:00 2026"
+		if len(p.Scan) < len(wantPrefix) || p.Scan[:len(wantPrefix)] != wantPrefix {
+			t.Errorf("Scan does not start with expected prefix.\nGot:  %q", p.Scan)
+		}
+		// The continuation lines should be joined with newlines.
+		if !contains(p.Scan, "38.67% done") {
+			t.Errorf("Scan missing continuation data.\nGot: %q", p.Scan)
+		}
+		if !contains(p.Scan, "1.23T scanned") {
+			t.Errorf("Scan missing first continuation line.\nGot: %q", p.Scan)
+		}
+	})
+	t.Run("vdev_count", func(t *testing.T) {
+		if len(p.Vdevs) != 5 {
+			t.Fatalf("expected 5 vdevs, got %d: %+v", len(p.Vdevs), p.Vdevs)
+		}
+	})
+	t.Run("raidz_depth", func(t *testing.T) {
+		v := p.Vdevs[1]
+		if v.Name != "raidz1-0" || v.Depth != 1 {
+			t.Errorf("raidz vdev = %+v, want Name=raidz1-0 Depth=1", v)
+		}
+	})
+	t.Run("disk_depth", func(t *testing.T) {
+		v := p.Vdevs[2]
+		if v.Name != "sda" || v.Depth != 2 {
+			t.Errorf("disk vdev = %+v, want Name=sda Depth=2", v)
+		}
+	})
+}
+
+func TestParsePoolStatuses_NoVdevs(t *testing.T) {
+	// Minimal pool output without a config section (unusual but should not crash).
+	input := `  pool: orphan
+ state: FAULTED
+  scan: none requested
+errors: pool I/O is currently suspended
+`
+	pools := parsePoolStatuses(input)
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool, got %d", len(pools))
+	}
+	if pools[0].Name != "orphan" {
+		t.Errorf("Name = %q, want orphan", pools[0].Name)
+	}
+	if pools[0].State != "FAULTED" {
+		t.Errorf("State = %q, want FAULTED", pools[0].State)
+	}
+	if len(pools[0].Vdevs) != 0 {
+		t.Errorf("expected 0 vdevs, got %d", len(pools[0].Vdevs))
+	}
+}
+
+func TestParsePoolStatuses_VdevErrorCounts(t *testing.T) {
+	input := `  pool: tank
+ state: ONLINE
+  scan: none requested
+config:
+
+	NAME        STATE     READ WRITE CKSUM
+	tank        ONLINE     100   200   300
+
+errors: No known data errors
+`
+	pools := parsePoolStatuses(input)
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool, got %d", len(pools))
+	}
+	if len(pools[0].Vdevs) != 1 {
+		t.Fatalf("expected 1 vdev, got %d", len(pools[0].Vdevs))
+	}
+	v := pools[0].Vdevs[0]
+	if v.Read != 100 {
+		t.Errorf("Read = %d, want 100", v.Read)
+	}
+	if v.Write != 200 {
+		t.Errorf("Write = %d, want 200", v.Write)
+	}
+	if v.Cksum != 300 {
+		t.Errorf("Cksum = %d, want 300", v.Cksum)
+	}
+}
+
+// contains is a test helper for substring matching.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add ~280 table-driven unit tests across 4 test files covering all pure/testable functions (validators, broker pub/sub, ZFS status parser, ACL parsers)
- Add GitHub Actions CI workflow running `go build`, `go vet`, and `go test -race` on push and PR
- Update TODO.md with new improvement items (test coverage, CI, file splits, consistent pre-checks)

## Test plan
- [x] `go test -race ./...` passes locally
- [x] `go build ./...` and `go vet ./...` pass
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)