### PR TITLE
feat: client-side name validation and SSE status badge

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -17,6 +17,7 @@
         <button class="tab-btn" data-tab="snapshots">Snapshots</button>
         <button class="tab-btn" data-tab="users">Users &amp; Groups</button>
       </nav>
+      <span id="sseStatus" class="sse-badge live">live</span>
       <span id="appVersion" class="app-version"></span>
       <button class="refresh-btn" id="refreshBtn" title="Refresh">&#8635;</button>
     </div>

--- a/static/js/datasets.js
+++ b/static/js/datasets.js
@@ -156,6 +156,8 @@ document.getElementById('newDatasetBtn').addEventListener('click', () => {
 });
 document.getElementById('datasetCancelBtn').addEventListener('click', () => datasetDialog.close());
 
+const reZFSName = /^[a-zA-Z][a-zA-Z0-9_.:-]*(\/[a-zA-Z][a-zA-Z0-9_.:-]*)*$/;
+
 document.getElementById('newDatasetForm').addEventListener('submit', async e => {
   e.preventDefault();
   const body = {
@@ -164,6 +166,10 @@ document.getElementById('newDatasetForm').addEventListener('submit', async e => 
     volsize: document.getElementById('ds-volsize').value.trim(),
     sparse:  document.getElementById('ds-sparse').checked,
   };
+  if (!reZFSName.test(body.name)) {
+    toast('Invalid dataset name', 'error');
+    return;
+  }
   for (const p of (state.schema?.dataset_properties || [])) {
     if (!p.create) continue;
     const el = document.getElementById('ds-' + p.name);

--- a/static/js/loader.js
+++ b/static/js/loader.js
@@ -125,13 +125,22 @@ let _pollInterval = null;  // setInterval handle; null when SSE is active
 let _sseRetryTimer = null; // setTimeout handle for SSE reconnect attempts
 let _es = null;            // active EventSource instance
 
+function setSseBadge(state) {
+  const el = document.getElementById('sseStatus');
+  if (!el) return;
+  el.className = 'sse-badge ' + state;
+  el.textContent = state;
+}
+
 function startPolling() {
   if (_pollInterval) return;
   _pollInterval = setInterval(loadAll, 30_000);
+  setSseBadge('polling');
 }
 
 function stopPolling() {
   if (_pollInterval) { clearInterval(_pollInterval); _pollInterval = null; }
+  setSseBadge('live');
 }
 
 export function startSSE() {

--- a/static/js/snapshots.js
+++ b/static/js/snapshots.js
@@ -1,5 +1,5 @@
 import { state, storeSet } from './store.js';
-import { api, esc, fmtBytes, fmtDate, showOpLog, showOpLogRunning } from './utils.js';
+import { api, esc, fmtBytes, fmtDate, showOpLog, showOpLogRunning, toast } from './utils.js';
 
 // ── Render: Snapshots ─────────────────────────────────────────────────────────
 let snapFilter = '';
@@ -144,11 +144,22 @@ document.getElementById('newSnapBtn').addEventListener('click', () => {
 });
 document.getElementById('snapCancelBtn').addEventListener('click', () => dialog.close());
 
+const reZFSName  = /^[a-zA-Z][a-zA-Z0-9_.:-]*(\/[a-zA-Z][a-zA-Z0-9_.:-]*)*$/;
+const reSnapLabel = /^[a-zA-Z0-9][a-zA-Z0-9_.:-]*$/;
+
 document.getElementById('newSnapForm').addEventListener('submit', async e => {
   e.preventDefault();
   const dataset = document.getElementById('snap-dataset').value.trim();
   const snapname = document.getElementById('snap-label').value.trim();
   const recursive = document.getElementById('snap-recursive').checked;
+  if (!reZFSName.test(dataset)) {
+    toast('Invalid dataset name', 'error');
+    return;
+  }
+  if (!reSnapLabel.test(snapname)) {
+    toast('Invalid snapshot label', 'error');
+    return;
+  }
   dialog.close();
   showOpLogRunning(`Creating snapshot…`);
   try {

--- a/static/style.css
+++ b/static/style.css
@@ -214,9 +214,29 @@ main {
 .load-high { color: var(--red); }
 .sw-na { color: var(--text-muted); }
 
+/* SSE connection status badge */
+.sse-badge {
+  font-size: 10px;
+  font-family: var(--font);
+  padding: 2px 7px;
+  border-radius: 8px;
+  white-space: nowrap;
+  margin-left: auto;
+}
+.sse-badge::before {
+  content: '● ';
+}
+.sse-badge.live {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.1);
+}
+.sse-badge.polling {
+  color: #facc15;
+  background: rgba(250, 204, 21, 0.1);
+}
+
 /* Header version badge */
 .app-version {
-  margin-left: auto;
   font-size: 11px;
   color: var(--text-muted);
   font-family: var(--font);


### PR DESCRIPTION
## Summary
- **Dataset create**: validates name against `reZFSName` regex before calling the API — shows a toast and leaves the dialog open on failure instead of a round-trip error
- **Snapshot create**: validates dataset name (`reZFSName`) and label (`reSnapLabel`) before calling the API  
- **SSE status badge**: subtle pill in the header showing `● live` (green) or `● polling` (amber); flips when `EventSource` closes and the client falls back to 30 s REST polling, reverts to live on reconnect

Closes the **"No client-side name validation"** and **"No visual indicator when SSE degrades to polling"** TODO items.

## Test plan
- [ ] Type an invalid dataset name (e.g. `123/foo`) → toast appears, dialog stays open, no API call
- [ ] Type a valid name → dialog closes and creation proceeds normally
- [ ] Type an invalid snapshot label → toast, no API call
- [ ] Block `/api/events` in devtools → badge flips to amber "polling"
- [ ] Unblock → badge returns to green "live"

🤖 Generated with [Claude Code](https://claude.com/claude-code)