### PR TITLE
docs: add iSCSI target management to all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,15 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
       │  iostat, status, props,           datasets, snapshots,        │
       │  sysinfo, SMART, metrics,         users, groups, ACLs,        │
       │  users, groups, ACLs,             SMB users/shares/config,    │
-      │  SMB users/shares, chown          dataset chown               │
+      │  SMB users/shares, chown,         dataset chown, scrub,       │
+      │  iSCSI targets                    iSCSI targets               │
       │                                                               │
       ▼                                                               ▼
 ┌───────────────────────┐                        ┌────────────────────────────┐
 │  internal/zfs/zfs.go  │                        │ internal/ansible/runner.go │
 │  internal/system/     │                        │                            │
 │  internal/smart/      │                        │  Run(playbook, extraVars)  │
+│  internal/iscsi/      │                        │                            │
 │                       │                        │                            │
 │  ListPools()          │                        │  exec: ansible-playbook    │
 │  ListDatasets()       │                        │    -i inventory/localhost  │
@@ -131,6 +133,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 │  system.ListGroups()  │                        │                            │
 │  system.ListSamba*()  │                        │                            │
 │  smart.Collect()      │                        │                            │
+│  iscsi.ListTargets()  │                        │                            │
 │                       │                        │                            │
 │  exec: zpool / zfs /  │                        │                            │
 │  smartctl / sysctl /  │                        │                            │
@@ -256,6 +259,7 @@ dumpstore has no built-in authentication and runs as root. It is designed for tr
 | NFS sharing (optional) | `nfs-kernel-server` (Debian) or `nfs-utils` (RHEL/Fedora) | built-in base system                         |
 | SMB sharing (optional) | `samba` (`smbd`, `net`, `pdbedit`); for ZFS ACL passthrough via `sharesmb` also install `samba-vfs-modules` (Debian/Ubuntu) or `samba-vfs` (RHEL/Fedora) | `samba` pkg |
 | NFSv4 ACLs (optional)  | `nfs4-acl-tools` pkg (`nfs4_getfacl`/`nfs4_setfacl`)      | `nfs4-acl-tools` port                        |
+| iSCSI (optional)       | `targetcli-fb` (`targetcli`)                               | built-in `ctld`                              |
 | Build                  | Go 1.22+                                                  | Go 1.22+                                     |
 
 Go and Ansible are the only hard requirements. ZFS must be available on the target machine; the binary itself builds and runs on any platform.
@@ -284,6 +288,16 @@ dnf install acl nfs4-acl-tools
 apt install samba
 # Then run the SMB setup from the dumpstore UI (Settings → Configure Samba)
 # or manually: ansible-playbook playbooks/smb_setup.yml
+
+# Debian/Ubuntu — iSCSI targets
+apt install targetcli-fb
+
+# RHEL/Fedora — iSCSI targets
+dnf install targetcli
+
+# FreeBSD — iSCSI targets (ctld is built-in, just enable the service)
+sysrc ctld_enable=YES
+service ctld start
 ```
 
 ## Contributing
@@ -395,6 +409,7 @@ sudo make uninstall
 │   ├── broker/broker.go             # Thread-safe pub/sub broker (Subscribe/Publish/Unsubscribe)
 │   ├── broker/poller.go             # Background poller (ZFS + users/groups) → publishes changes to broker
 │   ├── system/system.go             # Host + process info, ListUsers, ListGroups (/proc, /etc/passwd, /etc/group)
+│   ├── iscsi/iscsi.go              # iSCSI target listing (targetcli on Linux, ctld on FreeBSD)
 │   └── smart/smart.go              # S.M.A.R.T. data via smartctl
 ├── playbooks/
 │   ├── inventory/localhost          # Local connection inventory
@@ -417,7 +432,11 @@ sudo make uninstall
 │   ├── smb_usershare_set.yml        # Create/update a Samba usershare for a dataset
 │   ├── smb_usershare_unset.yml      # Remove a Samba usershare
 │   ├── smb_user_add.yml             # Add a local user to smbpasswd
-│   └── smb_user_remove.yml          # Remove a user from smbpasswd
+│   ├── smb_user_remove.yml          # Remove a user from smbpasswd
+│   ├── iscsi_target_create.yml      # Create iSCSI target (Linux/targetcli)
+│   ├── iscsi_target_delete.yml      # Remove iSCSI target (Linux/targetcli)
+│   ├── iscsi_target_create_freebsd.yml  # Create iSCSI target (FreeBSD/ctld)
+│   └── iscsi_target_delete_freebsd.yml  # Remove iSCSI target (FreeBSD/ctld)
 ├── images/                          # Logo source files (SVG, all variants)
 ├── static/
 │   ├── index.html                   # Single-page application shell + dialogs
@@ -472,6 +491,9 @@ sudo make uninstall
 | POST   | `/api/smb-users/{name}`     | Add a user to smbpasswd               |
 | DELETE | `/api/smb-users/{name}`     | Remove a user from smbpasswd          |
 | POST   | `/api/smb-config/pam`       | Run Samba setup playbook              |
+| GET    | `/api/iscsi-targets`        | List all iSCSI targets                |
+| POST   | `/api/iscsi-targets`        | Create an iSCSI target for a zvol     |
+| DELETE | `/api/iscsi-targets`        | Remove an iSCSI target                |
 
 ### POST /api/datasets
 
@@ -575,6 +597,53 @@ Remove an ACL entry. The `entry` query parameter is:
 - **NFSv4**: full ACE string to match and remove
 
 Append `&recursive=true` (POSIX only) to remove recursively.
+
+### GET /api/iscsi-targets
+
+List all iSCSI targets backed by ZFS volumes. Uses `targetcli` saveconfig on Linux or `/etc/ctl.conf` on FreeBSD. Returns an empty array if no backend is installed.
+
+```json
+[
+  {
+    "iqn": "iqn.2024-03.io.dumpstore:tank-vms-win11",
+    "zvol_name": "tank/vms/win11",
+    "zvol_device": "/dev/zvol/tank/vms/win11",
+    "lun": 0,
+    "portals": ["0.0.0.0:3260"],
+    "auth_mode": "none",
+    "initiators": []
+  }
+]
+```
+
+### POST /api/iscsi-targets
+
+Create an iSCSI target for a ZFS volume. Auto-selects the appropriate playbook based on platform (`targetcli` on Linux, `ctld` on FreeBSD). Returns 501 if no backend is detected.
+
+```json
+{
+  "zvol": "tank/vms/win11",
+  "iqn": "iqn.2024-03.io.dumpstore:tank-vms-win11",
+  "portal_ip": "0.0.0.0",
+  "portal_port": "3260",
+  "auth_mode": "none",
+  "chap_user": "",
+  "chap_password": "",
+  "initiators": []
+}
+```
+
+- `zvol` (required): ZFS volume name, must contain `/`
+- `iqn` (required): RFC 3720 iSCSI Qualified Name (`iqn.YYYY-MM.domain:name`)
+- `portal_ip`: listen IP, defaults to `0.0.0.0`
+- `portal_port`: listen port, defaults to `3260`
+- `auth_mode`: `"none"` or `"chap"`
+- `chap_user` / `chap_password`: required when `auth_mode` is `"chap"`
+- `initiators`: array of allowed initiator IQNs; empty array = allow all
+
+### DELETE /api/iscsi-targets?iqn=\<iqn\>&zvol=\<zvol\>
+
+Remove an iSCSI target and its backstore. Both query parameters are required.
 
 ### GET /api/events
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -756,6 +756,11 @@ sudo ./dumpstore -addr :8080 -dir .</pre>
             <td class="muted">samba</td>
             <td class="muted">samba pkg</td>
           </tr>
+          <tr>
+            <td>iSCSI targets<span class="opt-badge">optional</span></td>
+            <td class="muted">targetcli-fb</td>
+            <td class="muted">built-in ctld</td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -50,6 +50,9 @@ All endpoints are served at `http://<host>:8080`. The API is JSON-over-HTTP; all
 | DELETE | `/api/scrub-schedule/{pool}`| Remove pool from periodic scrub schedule |
 | GET    | `/api/auto-snapshot/{dataset}` | Get auto-snapshot property values for a dataset |
 | PUT    | `/api/auto-snapshot/{dataset}` | Set auto-snapshot properties for a dataset |
+| GET    | `/api/iscsi-targets`           | List all iSCSI targets |
+| POST   | `/api/iscsi-targets`           | Create an iSCSI target for a zvol |
+| DELETE | `/api/iscsi-targets`           | Remove an iSCSI target |
 
 ---
 
@@ -232,6 +235,66 @@ Empty string (`""`) triggers `zfs inherit` on the property (clears the local val
   "com.sun:auto-snapshot:monthly": "3"
 }
 ```
+
+---
+
+## iSCSI targets
+
+Expose ZFS volumes as iSCSI targets. Uses `targetcli`/LIO on Linux or `ctld` on FreeBSD. Endpoints return 501 if no backend is detected.
+
+### GET /api/iscsi-targets
+
+List all iSCSI targets backed by ZFS volumes.
+
+```json
+[
+  {
+    "iqn": "iqn.2024-03.io.dumpstore:tank-vms-win11",
+    "zvol_name": "tank/vms/win11",
+    "zvol_device": "/dev/zvol/tank/vms/win11",
+    "lun": 0,
+    "portals": ["0.0.0.0:3260"],
+    "auth_mode": "none",
+    "initiators": []
+  }
+]
+```
+
+### POST /api/iscsi-targets
+
+Create an iSCSI target for a ZFS volume.
+
+```json
+{
+  "zvol": "tank/vms/win11",
+  "iqn": "iqn.2024-03.io.dumpstore:tank-vms-win11",
+  "portal_ip": "0.0.0.0",
+  "portal_port": "3260",
+  "auth_mode": "none",
+  "chap_user": "",
+  "chap_password": "",
+  "initiators": []
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `zvol` | yes | ZFS volume name, must contain `/` |
+| `iqn` | yes | RFC 3720 iSCSI Qualified Name (`iqn.YYYY-MM.domain:name`) |
+| `portal_ip` | no | Listen IP, defaults to `0.0.0.0` |
+| `portal_port` | no | Listen port, defaults to `3260` |
+| `auth_mode` | yes | `"none"` or `"chap"` |
+| `chap_user` | when chap | CHAP username |
+| `chap_password` | when chap | CHAP password |
+| `initiators` | no | Array of allowed initiator IQNs; empty = allow all |
+
+Returns Ansible task steps.
+
+### DELETE /api/iscsi-targets?iqn=\<iqn\>&zvol=\<zvol\>
+
+Remove an iSCSI target and its backstore. Both query parameters are required.
+
+Returns Ansible task steps.
 
 ---
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -44,13 +44,15 @@
       │  iostat, status, props,           datasets, snapshots,        │
       │  sysinfo, SMART, metrics,         users, groups, ACLs,        │
       │  users, groups, ACLs,             SMB users/shares/config,    │
-      │  SMB users/shares, chown          dataset chown, scrub        │
+      │  SMB users/shares, chown,         dataset chown, scrub,       │
+      │  iSCSI targets                    iSCSI targets               │
       │                                                               │
       ▼                                                               ▼
 ┌───────────────────────┐                        ┌────────────────────────────┐
 │  internal/zfs/zfs.go  │                        │ internal/ansible/runner.go │
 │  internal/system/     │                        │                            │
 │  internal/smart/      │                        │  Run(playbook, extraVars)  │
+│  internal/iscsi/      │                        │                            │
 │                       │                        │                            │
 │  ListPools()          │                        │  exec: ansible-playbook    │
 │  ListDatasets()       │                        │    -i inventory/localhost  │
@@ -65,10 +67,12 @@
 │  system.ListUsers()   │                        │                            │
 │  system.ListGroups()  │                        │                            │
 │  smart.Collect()      │                        │                            │
+│  iscsi.ListTargets()  │                        │                            │
 │                       │                        │                            │
 │  exec: zpool / zfs /  │                        │                            │
 │  smartctl / sysctl /  │                        │                            │
-│  pdbedit / net        │                        │                            │
+│  pdbedit / net /      │                        │                            │
+│  targetcli / ctld     │                        │                            │
 │  (no Python startup)  │                        │                            │
 └──────────┬────────────┘                        └────────────┬───────────────┘
            │                                                  │

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -20,6 +20,7 @@ No container runtime, no database, no Node.js. Just a single compiled binary, so
 - **Group management** — list, create, edit, and delete local groups; system groups hidden by default
 - **NFS share management** — enable, configure, and disable NFS sharing per dataset via the ZFS `sharenfs` property; cross-platform
 - **SMB share management** — create and remove Samba usershares; manage Samba users; one-click Samba setup
+- **iSCSI target management** — expose ZFS volumes as iSCSI targets via `targetcli`/LIO on Linux or `ctld` on FreeBSD; per-zvol dialog with IQN, portal IP/port, auth mode (None/CHAP), and initiator ACL list
 - **ACL management** — POSIX ACL and NFSv4 ACL entries per dataset; recursive apply supported
 - **Live updates** — Server-Sent Events push changes every 10 s; falls back to 30 s REST polling
 - **Prometheus metrics** — Go runtime, HTTP request counters/latency, Ansible playbook metrics at `GET /metrics`

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -12,6 +12,7 @@
 | NFS sharing (optional) | `nfs-kernel-server` (Debian) or `nfs-utils` (RHEL/Fedora) | built-in base system                         |
 | SMB sharing (optional) | `samba` (`smbd`, `net`, `pdbedit`)                        | `samba` pkg                                  |
 | NFSv4 ACLs (optional)  | `nfs4-acl-tools` pkg                                      | `nfs4-acl-tools` port                        |
+| iSCSI (optional)       | `targetcli-fb` (`targetcli`)                               | built-in `ctld`                              |
 | Build                  | Go 1.22+                                                  | Go 1.22+                                     |
 
 Go and Ansible are the only hard requirements. ZFS must be available on the target machine.
@@ -40,6 +41,16 @@ systemctl enable --now nfs-server
 
 # RHEL/Fedora — ACLs
 dnf install acl nfs4-acl-tools
+
+# Debian/Ubuntu — iSCSI targets
+apt install targetcli-fb
+
+# RHEL/Fedora — iSCSI targets
+dnf install targetcli
+
+# FreeBSD — iSCSI targets (ctld is built-in, just enable the service)
+sysrc ctld_enable=YES
+service ctld start
 ```
 
 After installing Samba, run **Configure Samba** from the dumpstore UI (Users & Groups → Configure Samba) or manually:


### PR DESCRIPTION
## Summary

- Add iSCSI API endpoints (GET/POST/DELETE `/api/iscsi-targets`) to README API table, route map, and full request/response docs
- Add `internal/iscsi/` and 4 iSCSI playbooks to project layout
- Add `targetcli-fb` (Linux) / `ctld` (FreeBSD) to requirements tables and install instructions
- Update architecture diagrams (read/write columns) in README and wiki
- Add iSCSI section to wiki API-Reference, feature list to wiki Home, requirements to wiki Installation
- Add iSCSI row to docs/index.html requirements table

## Test plan

- [x] Verify all doc files updated (README.md, docs/index.html, wiki/*)
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)