### PR TITLE
fix: add existence pre-checks to snapshot/dataset/ACL handlers

### DIFF
--- a/internal/api/acl_handlers.go
+++ b/internal/api/acl_handlers.go
@@ -191,6 +191,47 @@ func (h *Handler) setACLEntry(w http.ResponseWriter, r *http.Request) {
 	writeJSON(r.Context(), w, map[string]any{"dataset": name, "ace": req.ACE, "tasks": out.Steps()})
 }
 
+// aclEntryExists reports whether the given ACL removal spec matches at least one
+// entry in the dataset's current ACL. This prevents setfacl -x / nfs4_setfacl -x
+// from silently succeeding on a nonexistent entry.
+//
+// For POSIX the spec is "tag:qualifier" or "default:tag:qualifier".
+// For NFSv4 the spec is "type:flags:principal:perms"; we match on type+principal (parts[0] and [2]).
+func aclEntryExists(acl *zfs.DatasetACL, entry string) bool {
+	switch acl.ACLType {
+	case "posix":
+		isDefault := false
+		s := entry
+		if strings.HasPrefix(s, "default:") {
+			isDefault = true
+			s = strings.TrimPrefix(s, "default:")
+		}
+		parts := strings.SplitN(s, ":", 2)
+		tag := parts[0]
+		qualifier := ""
+		if len(parts) == 2 {
+			qualifier = parts[1]
+		}
+		for _, e := range acl.Entries {
+			if e.Tag == tag && e.Qualifier == qualifier && e.Default == isDefault {
+				return true
+			}
+		}
+	case "nfsv4":
+		parts := strings.SplitN(entry, ":", 4)
+		if len(parts) < 3 {
+			return false
+		}
+		typ, principal := parts[0], parts[2]
+		for _, e := range acl.Entries {
+			if e.Tag == typ && e.Qualifier == principal {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // removeACLEntry handles DELETE /api/acl/{dataset...}?entry=<spec>
 // For POSIX: entry is the removal spec (e.g. "user:alice", "default:group:storage")
 // For NFSv4: entry is the full ACE string to remove
@@ -231,6 +272,10 @@ func (h *Handler) removeACLEntry(w http.ResponseWriter, r *http.Request) {
 	}
 	if acl.Mountpoint == "none" || acl.Mountpoint == "-" || acl.Mountpoint == "" {
 		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("dataset %s has no mountpoint", name), nil)
+		return
+	}
+	if !aclEntryExists(acl, entry) {
+		writeError(r.Context(), w, http.StatusNotFound, fmt.Errorf("ACL entry %q not found on dataset %s", entry, name), nil)
 		return
 	}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -125,6 +125,20 @@ func datasetExists(name string) (bool, error) {
 	return false, nil
 }
 
+// snapshotExists reports whether a snapshot with the given name exists.
+func snapshotExists(name string) (bool, error) {
+	snaps, err := zfs.ListSnapshots()
+	if err != nil {
+		return false, err
+	}
+	for _, s := range snaps {
+		if s.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // apiError is returned as JSON for all non-2xx responses.
 // Tasks is populated for Ansible-backed operations so the UI can show the op-log
 // even when the request fails.

--- a/internal/api/zfs_handlers.go
+++ b/internal/api/zfs_handlers.go
@@ -268,6 +268,13 @@ func (h *Handler) createSnapshot(w http.ResponseWriter, r *http.Request) {
 		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid snapshot label"), nil)
 		return
 	}
+	if ok, err := datasetExists(req.Dataset); err != nil {
+		writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
+		return
+	} else if !ok {
+		writeError(r.Context(), w, http.StatusNotFound, fmt.Errorf("dataset %q not found", req.Dataset), nil)
+		return
+	}
 
 	recursive := "false"
 	if req.Recursive {
@@ -356,6 +363,13 @@ func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
 	parts := strings.SplitN(snapshot, "@", 2)
 	if len(parts) != 2 || !validZFSName(parts[0]) || !validSnapLabel(parts[1]) {
 		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid snapshot name (expected dataset@label)"), nil)
+		return
+	}
+	if ok, err := snapshotExists(snapshot); err != nil {
+		writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
+		return
+	} else if !ok {
+		writeError(r.Context(), w, http.StatusNotFound, fmt.Errorf("snapshot %q not found", snapshot), nil)
 		return
 	}
 
@@ -739,6 +753,13 @@ func (h *Handler) setAutoSnapshotProps(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if !validZFSName(name) {
 		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid dataset name"), nil)
+		return
+	}
+	if ok, err := datasetExists(name); err != nil {
+		writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
+		return
+	} else if !ok {
+		writeError(r.Context(), w, http.StatusNotFound, fmt.Errorf("dataset %q not found", name), nil)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- `createSnapshot`: returns 404 if source dataset does not exist (previously Ansible would fail with a cryptic error)
- `deleteSnapshot`: returns 404 if snapshot does not exist — new `snapshotExists` helper mirrors `datasetExists`
- `setAutoSnapshotProps`: returns 404 if dataset does not exist
- `removeACLEntry`: returns 404 if the specific ACL entry does not exist — `setfacl -x` on a missing entry was a silent no-op

Closes the **"Consistent dataset pre-checks"** and **"ACL remove doesn't verify entry exists first"** TODO items.

## Test plan
- [ ] `go build ./... && go vet ./...` pass
- [ ] `go test ./...` passes
- [ ] `DELETE /api/snapshots/tank/ds@nonexistent` → 404 JSON
- [ ] `POST /api/snapshots` with a nonexistent dataset → 404 JSON
- [ ] `PUT /api/auto-snapshot/tank/nonexistent` → 404 JSON
- [ ] `DELETE /api/acl/tank/ds?entry=user:nobody` when nobody has no ACL entry → 404 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)