### PR TITLE
feat: Samba home shares ([homes] section)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -28,6 +28,7 @@
 | Pool scrub scheduling    | v0.1.2 | Per-pool schedule via Linux `zfsutils-linux` (2nd Sunday monthly) or FreeBSD `periodic.conf` (configurable threshold)          |
 | Auto-snapshot scheduling | v0.1.3 | Manage `com.sun:auto-snapshot*` ZFS properties per dataset; integrates with `zfs-auto-snapshot` (Linux) / `zfstools` (FreeBSD) |
 | iSCSI target management  | v0.1.4 | Expose zvols as iSCSI targets (`targetcli`/LIO on Linux, `ctld` on FreeBSD); dialog with IQN, portal, CHAP auth, initiator ACLs |
+| SMB home shares          | v0.1.5 | Enable/configure `[homes]` section in `smb.conf`; dataset picker or custom path; per-user auto-shares                           |
 
 ---
 
@@ -42,7 +43,7 @@
 | Snapshot diff            | Medium   | Show files changed between two snapshots (`zfs diff`)                            |
 | Per-user quota tracking  | Medium   | Space usage per user/group (`zfs userspace` / `zfs groupspace`)                  |
 | User mgmt extensions     | Medium   | SSH key management (`authorized_keys`), move home directory                      |
-| Samba home shares        | Medium   | Enable/configure `[homes]` section in `smb.conf` for per-user home dir shares   |
+| ~~Samba home shares~~    | ~~Medium~~ | ~~Implemented in v0.1.5~~                                                     |
 | Time Machine shares      | Medium   | Samba `vfs_fruit` share config for macOS Time Machine backups over SMB           |
 | ZFS send/receive         | Low      | Pool replication and off-site backup                                             |
 | Alerts                   | Low      | Configurable thresholds for pool health, disk temp, capacity                     |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 - **Group management** — list, create, edit (name, GID, members), and delete local groups; system groups hidden by default with the same toggle
 - **NFS share management** — enable, configure, and disable NFS sharing per dataset via the ZFS `sharenfs` property; cross-platform (Linux and FreeBSD)
 - **SMB share management** — create and remove Samba usershares per dataset via `net usershare`; manage Samba users (add/remove from `smbpasswd`); one-click Samba setup (`smb_setup.yml` configures usershares, disables `[homes]`, enables PAM passthrough on Linux); cross-platform (Linux and FreeBSD)
+- **SMB home shares** — enable and configure the Samba `[homes]` section in `smb.conf` so each authenticated user automatically gets a personal share mapped to a subdirectory; configurable base path (pick a ZFS dataset or specify a custom path), browseable, read only, create mask, and directory mask
 - **iSCSI target management** — expose ZFS volumes as iSCSI targets via `targetcli`/LIO on Linux or `ctld` on FreeBSD; per-zvol dialog with IQN (auto-generated, editable), portal IP/port, auth mode (None/CHAP), and initiator ACL list
 - **ACL management** — view, add, and remove POSIX ACL entries (`getfacl`/`setfacl`, requires `acl` package) and NFSv4 ACL entries (`nfs4_getfacl`/`nfs4_setfacl`, requires `nfs4-acl-tools`) per dataset; setting an ACL entry automatically sets the correct `acltype` ZFS property; one-click enable for datasets with `acltype=off`; recursive apply supported for POSIX
 - **Live updates** — Server-Sent Events push pool, dataset, snapshot, I/O, user and group changes; server polls every 10 s and pushes only on change; falls back to 30 s REST polling if SSE is unavailable
@@ -109,8 +110,9 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
       │  iostat, status, props,           datasets, snapshots,        │
       │  sysinfo, SMART, metrics,         users, groups, ACLs,        │
       │  users, groups, ACLs,             SMB users/shares/config,    │
-      │  SMB users/shares, chown,         dataset chown, scrub,       │
-      │  iSCSI targets                    iSCSI targets               │
+      │  SMB users/shares/homes,          dataset chown, scrub,       │
+      │  iSCSI targets                    iSCSI targets,              │
+      │                                   SMB homes config            │
       │                                                               │
       ▼                                                               ▼
 ┌───────────────────────┐                        ┌────────────────────────────┐
@@ -132,6 +134,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 │  system.ListUsers()   │                        │                            │
 │  system.ListGroups()  │                        │                            │
 │  system.ListSamba*()  │                        │                            │
+│  system.ParseSMBHomes()│                       │                            │
 │  smart.Collect()      │                        │                            │
 │  iscsi.ListTargets()  │                        │                            │
 │                       │                        │                            │
@@ -234,6 +237,10 @@ DELETE /api/smb-share/{ds}    → smb_usershare_unset.yml   (ansible)
 POST   /api/smb-users/{name}  → smb_user_add.yml          (ansible)
 DELETE /api/smb-users/{name}  → smb_user_remove.yml       (ansible)
 POST   /api/smb-config/pam    → smb_setup.yml             (ansible)
+
+GET    /api/smb/homes          → parse smb.conf [homes]   (direct)
+POST   /api/smb/homes          → smb_homes_set.yml        (ansible)
+DELETE /api/smb/homes          → smb_homes_unset.yml      (ansible)
 
 GET    /api/auto-snapshot/{ds} → zfs get com.sun:auto-snapshot* (direct)
 PUT    /api/auto-snapshot/{ds} → zfs_autosnap_set.yml           (ansible)
@@ -433,6 +440,8 @@ sudo make uninstall
 │   ├── smb_usershare_unset.yml      # Remove a Samba usershare
 │   ├── smb_user_add.yml             # Add a local user to smbpasswd
 │   ├── smb_user_remove.yml          # Remove a user from smbpasswd
+│   ├── smb_homes_set.yml            # Enable/update [homes] section in smb.conf
+│   ├── smb_homes_unset.yml          # Remove [homes] section from smb.conf
 │   ├── iscsi_target_create.yml      # Create iSCSI target (Linux/targetcli)
 │   ├── iscsi_target_delete.yml      # Remove iSCSI target (Linux/targetcli)
 │   ├── iscsi_target_create_freebsd.yml  # Create iSCSI target (FreeBSD/ctld)
@@ -491,6 +500,9 @@ sudo make uninstall
 | POST   | `/api/smb-users/{name}`     | Add a user to smbpasswd               |
 | DELETE | `/api/smb-users/{name}`     | Remove a user from smbpasswd          |
 | POST   | `/api/smb-config/pam`       | Run Samba setup playbook              |
+| GET    | `/api/smb/homes`            | Get current SMB [homes] config        |
+| POST   | `/api/smb/homes`            | Enable/update SMB [homes] section     |
+| DELETE | `/api/smb/homes`            | Disable/remove SMB [homes] section    |
 | GET    | `/api/iscsi-targets`        | List all iSCSI targets                |
 | POST   | `/api/iscsi-targets`        | Create an iSCSI target for a zvol     |
 | DELETE | `/api/iscsi-targets`        | Remove an iSCSI target                |
@@ -695,7 +707,7 @@ The browser UI uses `EventSource` to subscribe to all eight topics and falls bac
 | Snapshot diff            | Show files changed between two snapshots (`zfs diff`)                                         |
 | Per-user quota tracking  | Show space usage per user/group (`zfs userspace` / `zfs groupspace`)                          |
 | User mgmt extensions     | SSH key management (`authorized_keys`), move home directory                                   |
-| Samba home shares        | Enable/configure `[homes]` section in `smb.conf` for per-user home directory shares           |
+| ~~Samba home shares~~    | ~~Enable/configure `[homes]` section in `smb.conf` for per-user home directory shares~~ — **done** (enable/disable `[homes]` section; configurable base path, browseable, read only, create/directory masks) |
 | Time Machine shares      | Samba `vfs_fruit` share configuration for macOS Time Machine backups over SMB                  |
 | ZFS send/receive         | Pool replication and off-site backup                                                          |
 | Alerts                   | Configurable thresholds for pool health, disk temp, capacity                                  |

--- a/docs/index.html
+++ b/docs/index.html
@@ -531,6 +531,13 @@
       </div>
       <div class="pool-card">
         <div class="pool-card-header">
+          <span class="pool-name">SMB home shares</span>
+          <span class="health-badge badge-blue">[homes]</span>
+        </div>
+        <p>Enable the Samba <code>[homes]</code> section so each authenticated user gets a personal share mapped to a subdirectory. Pick a ZFS dataset as base path or specify a custom one. Configurable browseable, read only, create mask, and directory mask.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
           <span class="pool-name">auto-snapshot scheduling</span>
           <span class="health-badge badge-green">com.sun:auto-snapshot</span>
         </div>
@@ -584,13 +591,6 @@
           <span class="health-badge badge-blue">planned</span>
         </div>
         <p>SSH key management (<code>authorized_keys</code>) and home directory relocation per user.</p>
-      </div>
-      <div class="pool-card">
-        <div class="pool-card-header">
-          <span class="pool-name">Samba home shares</span>
-          <span class="health-badge badge-blue">planned</span>
-        </div>
-        <p>Enable and configure the <code>[homes]</code> section in <code>smb.conf</code> for automatic per-user home directory shares.</p>
       </div>
       <div class="pool-card">
         <div class="pool-card-header">

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -48,6 +48,9 @@ var (
 
 	// reIQN matches a valid iSCSI Qualified Name (RFC 3720).
 	reIQN = regexp.MustCompile(`^iqn\.\d{4}-\d{2}\.[a-z0-9.-]+:[a-zA-Z0-9._:-]+$`)
+
+	// reOctalMask matches a 3- or 4-digit octal permission mask.
+	reOctalMask = regexp.MustCompile(`^[0-7]{3,4}$`)
 )
 
 // validZFSName returns true if s is a safe ZFS dataset/pool path (no snapshot suffix).
@@ -183,6 +186,9 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/smb-shares", h.getSMBShares)
 	mux.HandleFunc("POST /api/smb-share/{dataset...}", h.setSMBShare)
 	mux.HandleFunc("DELETE /api/smb-share/{dataset...}", h.deleteSMBShare)
+	mux.HandleFunc("GET /api/smb/homes", h.getSMBHomes)
+	mux.HandleFunc("POST /api/smb/homes", h.setSMBHomes)
+	mux.HandleFunc("DELETE /api/smb/homes", h.deleteSMBHomes)
 	mux.HandleFunc("POST /api/scrub/{pool}", h.startScrub)
 	mux.HandleFunc("DELETE /api/scrub/{pool}", h.cancelScrub)
 	mux.HandleFunc("GET /api/scrub-schedules", h.listScrubSchedules)
@@ -1019,6 +1025,124 @@ func (h *Handler) removeSambaUser(w http.ResponseWriter, r *http.Request) {
 // Applies usershare + PAM passthrough settings to /etc/samba/smb.conf and restarts smbd/nmbd.
 func (h *Handler) configureSambaPAM(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp("smb_setup.yml", map[string]string{})
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(w, map[string]any{"tasks": out.Steps()})
+}
+
+// getSMBHomes handles GET /api/smb/homes
+// Returns the current [homes] section config from smb.conf.
+func (h *Handler) getSMBHomes(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, system.ParseSMBHomes())
+}
+
+// setSMBHomes handles POST /api/smb/homes
+// Body: {"path":"/tank/homes/%U","browseable":"no","read_only":"no","create_mask":"0644","directory_mask":"0755"}
+// The "path" field is required. If "dataset" is provided instead, its mountpoint is resolved and /%U is appended.
+func (h *Handler) setSMBHomes(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Dataset       string `json:"dataset"`
+		Path          string `json:"path"`
+		Browseable    string `json:"browseable"`
+		ReadOnly      string `json:"read_only"`
+		CreateMask    string `json:"create_mask"`
+		DirectoryMask string `json:"directory_mask"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err), nil)
+		return
+	}
+
+	// Resolve dataset to path if provided
+	if req.Dataset != "" && req.Path == "" {
+		if !validZFSName(req.Dataset) {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("invalid dataset name"), nil)
+			return
+		}
+		datasets, err := zfs.ListDatasets()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("failed to list datasets: %w", err), nil)
+			return
+		}
+		var mp string
+		for _, ds := range datasets {
+			if ds.Name == req.Dataset {
+				mp = ds.Mountpoint
+				break
+			}
+		}
+		if mp == "" || mp == "-" || mp == "none" {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("dataset %q has no mountpoint", req.Dataset), nil)
+			return
+		}
+		req.Path = mp + "/%U"
+	}
+
+	if req.Path == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("path is required (or provide dataset)"), nil)
+		return
+	}
+
+	// Defaults
+	if req.Browseable == "" {
+		req.Browseable = "no"
+	}
+	if req.ReadOnly == "" {
+		req.ReadOnly = "no"
+	}
+	if req.CreateMask == "" {
+		req.CreateMask = "0644"
+	}
+	if req.DirectoryMask == "" {
+		req.DirectoryMask = "0755"
+	}
+
+	// Validate
+	if req.Browseable != "yes" && req.Browseable != "no" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("browseable must be yes or no"), nil)
+		return
+	}
+	if req.ReadOnly != "yes" && req.ReadOnly != "no" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("read_only must be yes or no"), nil)
+		return
+	}
+	if !reOctalMask.MatchString(req.CreateMask) {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("create_mask must be a 3- or 4-digit octal value"), nil)
+		return
+	}
+	if !reOctalMask.MatchString(req.DirectoryMask) {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("directory_mask must be a 3- or 4-digit octal value"), nil)
+		return
+	}
+
+	out, err := h.runOp("smb_homes_set.yml", map[string]string{
+		"path":           req.Path,
+		"browseable":     req.Browseable,
+		"read_only":      req.ReadOnly,
+		"create_mask":    req.CreateMask,
+		"directory_mask": req.DirectoryMask,
+	})
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(w, map[string]any{"config": system.ParseSMBHomes(), "tasks": out.Steps()})
+}
+
+// deleteSMBHomes handles DELETE /api/smb/homes
+// Removes the [homes] section from smb.conf.
+func (h *Handler) deleteSMBHomes(w http.ResponseWriter, r *http.Request) {
+	out, err := h.runOp("smb_homes_unset.yml", map[string]string{})
 	if err != nil {
 		var steps []ansible.TaskStep
 		if out != nil {

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -153,6 +153,74 @@ func ListSambaUsers() ([]string, error) {
 	return users, nil
 }
 
+// SMBHomesConfig describes the current state of the [homes] section in smb.conf.
+type SMBHomesConfig struct {
+	Enabled       bool   `json:"enabled"`
+	Path          string `json:"path"`
+	Browseable    string `json:"browseable"`
+	ReadOnly      string `json:"read_only"`
+	CreateMask    string `json:"create_mask"`
+	DirectoryMask string `json:"directory_mask"`
+}
+
+// smbConfPath returns the platform-specific path to smb.conf.
+func smbConfPath() string {
+	if runtime.GOOS == "freebsd" {
+		return "/usr/local/etc/smb4.conf"
+	}
+	return "/etc/samba/smb.conf"
+}
+
+// ParseSMBHomes reads smb.conf and returns the current [homes] configuration.
+// Returns Enabled=false if smb.conf is missing or has no [homes] section.
+func ParseSMBHomes() SMBHomesConfig {
+	cfg := SMBHomesConfig{
+		Browseable:    "no",
+		ReadOnly:      "no",
+		CreateMask:    "0644",
+		DirectoryMask: "0755",
+	}
+	data, err := os.ReadFile(smbConfPath())
+	if err != nil {
+		return cfg
+	}
+	lines := strings.Split(string(data), "\n")
+	inHomes := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.EqualFold(trimmed, "[homes]") {
+			inHomes = true
+			cfg.Enabled = true
+			continue
+		}
+		if inHomes && strings.HasPrefix(trimmed, "[") {
+			break // next section
+		}
+		if !inHomes {
+			continue
+		}
+		parts := strings.SplitN(trimmed, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+		switch strings.ToLower(key) {
+		case "path":
+			cfg.Path = val
+		case "browseable", "browsable":
+			cfg.Browseable = val
+		case "read only":
+			cfg.ReadOnly = val
+		case "create mask", "create mode":
+			cfg.CreateMask = val
+		case "directory mask", "directory mode":
+			cfg.DirectoryMask = val
+		}
+	}
+	return cfg
+}
+
 // ListShells reads /etc/shells and returns all valid login shells.
 // Falls back to a minimal list if the file is not present.
 func ListShells() []string {

--- a/playbooks/smb_homes_set.yml
+++ b/playbooks/smb_homes_set.yml
@@ -1,0 +1,71 @@
+---
+# Enables or updates the [homes] section in smb.conf so that each authenticated
+# user automatically gets a personal share mapped to a subdirectory.
+#
+# Required extra vars:
+#   path           – base path with %U substitution, e.g. /tank/homes/%U
+#
+# Optional extra vars:
+#   browseable     – "yes" or "no"  (default "no")
+#   read_only      – "yes" or "no"  (default "no")
+#   create_mask    – 4-digit octal  (default "0644")
+#   directory_mask – 4-digit octal  (default "0755")
+
+- name: Enable Samba home shares
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Set OS-specific smb.conf path
+      ansible.builtin.set_fact:
+        smb_conf: >-
+          {{ '/usr/local/etc/smb4.conf'
+             if ansible_os_family == 'FreeBSD'
+             else '/etc/samba/smb.conf' }}
+
+    - name: Set defaults for optional variables
+      ansible.builtin.set_fact:
+        browseable: "{{ browseable | default('no') }}"
+        read_only: "{{ read_only | default('no') }}"
+        create_mask: "{{ create_mask | default('0644') }}"
+        directory_mask: "{{ directory_mask | default('0755') }}"
+
+    - name: Assert required variables
+      ansible.builtin.assert:
+        that:
+          - path is defined and path | length > 0
+          - browseable in ['yes', 'no']
+          - read_only in ['yes', 'no']
+          - create_mask is match('^[0-7]{4}$')
+          - directory_mask is match('^[0-7]{4}$')
+        fail_msg: "Invalid input — check path, browseable, read_only, create_mask, directory_mask"
+
+    - name: Check smb.conf exists
+      ansible.builtin.stat:
+        path: "{{ smb_conf }}"
+      register: smb_conf_stat
+
+    - name: Fail if smb.conf not found
+      ansible.builtin.fail:
+        msg: "{{ smb_conf }} not found — is Samba installed?"
+      when: not smb_conf_stat.stat.exists
+
+    - name: Insert or update [homes] section
+      ansible.builtin.blockinfile:
+        path: "{{ smb_conf }}"
+        marker: "# {mark} DUMPSTORE HOMES"
+        block: |
+          [homes]
+             comment = Home directory
+             path = {{ path }}
+             browseable = {{ browseable }}
+             read only = {{ read_only }}
+             create mask = {{ create_mask }}
+             directory mask = {{ directory_mask }}
+             valid users = %S
+      notify: Reload samba
+
+  handlers:
+    - name: Reload samba
+      ansible.builtin.command:
+        cmd: smbcontrol smbd reload-config
+      failed_when: false

--- a/playbooks/smb_homes_unset.yml
+++ b/playbooks/smb_homes_unset.yml
@@ -1,0 +1,37 @@
+---
+# Removes the [homes] section from smb.conf, disabling automatic home shares.
+# No extra vars required.
+
+- name: Disable Samba home shares
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Set OS-specific smb.conf path
+      ansible.builtin.set_fact:
+        smb_conf: >-
+          {{ '/usr/local/etc/smb4.conf'
+             if ansible_os_family == 'FreeBSD'
+             else '/etc/samba/smb.conf' }}
+
+    - name: Check smb.conf exists
+      ansible.builtin.stat:
+        path: "{{ smb_conf }}"
+      register: smb_conf_stat
+
+    - name: Fail if smb.conf not found
+      ansible.builtin.fail:
+        msg: "{{ smb_conf }} not found — is Samba installed?"
+      when: not smb_conf_stat.stat.exists
+
+    - name: Remove [homes] section
+      ansible.builtin.blockinfile:
+        path: "{{ smb_conf }}"
+        marker: "# {mark} DUMPSTORE HOMES"
+        state: absent
+      notify: Reload samba
+
+  handlers:
+    - name: Reload samba
+      ansible.builtin.command:
+        cmd: smbcontrol smbd reload-config
+      failed_when: false

--- a/static/app.js
+++ b/static/app.js
@@ -15,6 +15,7 @@ const state = {
   sambaUsers: [],
   sambaAvailable: false,
   smbShares: [],      // [{name, path}] from net usershare info
+  smbHomes: { enabled: false, path: '', browseable: 'no', read_only: 'no', create_mask: '0644', directory_mask: '0755' },
   iscsiTargets: [],   // [{iqn, zvol_name, ...}] from /api/iscsi-targets
   activeTab: 'pools',
   collapsedDatasets: new Set(),
@@ -227,7 +228,7 @@ async function loadAll() {
   try {
     // Use null as the sentinel for failed fetches so we can distinguish
     // "endpoint returned empty" from "fetch failed" and preserve last-known-good state.
-    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, users, groups, smbData, smbShares, iscsiTargets, scrubSchedules, autoSnapshotSchedules, schema] = await Promise.all([
+    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, users, groups, smbData, smbShares, smbHomes, iscsiTargets, scrubSchedules, autoSnapshotSchedules, schema] = await Promise.all([
       api('GET', '/api/pools').catch(() => null),
       api('GET', '/api/poolstatus').catch(() => null),
       api('GET', '/api/version').catch(() => null),
@@ -238,6 +239,7 @@ async function loadAll() {
       api('GET', '/api/groups').catch(() => null),
       api('GET', '/api/smb-users').catch(() => null),
       api('GET', '/api/smb-shares').catch(() => null),
+      api('GET', '/api/smb/homes').catch(() => null),
       api('GET', '/api/iscsi-targets').catch(() => null),
       api('GET', '/api/scrub-schedules').catch(() => null),
       api('GET', '/api/auto-snapshot-schedules').catch(() => null),
@@ -257,6 +259,7 @@ async function loadAll() {
         storeSet('sambaUsers', smbData?.users || []);
       }
       if (smbShares !== null) storeSet('smbShares', smbShares);
+      if (smbHomes !== null) storeSet('smbHomes', smbHomes);
       if (iscsiTargets !== null) storeSet('iscsiTargets', iscsiTargets);
       if (scrubSchedules !== null) {
         const schedData = scrubSchedules || { mode: 'cron', schedules: [] };
@@ -1583,6 +1586,127 @@ document.getElementById('editGroupForm').addEventListener('submit', async e => {
   }
 });
 
+// ── Render: SMB Home Shares ───────────────────────────────────────────────────
+function renderSMBHomes() {
+  const wrap = document.getElementById('smb-homes-wrap');
+  const cfg = state.smbHomes;
+  if (!cfg.enabled) {
+    wrap.innerHTML = `
+      <div style="display:flex;align-items:center;gap:1rem;padding:0.5rem 0">
+        <span class="muted">Home shares are disabled.</span>
+        <button class="btn-primary btn-small" id="smbHomesEnableBtn">Enable</button>
+      </div>`;
+    document.getElementById('smbHomesEnableBtn').addEventListener('click', openSMBHomesDialog);
+  } else {
+    wrap.innerHTML = `
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Path</th><th>Browseable</th><th>Read Only</th><th>Create Mask</th><th>Dir Mask</th><th></th></tr></thead>
+          <tbody>
+            <tr>
+              <td class="mono">${esc(cfg.path)}</td>
+              <td>${esc(cfg.browseable)}</td>
+              <td>${esc(cfg.read_only)}</td>
+              <td class="mono">${esc(cfg.create_mask)}</td>
+              <td class="mono">${esc(cfg.directory_mask)}</td>
+              <td><button class="btn-secondary btn-small smb-homes-edit-btn">Edit</button></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>`;
+    wrap.querySelector('.smb-homes-edit-btn').addEventListener('click', openSMBHomesDialog);
+  }
+}
+
+// ── SMB Home Shares dialog ───────────────────────────────────────────────────
+const smbHomesDialog = document.getElementById('smbHomesDialog');
+
+function openSMBHomesDialog() {
+  const cfg = state.smbHomes;
+
+  // Populate dataset picker
+  const sel = document.getElementById('smb-homes-dataset');
+  sel.innerHTML = '<option value="">— custom path —</option>';
+  const fsList = (state.datasets || []).filter(d => d.type === 'filesystem' && d.mountpoint && d.mountpoint !== '-' && d.mountpoint !== 'none');
+  fsList.forEach(d => {
+    const opt = document.createElement('option');
+    opt.value = d.mountpoint;
+    opt.textContent = d.name + ' (' + d.mountpoint + ')';
+    sel.appendChild(opt);
+  });
+
+  // Pre-fill from current config
+  const pathInput = document.getElementById('smb-homes-path');
+  if (cfg.enabled && cfg.path) {
+    pathInput.value = cfg.path;
+    // Try to match dataset
+    const base = cfg.path.replace(/\/%U$/, '');
+    const matchOpt = Array.from(sel.options).find(o => o.value === base);
+    if (matchOpt) sel.value = base;
+  } else {
+    pathInput.value = '';
+    sel.value = '';
+  }
+
+  document.getElementById('smb-homes-browseable').value = cfg.browseable || 'no';
+  document.getElementById('smb-homes-readonly').value = cfg.read_only || 'no';
+  document.getElementById('smb-homes-create-mask').value = cfg.create_mask || '0644';
+  document.getElementById('smb-homes-directory-mask').value = cfg.directory_mask || '0755';
+
+  // Show/hide disable button
+  const disableBtn = document.getElementById('smbHomesDisableBtn');
+  const applyBtn = document.getElementById('smbHomesApplyBtn');
+  disableBtn.style.display = cfg.enabled ? '' : 'none';
+  applyBtn.textContent = cfg.enabled ? 'Apply' : 'Enable';
+
+  smbHomesDialog.showModal();
+}
+
+// Dataset picker → auto-fill path
+document.getElementById('smb-homes-dataset').addEventListener('change', function() {
+  const pathInput = document.getElementById('smb-homes-path');
+  if (this.value) {
+    pathInput.value = this.value + '/%U';
+  } else {
+    pathInput.value = '';
+  }
+});
+
+document.getElementById('smbHomesCancelBtn').addEventListener('click', () => smbHomesDialog.close());
+
+document.getElementById('smbHomesApplyBtn').addEventListener('click', async () => {
+  const path = document.getElementById('smb-homes-path').value.trim();
+  if (!path) { toast('Path is required', 'err'); return; }
+  const body = {
+    path,
+    browseable: document.getElementById('smb-homes-browseable').value,
+    read_only: document.getElementById('smb-homes-readonly').value,
+    create_mask: document.getElementById('smb-homes-create-mask').value.trim(),
+    directory_mask: document.getElementById('smb-homes-directory-mask').value.trim(),
+  };
+  smbHomesDialog.close();
+  showOpLogRunning('Configuring home shares…');
+  try {
+    const result = await api('POST', '/api/smb/homes', body);
+    showOpLog('Home shares enabled', result.tasks, null);
+    storeSet('smbHomes', result.config);
+  } catch (err) {
+    showOpLog('Failed to enable home shares', err.tasks, err.message);
+  }
+});
+
+document.getElementById('smbHomesDisableBtn').addEventListener('click', async () => {
+  smbHomesDialog.close();
+  showOpLogRunning('Disabling home shares…');
+  try {
+    const result = await api('DELETE', '/api/smb/homes');
+    showOpLog('Home shares disabled', result.tasks, null);
+    storeSet('smbHomes', { enabled: false, path: '', browseable: 'no', read_only: 'no', create_mask: '0644', directory_mask: '0755' });
+  } catch (err) {
+    showOpLog('Failed to disable home shares', err.tasks, err.message);
+  }
+});
+
 // ── Render: SMB Users ─────────────────────────────────────────────────────────
 function renderSambaUsers() {
   const wrap = document.getElementById('smb-users-wrap');
@@ -2262,6 +2386,7 @@ subscribe(['snapshots'],                                        renderSnapshots)
 subscribe(['users'],                                            renderUsers);
 subscribe(['groups'],                                           renderGroups);
 subscribe(['sambaUsers', 'sambaAvailable', 'users'],            renderSambaUsers);
+subscribe(['smbHomes', 'datasets'],                             renderSMBHomes);
 subscribe(['schema'],                                           buildFormSelects);
 
 // ── SSE client ────────────────────────────────────────────────────────────────

--- a/static/index.html
+++ b/static/index.html
@@ -103,6 +103,12 @@
         <div class="loading">Loading groups…</div>
       </div>
       <div class="section-header" style="margin-top:2rem">
+        <h2>SMB Home Shares</h2>
+      </div>
+      <div id="smb-homes-wrap">
+        <div class="loading">Loading home share config…</div>
+      </div>
+      <div class="section-header" style="margin-top:2rem">
         <h2>SMB Users</h2>
         <button class="btn-secondary" id="smbConfigPamBtn">Configure Samba</button>
       </div>
@@ -605,6 +611,51 @@
       <div class="dialog-actions">
         <button type="button" id="configureSambaCancelBtn" class="btn-secondary">Cancel</button>
         <button type="button" id="configureSambaConfirmBtn" class="btn-primary">Apply</button>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- SMB HOME SHARES DIALOG -->
+  <dialog id="smbHomesDialog">
+    <h3>SMB Home Shares</h3>
+    <div class="dialog-body">
+      <p class="muted" style="margin:0 0 1rem">The <code>[homes]</code> section auto-creates a personal share for each authenticated user, mapped to a subdirectory under the chosen path.</p>
+      <fieldset class="form-section">
+        <legend>Base path</legend>
+        <label>Dataset
+          <select id="smb-homes-dataset">
+            <option value="">— custom path —</option>
+          </select>
+        </label>
+        <label>Path <span class="field-note">(%U = connecting username)</span>
+          <input type="text" id="smb-homes-path" placeholder="/tank/homes/%U" autocomplete="off" spellcheck="false">
+        </label>
+      </fieldset>
+      <fieldset class="form-section">
+        <legend>Options</legend>
+        <label>Browseable
+          <select id="smb-homes-browseable">
+            <option value="no">no</option>
+            <option value="yes">yes</option>
+          </select>
+        </label>
+        <label>Read only
+          <select id="smb-homes-readonly">
+            <option value="no">no</option>
+            <option value="yes">yes</option>
+          </select>
+        </label>
+        <label>Create mask
+          <input type="text" id="smb-homes-create-mask" value="0644" maxlength="4" autocomplete="off">
+        </label>
+        <label>Directory mask
+          <input type="text" id="smb-homes-directory-mask" value="0755" maxlength="4" autocomplete="off">
+        </label>
+      </fieldset>
+      <div class="dialog-actions">
+        <button type="button" id="smbHomesCancelBtn" class="btn-secondary">Cancel</button>
+        <button type="button" id="smbHomesDisableBtn" class="btn-danger" style="display:none">Disable</button>
+        <button type="button" id="smbHomesApplyBtn" class="btn-primary">Enable</button>
       </div>
     </div>
   </dialog>

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -43,6 +43,9 @@ All endpoints are served at `http://<host>:8080`. The API is JSON-over-HTTP; all
 | POST   | `/api/smb-users/{name}`     | Add a user to smbpasswd |
 | DELETE | `/api/smb-users/{name}`     | Remove a user from smbpasswd |
 | POST   | `/api/smb-config/pam`       | Run Samba setup playbook |
+| GET    | `/api/smb/homes`            | Get current SMB [homes] config |
+| POST   | `/api/smb/homes`            | Enable/update SMB [homes] section |
+| DELETE | `/api/smb/homes`            | Disable/remove SMB [homes] section |
 | POST   | `/api/scrub/{pool}`         | Start a pool scrub |
 | DELETE | `/api/scrub/{pool}`         | Cancel a running pool scrub |
 | GET    | `/api/scrub-schedules`      | List periodic scrub schedule config |
@@ -347,6 +350,55 @@ Remove an ACL entry. The `entry` query parameter:
 - **NFSv4**: full ACE string to match
 
 Append `&recursive=true` (POSIX only) to remove recursively.
+
+---
+
+## SMB Home Shares
+
+Manage the Samba `[homes]` section in `smb.conf`. When enabled, each authenticated user automatically gets a personal share mapped to a subdirectory under the configured base path.
+
+### GET /api/smb/homes
+
+Returns the current `[homes]` configuration. If the section is not present, `enabled` is `false` and all fields are empty.
+
+```json
+{
+  "enabled": true,
+  "path": "/tank/homes/%S",
+  "browseable": true,
+  "read_only": false,
+  "create_mask": "0644",
+  "directory_mask": "0755"
+}
+```
+
+### POST /api/smb/homes
+
+Enable or update the `[homes]` section. Returns Ansible task steps.
+
+```json
+{
+  "path": "/tank/homes/%S",
+  "dataset": "tank/homes",
+  "browseable": true,
+  "read_only": false,
+  "create_mask": "0644",
+  "directory_mask": "0755"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `path` | yes | Base path for home directories (may include `%S` for username substitution) |
+| `dataset` | no | ZFS dataset to use as base path (alternative to specifying `path` directly) |
+| `browseable` | no | Whether the share is visible in browse lists (default `true`) |
+| `read_only` | no | Whether the share is read-only (default `false`) |
+| `create_mask` | no | File creation mask (default `"0644"`) |
+| `directory_mask` | no | Directory creation mask (default `"0755"`) |
+
+### DELETE /api/smb/homes
+
+Remove the `[homes]` section from `smb.conf`. Returns Ansible task steps.
 
 ---
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -44,8 +44,9 @@
       │  iostat, status, props,           datasets, snapshots,        │
       │  sysinfo, SMART, metrics,         users, groups, ACLs,        │
       │  users, groups, ACLs,             SMB users/shares/config,    │
-      │  SMB users/shares, chown,         dataset chown, scrub,       │
-      │  iSCSI targets                    iSCSI targets               │
+      │  SMB users/shares/homes,          dataset chown, scrub,       │
+      │  iSCSI targets                    iSCSI targets,              │
+      │                                   SMB homes config            │
       │                                                               │
       ▼                                                               ▼
 ┌───────────────────────┐                        ┌────────────────────────────┐

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -20,6 +20,7 @@ No container runtime, no database, no Node.js. Just a single compiled binary, so
 - **Group management** — list, create, edit, and delete local groups; system groups hidden by default
 - **NFS share management** — enable, configure, and disable NFS sharing per dataset via the ZFS `sharenfs` property; cross-platform
 - **SMB share management** — create and remove Samba usershares; manage Samba users; one-click Samba setup
+- **SMB home shares** — enable/configure the Samba `[homes]` section for automatic per-user home directory shares; configurable base path, browseable, read only, create/directory masks
 - **iSCSI target management** — expose ZFS volumes as iSCSI targets via `targetcli`/LIO on Linux or `ctld` on FreeBSD; per-zvol dialog with IQN, portal IP/port, auth mode (None/CHAP), and initiator ACL list
 - **ACL management** — POSIX ACL and NFSv4 ACL entries per dataset; recursive apply supported
 - **Live updates** — Server-Sent Events push changes every 10 s; falls back to 30 s REST polling
@@ -28,7 +29,6 @@ No container runtime, no database, no Node.js. Just a single compiled binary, so
 ## Planned
 
 - **User mgmt extensions** — SSH key management (`authorized_keys`), move home directory
-- **Samba home shares** — enable/configure `[homes]` section in `smb.conf` for per-user home directory shares
 - **Time Machine shares** — Samba `vfs_fruit` share configuration for macOS Time Machine backups over SMB
 - **ZFS native encryption** — load/unload keys, encryption status per dataset, keyformat/keylocation support
 - **Pool import/export** — import available pools from attached devices; export pools safely


### PR DESCRIPTION
## Summary

- Add support for enabling/configuring/disabling the Samba `[homes]` section in `smb.conf`
- Each authenticated user automatically gets a personal SMB share mapped to a subdirectory under a chosen ZFS dataset or custom path
- New API endpoints: `GET/POST/DELETE /api/smb/homes`
- New playbooks: `smb_homes_set.yml` / `smb_homes_unset.yml` using `blockinfile` for clean section management
- Frontend: "SMB Home Shares" section on Users & Groups tab with dataset picker, custom path override, and options dialog

Closes #33

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `GET /api/smb/homes` returns `{ enabled: false }` on clean system
- [ ] `POST /api/smb/homes` with `{ dataset: "tank/homes" }` creates `[homes]` block in smb.conf with path `<mountpoint>/%U`
- [ ] `POST /api/smb/homes` with `{ path: "/custom/path/%U" }` works with custom path
- [ ] `GET /api/smb/homes` returns full config after enable
- [ ] `DELETE /api/smb/homes` removes the block cleanly
- [ ] Frontend: dataset picker auto-fills path, dialog shows op-log on success/failure
- [ ] Frontend: edit button pre-fills current config, disable button removes section

🤖 Generated with [Claude Code](https://claude.com/claude-code)