### PR TITLE
fix: validate CHAP password with safePassword like Unix/SMB passwords

### DIFF
--- a/internal/api/iscsi_handlers.go
+++ b/internal/api/iscsi_handlers.go
@@ -83,8 +83,12 @@ func (h *Handler) createISCSITarget(w http.ResponseWriter, r *http.Request) {
 			writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("chap_user and chap_password required when auth_mode is 'chap'"), nil)
 			return
 		}
-		if !safePropertyValue(req.CHAPUser) || !safePropertyValue(req.CHAPPassword) {
-			writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid characters in CHAP credentials"), nil)
+		if !safePropertyValue(req.CHAPUser) {
+			writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid characters in CHAP username"), nil)
+			return
+		}
+		if !safePassword(req.CHAPPassword) {
+			writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("CHAP password must not contain newline characters"), nil)
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- CHAP password in `createISCSITarget` was validated with `safePropertyValue`, which rejects common password characters (`$`, `!`, `*`, `?`, `~`, `"`, `'`, etc.)
- Unix and SMB passwords use `safePassword` (newline-only check), which is correct since newlines corrupt line-delimited stdin input
- Extra-vars are JSON-marshaled and passed as a single arg to `exec.Command` — no shell involved — so `safePropertyValue` was overly restrictive for a password field
- Now `CHAPPassword` uses `safePassword`; `CHAPUser` keeps `safePropertyValue` as it's a config identifier, not a password

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] CHAP password containing `$`, `!`, `*` etc. is now accepted
- [ ] CHAP password containing `\n` is still rejected
- [ ] CHAP username validation is unchanged (still uses `safePropertyValue`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)