### PR TITLE
feat: Time Machine shares (Samba vfs_fruit)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -29,6 +29,7 @@
 | Auto-snapshot scheduling | v0.1.3 | Manage `com.sun:auto-snapshot*` ZFS properties per dataset; integrates with `zfs-auto-snapshot` (Linux) / `zfstools` (FreeBSD) |
 | iSCSI target management  | v0.1.4 | Expose zvols as iSCSI targets (`targetcli`/LIO on Linux, `ctld` on FreeBSD); dialog with IQN, portal, CHAP auth, initiator ACLs |
 | SMB home shares          | v0.1.5 | Enable/configure `[homes]` section in `smb.conf`; dataset picker or custom path; per-user auto-shares                           |
+| Time Machine shares      | v0.1.6 | Samba `vfs_fruit` Time Machine backup targets; named shares backed by ZFS datasets; configurable max size and valid users         |
 
 ---
 
@@ -44,7 +45,7 @@
 | Per-user quota tracking  | Medium   | Space usage per user/group (`zfs userspace` / `zfs groupspace`)                  |
 | User mgmt extensions     | Medium   | SSH key management (`authorized_keys`), move home directory                      |
 | ~~Samba home shares~~    | ~~Medium~~ | ~~Implemented in v0.1.5~~                                                     |
-| Time Machine shares      | Medium   | Samba `vfs_fruit` share config for macOS Time Machine backups over SMB           |
+| ~~Time Machine shares~~  | ~~Medium~~ | ~~Implemented in v0.1.6~~                                                     |
 | ZFS send/receive         | Low      | Pool replication and off-site backup                                             |
 | Alerts                   | Low      | Configurable thresholds for pool health, disk temp, capacity                     |
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 - **NFS share management** — enable, configure, and disable NFS sharing per dataset via the ZFS `sharenfs` property; cross-platform (Linux and FreeBSD)
 - **SMB share management** — create and remove Samba usershares per dataset via `net usershare`; manage Samba users (add/remove from `smbpasswd`); one-click Samba setup (`smb_setup.yml` configures usershares, disables `[homes]`, enables PAM passthrough on Linux); cross-platform (Linux and FreeBSD)
 - **SMB home shares** — enable and configure the Samba `[homes]` section in `smb.conf` so each authenticated user automatically gets a personal share mapped to a subdirectory; configurable base path (pick a ZFS dataset or specify a custom path), browseable, read only, create mask, and directory mask
+- **Time Machine shares** — create Samba shares configured as macOS Time Machine backup targets using `vfs_fruit` with catia and streams_xattr; multiple named shares each backed by a different ZFS dataset; configurable max size quota and valid users per share
 - **iSCSI target management** — expose ZFS volumes as iSCSI targets via `targetcli`/LIO on Linux or `ctld` on FreeBSD; per-zvol dialog with IQN (auto-generated, editable), portal IP/port, auth mode (None/CHAP), and initiator ACL list
 - **ACL management** — view, add, and remove POSIX ACL entries (`getfacl`/`setfacl`, requires `acl` package) and NFSv4 ACL entries (`nfs4_getfacl`/`nfs4_setfacl`, requires `nfs4-acl-tools`) per dataset; setting an ACL entry automatically sets the correct `acltype` ZFS property; one-click enable for datasets with `acltype=off`; recursive apply supported for POSIX
 - **Live updates** — Server-Sent Events push pool, dataset, snapshot, I/O, user and group changes; server polls every 10 s and pushes only on change; falls back to 30 s REST polling if SSE is unavailable
@@ -111,8 +112,9 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
       │  sysinfo, SMART, metrics,         users, groups, ACLs,        │
       │  users, groups, ACLs,             SMB users/shares/config,    │
       │  SMB users/shares/homes,          dataset chown, scrub,       │
-      │  iSCSI targets                    iSCSI targets,              │
-      │                                   SMB homes config            │
+      │  iSCSI targets,                   iSCSI targets,              │
+      │  Time Machine shares              SMB homes config,           │
+      │                                   Time Machine shares         │
       │                                                               │
       ▼                                                               ▼
 ┌───────────────────────┐                        ┌────────────────────────────┐
@@ -241,6 +243,10 @@ POST   /api/smb-config/pam    → smb_setup.yml             (ansible)
 GET    /api/smb/homes          → parse smb.conf [homes]   (direct)
 POST   /api/smb/homes          → smb_homes_set.yml        (ansible)
 DELETE /api/smb/homes          → smb_homes_unset.yml      (ansible)
+
+GET    /api/smb/timemachine    → parse smb.conf fruit:time machine  (direct)
+POST   /api/smb/timemachine    → smb_timemachine_set.yml  (ansible)
+DELETE /api/smb/timemachine/{n}→ smb_timemachine_unset.yml (ansible)
 
 GET    /api/auto-snapshot/{ds} → zfs get com.sun:auto-snapshot* (direct)
 PUT    /api/auto-snapshot/{ds} → zfs_autosnap_set.yml           (ansible)
@@ -442,6 +448,8 @@ sudo make uninstall
 │   ├── smb_user_remove.yml          # Remove a user from smbpasswd
 │   ├── smb_homes_set.yml            # Enable/update [homes] section in smb.conf
 │   ├── smb_homes_unset.yml          # Remove [homes] section from smb.conf
+│   ├── smb_timemachine_set.yml      # Create/update Time Machine share in smb.conf (vfs_fruit)
+│   ├── smb_timemachine_unset.yml    # Remove Time Machine share from smb.conf
 │   ├── iscsi_target_create.yml      # Create iSCSI target (Linux/targetcli)
 │   ├── iscsi_target_delete.yml      # Remove iSCSI target (Linux/targetcli)
 │   ├── iscsi_target_create_freebsd.yml  # Create iSCSI target (FreeBSD/ctld)
@@ -503,6 +511,9 @@ sudo make uninstall
 | GET    | `/api/smb/homes`            | Get current SMB [homes] config        |
 | POST   | `/api/smb/homes`            | Enable/update SMB [homes] section     |
 | DELETE | `/api/smb/homes`            | Disable/remove SMB [homes] section    |
+| GET    | `/api/smb/timemachine`      | List all Time Machine shares          |
+| POST   | `/api/smb/timemachine`      | Create/update a Time Machine share    |
+| DELETE | `/api/smb/timemachine/{name}` | Remove a Time Machine share         |
 | GET    | `/api/iscsi-targets`        | List all iSCSI targets                |
 | POST   | `/api/iscsi-targets`        | Create an iSCSI target for a zvol     |
 | DELETE | `/api/iscsi-targets`        | Remove an iSCSI target                |
@@ -708,7 +719,7 @@ The browser UI uses `EventSource` to subscribe to all eight topics and falls bac
 | Per-user quota tracking  | Show space usage per user/group (`zfs userspace` / `zfs groupspace`)                          |
 | User mgmt extensions     | SSH key management (`authorized_keys`), move home directory                                   |
 | ~~Samba home shares~~    | ~~Enable/configure `[homes]` section in `smb.conf` for per-user home directory shares~~ — **done** (enable/disable `[homes]` section; configurable base path, browseable, read only, create/directory masks) |
-| Time Machine shares      | Samba `vfs_fruit` share configuration for macOS Time Machine backups over SMB                  |
+| ~~Time Machine shares~~  | ~~Samba `vfs_fruit` share configuration for macOS Time Machine backups over SMB~~ — **done** (named shares backed by ZFS datasets; configurable max size and valid users; `vfs_fruit` with catia and streams_xattr) |
 | ZFS send/receive         | Pool replication and off-site backup                                                          |
 | Alerts                   | Configurable thresholds for pool health, disk temp, capacity                                  |
 | ~~Pool scrub management~~| ~~Trigger scrubs, view last scrub time/status/progress, schedule periodic scrubs~~ — **done** (start/cancel + periodic schedule; Linux `zfsutils-linux`, FreeBSD `periodic.conf`) |

--- a/docs/index.html
+++ b/docs/index.html
@@ -538,6 +538,13 @@
       </div>
       <div class="pool-card">
         <div class="pool-card-header">
+          <span class="pool-name">Time Machine shares</span>
+          <span class="health-badge badge-blue">vfs_fruit</span>
+        </div>
+        <p>Create Samba shares configured as macOS Time Machine backup targets using <code>vfs_fruit</code> with catia and streams_xattr. Multiple named shares each backed by a different ZFS dataset. Configurable max size quota and valid users per share.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
           <span class="pool-name">auto-snapshot scheduling</span>
           <span class="health-badge badge-green">com.sun:auto-snapshot</span>
         </div>
@@ -591,13 +598,6 @@
           <span class="health-badge badge-blue">planned</span>
         </div>
         <p>SSH key management (<code>authorized_keys</code>) and home directory relocation per user.</p>
-      </div>
-      <div class="pool-card">
-        <div class="pool-card-header">
-          <span class="pool-name">Time Machine shares</span>
-          <span class="health-badge badge-blue">planned</span>
-        </div>
-        <p>Samba <code>vfs_fruit</code> share configuration for macOS Time Machine backups over SMB.</p>
       </div>
       <div class="pool-card">
         <div class="pool-card-header">

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -189,6 +189,9 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/smb/homes", h.getSMBHomes)
 	mux.HandleFunc("POST /api/smb/homes", h.setSMBHomes)
 	mux.HandleFunc("DELETE /api/smb/homes", h.deleteSMBHomes)
+	mux.HandleFunc("GET /api/smb/timemachine", h.getTimeMachineShares)
+	mux.HandleFunc("POST /api/smb/timemachine", h.createTimeMachineShare)
+	mux.HandleFunc("DELETE /api/smb/timemachine/{sharename}", h.deleteTimeMachineShare)
 	mux.HandleFunc("POST /api/scrub/{pool}", h.startScrub)
 	mux.HandleFunc("DELETE /api/scrub/{pool}", h.cancelScrub)
 	mux.HandleFunc("GET /api/scrub-schedules", h.listScrubSchedules)
@@ -1143,6 +1146,107 @@ func (h *Handler) setSMBHomes(w http.ResponseWriter, r *http.Request) {
 // Removes the [homes] section from smb.conf.
 func (h *Handler) deleteSMBHomes(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp("smb_homes_unset.yml", map[string]string{})
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(w, map[string]any{"tasks": out.Steps()})
+}
+
+// getTimeMachineShares handles GET /api/smb/timemachine
+// Returns all Samba shares configured as Time Machine targets.
+func (h *Handler) getTimeMachineShares(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, system.ParseTimeMachineShares())
+}
+
+// createTimeMachineShare handles POST /api/smb/timemachine
+// Body: {"sharename":"TimeMachine","dataset":"tank/tm","path":"/tank/tm","max_size":"500G","valid_users":"@backup"}
+func (h *Handler) createTimeMachineShare(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Sharename  string `json:"sharename"`
+		Dataset    string `json:"dataset"`
+		Path       string `json:"path"`
+		MaxSize    string `json:"max_size"`
+		ValidUsers string `json:"valid_users"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err), nil)
+		return
+	}
+
+	if req.Sharename == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("sharename is required"), nil)
+		return
+	}
+	if !validSMBShare(req.Sharename) {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid share name"), nil)
+		return
+	}
+
+	// Resolve dataset to path if provided
+	if req.Dataset != "" && req.Path == "" {
+		if !validZFSName(req.Dataset) {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("invalid dataset name"), nil)
+			return
+		}
+		datasets, err := zfs.ListDatasets()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("failed to list datasets: %w", err), nil)
+			return
+		}
+		for _, ds := range datasets {
+			if ds.Name == req.Dataset {
+				req.Path = ds.Mountpoint
+				break
+			}
+		}
+		if req.Path == "" || req.Path == "-" || req.Path == "none" {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("dataset %q has no mountpoint", req.Dataset), nil)
+			return
+		}
+	}
+
+	if req.Path == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("path is required (or provide dataset)"), nil)
+		return
+	}
+
+	out, err := h.runOp("smb_timemachine_set.yml", map[string]string{
+		"sharename":   req.Sharename,
+		"path":        req.Path,
+		"max_size":    req.MaxSize,
+		"valid_users": req.ValidUsers,
+	})
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(w, map[string]any{"shares": system.ParseTimeMachineShares(), "tasks": out.Steps()})
+}
+
+// deleteTimeMachineShare handles DELETE /api/smb/timemachine/{sharename}
+func (h *Handler) deleteTimeMachineShare(w http.ResponseWriter, r *http.Request) {
+	sharename := r.PathValue("sharename")
+	if sharename == "" {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("sharename is required"), nil)
+		return
+	}
+	if !validSMBShare(sharename) {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid share name"), nil)
+		return
+	}
+
+	out, err := h.runOp("smb_timemachine_unset.yml", map[string]string{
+		"sharename": sharename,
+	})
 	if err != nil {
 		var steps []ansible.TaskStep
 		if out != nil {

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -221,6 +221,70 @@ func ParseSMBHomes() SMBHomesConfig {
 	return cfg
 }
 
+// TimeMachineShare describes a single Time Machine backup share in smb.conf.
+type TimeMachineShare struct {
+	Name       string `json:"name"`
+	Path       string `json:"path"`
+	MaxSize    string `json:"max_size"`
+	ValidUsers string `json:"valid_users"`
+}
+
+// ParseTimeMachineShares reads smb.conf and returns all shares configured
+// as Time Machine targets (sections containing "fruit:time machine = yes").
+func ParseTimeMachineShares() []TimeMachineShare {
+	data, err := os.ReadFile(smbConfPath())
+	if err != nil {
+		return []TimeMachineShare{}
+	}
+
+	var result []TimeMachineShare
+	var cur *TimeMachineShare
+	isTM := false
+
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			if cur != nil && isTM {
+				result = append(result, *cur)
+			}
+			name := trimmed[1 : len(trimmed)-1]
+			if strings.EqualFold(name, "global") || strings.EqualFold(name, "homes") || strings.EqualFold(name, "printers") {
+				cur = nil
+				isTM = false
+				continue
+			}
+			cur = &TimeMachineShare{Name: name}
+			isTM = false
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		parts := strings.SplitN(trimmed, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+		switch strings.ToLower(key) {
+		case "path":
+			cur.Path = val
+		case "fruit:time machine":
+			if strings.EqualFold(val, "yes") {
+				isTM = true
+			}
+		case "fruit:time machine max size":
+			cur.MaxSize = val
+		case "valid users":
+			cur.ValidUsers = val
+		}
+	}
+	if cur != nil && isTM {
+		result = append(result, *cur)
+	}
+	return result
+}
+
 // ListShells reads /etc/shells and returns all valid login shells.
 // Falls back to a minimal list if the file is not present.
 func ListShells() []string {

--- a/playbooks/smb_timemachine_set.yml
+++ b/playbooks/smb_timemachine_set.yml
@@ -1,0 +1,71 @@
+---
+# Creates or updates a Samba share configured as a macOS Time Machine backup
+# target using the vfs_fruit VFS module.
+#
+# Required extra vars:
+#   sharename   – Samba share name, e.g. "TimeMachine"
+#   path        – absolute path to the backup directory, e.g. /tank/timemachine
+#
+# Optional extra vars:
+#   max_size    – quota for Time Machine backups, e.g. "500G" (default: no limit)
+#   valid_users – space-separated list of users/groups, e.g. "@backup alice" (default: all)
+
+- name: Create Time Machine share
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Set OS-specific smb.conf path
+      ansible.builtin.set_fact:
+        smb_conf: >-
+          {{ '/usr/local/etc/smb4.conf'
+             if ansible_os_family == 'FreeBSD'
+             else '/etc/samba/smb.conf' }}
+
+    - name: Set defaults for optional variables
+      ansible.builtin.set_fact:
+        max_size: "{{ max_size | default('') }}"
+        valid_users: "{{ valid_users | default('') }}"
+
+    - name: Assert required variables
+      ansible.builtin.assert:
+        that:
+          - sharename is defined and sharename | length > 0
+          - path is defined and path | length > 0
+        fail_msg: "sharename and path are required"
+
+    - name: Check smb.conf exists
+      ansible.builtin.stat:
+        path: "{{ smb_conf }}"
+      register: smb_conf_stat
+
+    - name: Fail if smb.conf not found
+      ansible.builtin.fail:
+        msg: "{{ smb_conf }} not found — is Samba installed?"
+      when: not smb_conf_stat.stat.exists
+
+    - name: Build share configuration block
+      ansible.builtin.set_fact:
+        tm_block: |
+          [{{ sharename }}]
+             comment = Time Machine backup
+             path = {{ path }}
+             vfs objects = catia fruit streams_xattr
+             fruit:time machine = yes
+             {% if max_size | length > 0 %}fruit:time machine max size = {{ max_size }}
+             {% endif %}browseable = yes
+             read only = no
+             {% if valid_users | length > 0 %}valid users = {{ valid_users }}
+             {% endif %}
+
+    - name: Insert or update Time Machine share
+      ansible.builtin.blockinfile:
+        path: "{{ smb_conf }}"
+        marker: "# {mark} DUMPSTORE TM {{ sharename }}"
+        block: "{{ tm_block }}"
+      notify: Reload samba
+
+  handlers:
+    - name: Reload samba
+      ansible.builtin.command:
+        cmd: smbcontrol smbd reload-config
+      failed_when: false

--- a/playbooks/smb_timemachine_unset.yml
+++ b/playbooks/smb_timemachine_unset.yml
@@ -1,0 +1,45 @@
+---
+# Removes a Time Machine share from smb.conf.
+#
+# Required extra vars:
+#   sharename – name of the share to remove
+
+- name: Remove Time Machine share
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Set OS-specific smb.conf path
+      ansible.builtin.set_fact:
+        smb_conf: >-
+          {{ '/usr/local/etc/smb4.conf'
+             if ansible_os_family == 'FreeBSD'
+             else '/etc/samba/smb.conf' }}
+
+    - name: Assert required variables
+      ansible.builtin.assert:
+        that:
+          - sharename is defined and sharename | length > 0
+        fail_msg: "sharename is required"
+
+    - name: Check smb.conf exists
+      ansible.builtin.stat:
+        path: "{{ smb_conf }}"
+      register: smb_conf_stat
+
+    - name: Fail if smb.conf not found
+      ansible.builtin.fail:
+        msg: "{{ smb_conf }} not found — is Samba installed?"
+      when: not smb_conf_stat.stat.exists
+
+    - name: Remove Time Machine share
+      ansible.builtin.blockinfile:
+        path: "{{ smb_conf }}"
+        marker: "# {mark} DUMPSTORE TM {{ sharename }}"
+        state: absent
+      notify: Reload samba
+
+  handlers:
+    - name: Reload samba
+      ansible.builtin.command:
+        cmd: smbcontrol smbd reload-config
+      failed_when: false

--- a/static/app.js
+++ b/static/app.js
@@ -16,6 +16,7 @@ const state = {
   sambaAvailable: false,
   smbShares: [],      // [{name, path}] from net usershare info
   smbHomes: { enabled: false, path: '', browseable: 'no', read_only: 'no', create_mask: '0644', directory_mask: '0755' },
+  timeMachineShares: [],  // [{name, path, max_size, valid_users}]
   iscsiTargets: [],   // [{iqn, zvol_name, ...}] from /api/iscsi-targets
   activeTab: 'pools',
   collapsedDatasets: new Set(),
@@ -228,7 +229,7 @@ async function loadAll() {
   try {
     // Use null as the sentinel for failed fetches so we can distinguish
     // "endpoint returned empty" from "fetch failed" and preserve last-known-good state.
-    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, users, groups, smbData, smbShares, smbHomes, iscsiTargets, scrubSchedules, autoSnapshotSchedules, schema] = await Promise.all([
+    const [pools, poolStatuses, version, sysinfo, datasets, snapshots, users, groups, smbData, smbShares, smbHomes, tmShares, iscsiTargets, scrubSchedules, autoSnapshotSchedules, schema] = await Promise.all([
       api('GET', '/api/pools').catch(() => null),
       api('GET', '/api/poolstatus').catch(() => null),
       api('GET', '/api/version').catch(() => null),
@@ -240,6 +241,7 @@ async function loadAll() {
       api('GET', '/api/smb-users').catch(() => null),
       api('GET', '/api/smb-shares').catch(() => null),
       api('GET', '/api/smb/homes').catch(() => null),
+      api('GET', '/api/smb/timemachine').catch(() => null),
       api('GET', '/api/iscsi-targets').catch(() => null),
       api('GET', '/api/scrub-schedules').catch(() => null),
       api('GET', '/api/auto-snapshot-schedules').catch(() => null),
@@ -260,6 +262,7 @@ async function loadAll() {
       }
       if (smbShares !== null) storeSet('smbShares', smbShares);
       if (smbHomes !== null) storeSet('smbHomes', smbHomes);
+      if (tmShares !== null) storeSet('timeMachineShares', tmShares);
       if (iscsiTargets !== null) storeSet('iscsiTargets', iscsiTargets);
       if (scrubSchedules !== null) {
         const schedData = scrubSchedules || { mode: 'cron', schedules: [] };
@@ -1707,6 +1710,107 @@ document.getElementById('smbHomesDisableBtn').addEventListener('click', async ()
   }
 });
 
+// ── Render: Time Machine Shares ───────────────────────────────────────────────
+function renderTimeMachine() {
+  const wrap = document.getElementById('tm-shares-wrap');
+  const shares = state.timeMachineShares || [];
+  if (!shares.length) {
+    wrap.innerHTML = '<div class="muted" style="padding:0.5rem 0">No Time Machine shares configured.</div>';
+    return;
+  }
+  const rows = shares.map(s => `
+    <tr>
+      <td class="mono">${esc(s.name)}</td>
+      <td class="mono">${esc(s.path)}</td>
+      <td>${s.max_size ? esc(s.max_size) : '<span class="muted">no limit</span>'}</td>
+      <td>${s.valid_users ? esc(s.valid_users) : '<span class="muted">all</span>'}</td>
+      <td><button class="btn-del btn-small tm-del-btn" data-name="${esc(s.name)}">Delete</button></td>
+    </tr>`).join('');
+  wrap.innerHTML = `
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Share</th><th>Path</th><th>Max Size</th><th>Valid Users</th><th></th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`;
+  wrap.querySelectorAll('.tm-del-btn').forEach(btn => {
+    btn.addEventListener('click', () => deleteTimeMachineShare(btn.dataset.name));
+  });
+}
+
+async function deleteTimeMachineShare(name) {
+  if (!confirm(`Delete Time Machine share "${name}"?`)) return;
+  showOpLogRunning('Removing Time Machine share…');
+  try {
+    const result = await api('DELETE', '/api/smb/timemachine/' + encodeURIComponent(name));
+    showOpLog(`Time Machine share deleted: ${name}`, result.tasks, null);
+    const shares = await api('GET', '/api/smb/timemachine').catch(() => []);
+    storeSet('timeMachineShares', shares || []);
+  } catch (err) {
+    showOpLog(`Failed to delete Time Machine share: ${name}`, err.tasks, err.message);
+  }
+}
+
+// ── Time Machine dialog ──────────────────────────────────────────────────────
+const timeMachineDialog = document.getElementById('timeMachineDialog');
+
+function openTimeMachineDialog() {
+  document.getElementById('tm-sharename').value = '';
+  document.getElementById('tm-path').value = '';
+  document.getElementById('tm-max-size').value = '';
+  document.getElementById('tm-valid-users').value = '';
+
+  // Populate dataset picker
+  const sel = document.getElementById('tm-dataset');
+  sel.innerHTML = '<option value="">— custom path —</option>';
+  const fsList = (state.datasets || []).filter(d => d.type === 'filesystem' && d.mountpoint && d.mountpoint !== '-' && d.mountpoint !== 'none');
+  fsList.forEach(d => {
+    const opt = document.createElement('option');
+    opt.value = d.mountpoint;
+    opt.textContent = d.name + ' (' + d.mountpoint + ')';
+    sel.appendChild(opt);
+  });
+  sel.value = '';
+
+  timeMachineDialog.showModal();
+  document.getElementById('tm-sharename').focus();
+}
+
+document.getElementById('tmAddBtn').addEventListener('click', openTimeMachineDialog);
+
+document.getElementById('tm-dataset').addEventListener('change', function() {
+  const pathInput = document.getElementById('tm-path');
+  if (this.value) {
+    pathInput.value = this.value;
+  } else {
+    pathInput.value = '';
+  }
+});
+
+document.getElementById('tmCancelBtn').addEventListener('click', () => timeMachineDialog.close());
+
+document.getElementById('tmCreateBtn').addEventListener('click', async () => {
+  const sharename = document.getElementById('tm-sharename').value.trim();
+  const path = document.getElementById('tm-path').value.trim();
+  if (!sharename) { toast('Share name is required', 'err'); return; }
+  if (!path) { toast('Path is required', 'err'); return; }
+  const body = {
+    sharename,
+    path,
+    max_size: document.getElementById('tm-max-size').value.trim(),
+    valid_users: document.getElementById('tm-valid-users').value.trim(),
+  };
+  timeMachineDialog.close();
+  showOpLogRunning('Creating Time Machine share…');
+  try {
+    const result = await api('POST', '/api/smb/timemachine', body);
+    showOpLog('Time Machine share created', result.tasks, null);
+    storeSet('timeMachineShares', result.shares || []);
+  } catch (err) {
+    showOpLog('Failed to create Time Machine share', err.tasks, err.message);
+  }
+});
+
 // ── Render: SMB Users ─────────────────────────────────────────────────────────
 function renderSambaUsers() {
   const wrap = document.getElementById('smb-users-wrap');
@@ -2387,6 +2491,7 @@ subscribe(['users'],                                            renderUsers);
 subscribe(['groups'],                                           renderGroups);
 subscribe(['sambaUsers', 'sambaAvailable', 'users'],            renderSambaUsers);
 subscribe(['smbHomes', 'datasets'],                             renderSMBHomes);
+subscribe(['timeMachineShares'],                                renderTimeMachine);
 subscribe(['schema'],                                           buildFormSelects);
 
 // ── SSE client ────────────────────────────────────────────────────────────────

--- a/static/index.html
+++ b/static/index.html
@@ -109,6 +109,13 @@
         <div class="loading">Loading home share config…</div>
       </div>
       <div class="section-header" style="margin-top:2rem">
+        <h2>Time Machine Shares</h2>
+        <button class="btn-primary btn-small" id="tmAddBtn">+ Add</button>
+      </div>
+      <div id="tm-shares-wrap">
+        <div class="loading">Loading Time Machine shares…</div>
+      </div>
+      <div class="section-header" style="margin-top:2rem">
         <h2>SMB Users</h2>
         <button class="btn-secondary" id="smbConfigPamBtn">Configure Samba</button>
       </div>
@@ -656,6 +663,41 @@
         <button type="button" id="smbHomesCancelBtn" class="btn-secondary">Cancel</button>
         <button type="button" id="smbHomesDisableBtn" class="btn-danger" style="display:none">Disable</button>
         <button type="button" id="smbHomesApplyBtn" class="btn-primary">Enable</button>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- TIME MACHINE SHARE DIALOG -->
+  <dialog id="timeMachineDialog">
+    <h3>Add Time Machine Share</h3>
+    <div class="dialog-body">
+      <p class="muted" style="margin:0 0 1rem">Create a Samba share configured as a macOS Time Machine backup target using <code>vfs_fruit</code>.</p>
+      <fieldset class="form-section">
+        <legend>Share settings</legend>
+        <label>Share name
+          <input type="text" id="tm-sharename" placeholder="TimeMachine" autocomplete="off" spellcheck="false" required>
+        </label>
+        <label>Dataset
+          <select id="tm-dataset">
+            <option value="">— custom path —</option>
+          </select>
+        </label>
+        <label>Path
+          <input type="text" id="tm-path" placeholder="/tank/timemachine" autocomplete="off" spellcheck="false">
+        </label>
+      </fieldset>
+      <fieldset class="form-section">
+        <legend>Options</legend>
+        <label>Max size <span class="field-note">(optional, e.g. 500G)</span>
+          <input type="text" id="tm-max-size" placeholder="no limit" autocomplete="off">
+        </label>
+        <label>Valid users <span class="field-note">(optional, e.g. @backup alice)</span>
+          <input type="text" id="tm-valid-users" placeholder="all users" autocomplete="off">
+        </label>
+      </fieldset>
+      <div class="dialog-actions">
+        <button type="button" id="tmCancelBtn" class="btn-secondary">Cancel</button>
+        <button type="button" id="tmCreateBtn" class="btn-primary">Create</button>
       </div>
     </div>
   </dialog>

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -46,6 +46,9 @@ All endpoints are served at `http://<host>:8080`. The API is JSON-over-HTTP; all
 | GET    | `/api/smb/homes`            | Get current SMB [homes] config |
 | POST   | `/api/smb/homes`            | Enable/update SMB [homes] section |
 | DELETE | `/api/smb/homes`            | Disable/remove SMB [homes] section |
+| GET    | `/api/smb/timemachine`      | List all Time Machine shares |
+| POST   | `/api/smb/timemachine`      | Create/update a Time Machine share |
+| DELETE | `/api/smb/timemachine/{name}` | Remove a Time Machine share |
 | POST   | `/api/scrub/{pool}`         | Start a pool scrub |
 | DELETE | `/api/scrub/{pool}`         | Cancel a running pool scrub |
 | GET    | `/api/scrub-schedules`      | List periodic scrub schedule config |
@@ -399,6 +402,53 @@ Enable or update the `[homes]` section. Returns Ansible task steps.
 ### DELETE /api/smb/homes
 
 Remove the `[homes]` section from `smb.conf`. Returns Ansible task steps.
+
+---
+
+## Time Machine Shares
+
+Manage Samba shares configured as macOS Time Machine backup targets using `vfs_fruit` with catia and streams_xattr VFS modules.
+
+### GET /api/smb/timemachine
+
+List all Time Machine shares. Parses `smb.conf` for sections with `fruit:time machine = yes`.
+
+```json
+[
+  {
+    "sharename": "timemachine",
+    "path": "/tank/backups/timemachine",
+    "max_size": "1T",
+    "valid_users": "alice bob"
+  }
+]
+```
+
+### POST /api/smb/timemachine
+
+Create or update a Time Machine share. Returns Ansible task steps.
+
+```json
+{
+  "sharename": "timemachine",
+  "dataset": "tank/backups",
+  "path": "/tank/backups/timemachine",
+  "max_size": "1T",
+  "valid_users": "alice bob"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `sharename` | yes | Samba share name |
+| `dataset` | no | ZFS dataset (alternative to specifying `path` directly) |
+| `path` | yes | Filesystem path for the share |
+| `max_size` | no | Maximum size quota for Time Machine backups |
+| `valid_users` | no | Space-separated list of allowed users |
+
+### DELETE /api/smb/timemachine/{sharename}
+
+Remove a Time Machine share from `smb.conf`. Returns Ansible task steps.
 
 ---
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -45,8 +45,9 @@
       │  sysinfo, SMART, metrics,         users, groups, ACLs,        │
       │  users, groups, ACLs,             SMB users/shares/config,    │
       │  SMB users/shares/homes,          dataset chown, scrub,       │
-      │  iSCSI targets                    iSCSI targets,              │
-      │                                   SMB homes config            │
+      │  iSCSI targets,                   iSCSI targets,              │
+      │  Time Machine shares              SMB homes config,           │
+      │                                   Time Machine shares         │
       │                                                               │
       ▼                                                               ▼
 ┌───────────────────────┐                        ┌────────────────────────────┐

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -21,6 +21,7 @@ No container runtime, no database, no Node.js. Just a single compiled binary, so
 - **NFS share management** — enable, configure, and disable NFS sharing per dataset via the ZFS `sharenfs` property; cross-platform
 - **SMB share management** — create and remove Samba usershares; manage Samba users; one-click Samba setup
 - **SMB home shares** — enable/configure the Samba `[homes]` section for automatic per-user home directory shares; configurable base path, browseable, read only, create/directory masks
+- **Time Machine shares** — create Samba shares configured as macOS Time Machine backup targets using `vfs_fruit`; multiple named shares each backed by a different ZFS dataset; configurable max size quota and valid users
 - **iSCSI target management** — expose ZFS volumes as iSCSI targets via `targetcli`/LIO on Linux or `ctld` on FreeBSD; per-zvol dialog with IQN, portal IP/port, auth mode (None/CHAP), and initiator ACL list
 - **ACL management** — POSIX ACL and NFSv4 ACL entries per dataset; recursive apply supported
 - **Live updates** — Server-Sent Events push changes every 10 s; falls back to 30 s REST polling
@@ -29,7 +30,6 @@ No container runtime, no database, no Node.js. Just a single compiled binary, so
 ## Planned
 
 - **User mgmt extensions** — SSH key management (`authorized_keys`), move home directory
-- **Time Machine shares** — Samba `vfs_fruit` share configuration for macOS Time Machine backups over SMB
 - **ZFS native encryption** — load/unload keys, encryption status per dataset, keyformat/keylocation support
 - **Pool import/export** — import available pools from attached devices; export pools safely
 - **ZFS send/receive** — pool replication and off-site backup


### PR DESCRIPTION
## Summary

- Add support for creating Samba shares configured as macOS Time Machine backup targets using `vfs_fruit`
- Supports multiple named shares, each backed by a different ZFS dataset with optional max size quota
- New API endpoints: `GET/POST /api/smb/timemachine`, `DELETE /api/smb/timemachine/{sharename}`
- New playbooks: `smb_timemachine_set.yml` / `smb_timemachine_unset.yml` using per-share `blockinfile` markers
- Frontend: "Time Machine Shares" section on Users & Groups tab with dataset picker and options dialog

Closes #34

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `GET /api/smb/timemachine` returns `[]` on clean system
- [ ] `POST /api/smb/timemachine` with `{sharename: "TimeMachine", dataset: "tank/tm"}` creates share in smb.conf with vfs_fruit config
- [ ] `POST /api/smb/timemachine` with `{sharename: "TM2", path: "/custom/path", max_size: "500G"}` works with custom path and quota
- [ ] `GET /api/smb/timemachine` returns shares with correct fields
- [ ] `DELETE /api/smb/timemachine/TimeMachine` removes the share cleanly
- [ ] Frontend: table renders shares, dialog creates new ones, delete button works, op-log shown for all operations
- [ ] Multiple Time Machine shares can coexist independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)