### PR TITLE
docs: add planned features to all documentation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -41,6 +41,9 @@
 | Pool create/import/export| High     | Import available pools from attached devices; export pools safely                |
 | Snapshot diff            | Medium   | Show files changed between two snapshots (`zfs diff`)                            |
 | Per-user quota tracking  | Medium   | Space usage per user/group (`zfs userspace` / `zfs groupspace`)                  |
+| User mgmt extensions     | Medium   | SSH key management (`authorized_keys`), move home directory                      |
+| Samba home shares        | Medium   | Enable/configure `[homes]` section in `smb.conf` for per-user home dir shares   |
+| Time Machine shares      | Medium   | Samba `vfs_fruit` share config for macOS Time Machine backups over SMB           |
 | ZFS send/receive         | Low      | Pool replication and off-site backup                                             |
 | Alerts                   | Low      | Configurable thresholds for pool health, disk temp, capacity                     |
 

--- a/README.md
+++ b/README.md
@@ -694,6 +694,9 @@ The browser UI uses `EventSource` to subscribe to all eight topics and falls bac
 | Pool import/export       | Import available pools from attached devices; export pools safely                             |
 | Snapshot diff            | Show files changed between two snapshots (`zfs diff`)                                         |
 | Per-user quota tracking  | Show space usage per user/group (`zfs userspace` / `zfs groupspace`)                          |
+| User mgmt extensions     | SSH key management (`authorized_keys`), move home directory                                   |
+| Samba home shares        | Enable/configure `[homes]` section in `smb.conf` for per-user home directory shares           |
+| Time Machine shares      | Samba `vfs_fruit` share configuration for macOS Time Machine backups over SMB                  |
 | ZFS send/receive         | Pool replication and off-site backup                                                          |
 | Alerts                   | Configurable thresholds for pool health, disk temp, capacity                                  |
 | ~~Pool scrub management~~| ~~Trigger scrubs, view last scrub time/status/progress, schedule periodic scrubs~~ — **done** (start/cancel + periodic schedule; Linux `zfsutils-linux`, FreeBSD `periodic.conf`) |

--- a/docs/index.html
+++ b/docs/index.html
@@ -572,6 +572,48 @@
         <p>Go runtime, HTTP request counters &amp; latency histograms, and Ansible playbook run metrics out of the box.</p>
       </div>
     </div>
+
+    <div class="section-header" style="margin-top:2rem;">
+      <h2>planned</h2>
+      <div class="divider"></div>
+    </div>
+    <div class="card-grid">
+      <div class="pool-card">
+        <div class="pool-card-header">
+          <span class="pool-name">user mgmt extensions</span>
+          <span class="health-badge badge-blue">planned</span>
+        </div>
+        <p>SSH key management (<code>authorized_keys</code>) and home directory relocation per user.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
+          <span class="pool-name">Samba home shares</span>
+          <span class="health-badge badge-blue">planned</span>
+        </div>
+        <p>Enable and configure the <code>[homes]</code> section in <code>smb.conf</code> for automatic per-user home directory shares.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
+          <span class="pool-name">Time Machine shares</span>
+          <span class="health-badge badge-blue">planned</span>
+        </div>
+        <p>Samba <code>vfs_fruit</code> share configuration for macOS Time Machine backups over SMB.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
+          <span class="pool-name">ZFS native encryption</span>
+          <span class="health-badge badge-blue">planned</span>
+        </div>
+        <p>Load/unload keys, show encryption status per dataset, support keyformat and keylocation.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
+          <span class="pool-name">ZFS send/receive</span>
+          <span class="health-badge badge-blue">planned</span>
+        </div>
+        <p>Pool replication and off-site backup via ZFS send/receive streams.</p>
+      </div>
+    </div>
   </section>
 
   <!-- WHY -->

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -25,6 +25,15 @@ No container runtime, no database, no Node.js. Just a single compiled binary, so
 - **Live updates** — Server-Sent Events push changes every 10 s; falls back to 30 s REST polling
 - **Prometheus metrics** — Go runtime, HTTP request counters/latency, Ansible playbook metrics at `GET /metrics`
 
+## Planned
+
+- **User mgmt extensions** — SSH key management (`authorized_keys`), move home directory
+- **Samba home shares** — enable/configure `[homes]` section in `smb.conf` for per-user home directory shares
+- **Time Machine shares** — Samba `vfs_fruit` share configuration for macOS Time Machine backups over SMB
+- **ZFS native encryption** — load/unload keys, encryption status per dataset, keyformat/keylocation support
+- **Pool import/export** — import available pools from attached devices; export pools safely
+- **ZFS send/receive** — pool replication and off-site backup
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary
- Add three new planned features to FEATURES.md, README.md, wiki/Home.md, and docs/index.html
- **User mgmt extensions** — SSH key management (`authorized_keys`), move home directory
- **Samba home shares** — `[homes]` section in `smb.conf` for per-user home dir shares
- **Time Machine shares** — Samba `vfs_fruit` for macOS Time Machine backups over SMB

## Related issues
- #32 — User management extensions
- #33 — Samba home shares
- #34 — Time Machine shares

## Test plan
- [x] Verify FEATURES.md table formatting
- [x] Verify README.md planned section updated
- [x] Verify wiki/Home.md has new planned section
- [x] Verify docs/index.html planned cards render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)