### PR TITLE
feat: service management tab (Samba, NFS, iSCSI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 ## [Unreleased]
 
 ### Added
+- **Service management** — new Services tab with start/stop/restart/enable/disable controls for Samba, NFS, and iSCSI; `GET /api/services` returns live status for all three; mutations go through `service_control_linux.yml` (systemd) or `service_control_freebsd.yml` (rc.d) with full op-log display; status updates via SSE every 10 s; NFS stop shows a client-disconnect warning
 - **Network interface overview** — `GET /api/network` returns all interfaces with name, state (up/down), MAC, MTU, IPv4/IPv6 addresses, link speed, and RX/TX byte counters; displayed as a Network section in the Pools tab with state badges and muted virtual/loopback rows; Linux reads speed and counters from `/sys/class/net`; FreeBSD parses a single `ifconfig -a` call for speed
 
 ---

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -34,6 +34,7 @@
 | Request ID correlation   | v0.1.8 | Per-request `req_id` on all log lines; reads `X-Request-ID` from upstream proxies (nginx, Traefik) and echoes it back on response |
 | Authentication           | v0.1.9 | Session-based login, bcrypt password, `--set-password` CLI, trusted proxy delegation (`X-Remote-User`), per-IP rate limiting   |
 | Network interface overview | v0.1.10 | Read-only view of all interfaces: state badge, MAC, MTU, IPs, link speed, RX/TX counters; Linux via `/sys/class/net`, FreeBSD via `ifconfig -a` |
+| Service management         | v0.1.11 | Start/stop/restart/enable/disable Samba, NFS, iSCSI from the Services tab; live status via SSE; systemd on Linux, rc.d on FreeBSD; op-log for all mutations |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -563,6 +563,8 @@ sudo make uninstall
 | GET    | `/api/iscsi-targets`        | List all iSCSI targets                |
 | POST   | `/api/iscsi-targets`        | Create an iSCSI target for a zvol     |
 | DELETE | `/api/iscsi-targets`        | Remove an iSCSI target                |
+| GET    | `/api/services`             | List status of managed services (Samba, NFS, iSCSI) |
+| POST   | `/api/services/{name}/{action}` | Control a service (start/stop/restart/enable/disable) |
 
 ### POST /api/datasets
 
@@ -732,6 +734,7 @@ Server-Sent Events stream. The server pushes named events whenever data changes,
 | `iostat`             | Same JSON as `GET /api/iostat`                  | Pushed every 10 s always                  |
 | `user.query`         | Same JSON as `GET /api/users`                   | Pushed on write op + every 10 s on change |
 | `group.query`        | Same JSON as `GET /api/groups`                  | Pushed on write op + every 10 s on change |
+| `service.query`      | Same JSON as `GET /api/services`                | Pushed every 10 s on change               |
 
 Each event follows the SSE wire format:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -559,6 +559,13 @@
       </div>
       <div class="pool-card">
         <div class="pool-card-header">
+          <span class="pool-name">Service management</span>
+          <span class="health-badge badge-blue">systemd / rc.d</span>
+        </div>
+        <p>Start, stop, restart, enable, and disable Samba, NFS, and iSCSI from the Services tab. Live status badges update via SSE every 10 s. Mutations go through Ansible playbooks with full op-log display. Stopping NFS surfaces a client-disconnect warning.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
           <span class="pool-name">S.M.A.R.T. health</span>
           <span class="health-badge badge-green">smartctl</span>
         </div>

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -266,6 +266,8 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/schema", h.getSchema)
 	mux.HandleFunc("POST /api/auth/change-password", h.changePassword)
 	mux.HandleFunc("POST /api/auth/change-username", h.changeUsername)
+	mux.HandleFunc("GET /api/services", h.getServices)
+	mux.HandleFunc("POST /api/services/{service}/{action}", h.mutateService)
 }
 
 func (h *Handler) getSysInfo(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/service_handlers.go
+++ b/internal/api/service_handlers.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"runtime"
+
+	"dumpstore/internal/ansible"
+	"dumpstore/internal/system"
+)
+
+// validServiceName matches the logical service names we accept from clients.
+var validServiceName = regexp.MustCompile(`^[a-z][a-z0-9-]{0,30}$`)
+
+var validServiceActions = map[string]bool{
+	"start":   true,
+	"stop":    true,
+	"restart": true,
+	"enable":  true,
+	"disable": true,
+}
+
+// servicePlaybook returns the OS-appropriate service control playbook path.
+func servicePlaybook() string {
+	if runtime.GOOS == "freebsd" {
+		return "service_control_freebsd.yml"
+	}
+	return "service_control_linux.yml"
+}
+
+// getServices handles GET /api/services
+// Returns the status of all managed sharing services (Samba, NFS, iSCSI).
+func (h *Handler) getServices(w http.ResponseWriter, r *http.Request) {
+	writeJSON(r.Context(), w, system.ListServices())
+}
+
+// mutateService handles POST /api/services/{service}/{action}
+// Valid actions: start, stop, restart, enable, disable.
+func (h *Handler) mutateService(w http.ResponseWriter, r *http.Request) {
+	svc := r.PathValue("service")
+	action := r.PathValue("action")
+
+	if !validServiceName.MatchString(svc) {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid service name"), nil)
+		return
+	}
+	if !validServiceActions[action] {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid action %q", action), nil)
+		return
+	}
+
+	unitName := system.ServiceUnitName(svc)
+	if unitName == "" {
+		writeError(r.Context(), w, http.StatusNotFound, fmt.Errorf("unknown service: %s", svc), nil)
+		return
+	}
+
+	out, err := h.runOp(servicePlaybook(), map[string]string{
+		"service_name": unitName,
+		"action":       action,
+	})
+	auditLog(r.Context(), r, "service."+action, svc, err)
+	if err != nil {
+		var steps []ansible.TaskStep
+		if out != nil {
+			steps = out.Steps()
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		return
+	}
+	writeJSON(r.Context(), w, map[string]any{"service": svc, "tasks": out.Steps()})
+}

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -18,6 +18,7 @@ var ValidTopics = map[string]bool{
 	"user.query":         true,
 	"group.query":        true,
 	"ansible.progress":   true,
+	"service.query":      true,
 }
 
 // Broker is a thread-safe, topic-based pub/sub message broker.

--- a/internal/broker/poller.go
+++ b/internal/broker/poller.go
@@ -131,5 +131,7 @@ func pollOnce(publish func(string, any)) bool {
 		slog.Warn("poller: ListGroups failed", "err", err)
 	}
 
+	publish("service.query", system.ListServices())
+
 	return zfsOK
 }

--- a/internal/system/services.go
+++ b/internal/system/services.go
@@ -1,0 +1,124 @@
+package system
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// ServiceStatus describes a managed sharing service.
+type ServiceStatus struct {
+	Name        string `json:"name"`         // logical name: "samba", "nfs", "iscsi"
+	DisplayName string `json:"display_name"` // human-readable label
+	UnitName    string `json:"unit_name"`    // platform-specific unit/service name
+	Active      bool   `json:"active"`
+	Enabled     bool   `json:"enabled"`
+	State       string `json:"state"` // "active", "inactive", "failed", "unknown"
+}
+
+// managedServiceDef maps a logical service name to platform-specific unit names.
+type managedServiceDef struct {
+	name    string
+	display string
+	linux   string
+	freebsd string
+}
+
+var managedServices = []managedServiceDef{
+	{"samba", "Samba (SMB)", "smbd", "samba_server"},
+	{"nfs", "NFS Server", "nfs-kernel-server", "nfsd"},
+	{"iscsi", "iSCSI Target", "iscsid", "ctld"},
+}
+
+// ServiceUnitName returns the platform-specific unit name for a logical service
+// name (e.g. "samba" → "smbd" on Linux). Returns "" if the name is unknown.
+func ServiceUnitName(logical string) string {
+	isFreeBSD := runtime.GOOS == "freebsd"
+	for _, svc := range managedServices {
+		if svc.name == logical {
+			if isFreeBSD {
+				return svc.freebsd
+			}
+			return svc.linux
+		}
+	}
+	return ""
+}
+
+// ListServices returns the current status of all managed sharing services.
+// Failures for individual services are swallowed; the state is set to "unknown".
+func ListServices() []ServiceStatus {
+	isFreeBSD := runtime.GOOS == "freebsd"
+	out := make([]ServiceStatus, 0, len(managedServices))
+	for _, svc := range managedServices {
+		unit := svc.linux
+		if isFreeBSD {
+			unit = svc.freebsd
+		}
+		st := ServiceStatus{
+			Name:        svc.name,
+			DisplayName: svc.display,
+			UnitName:    unit,
+			State:       "unknown",
+		}
+		if isFreeBSD {
+			st.Active, st.Enabled, st.State = serviceStatusFreeBSD(unit)
+		} else {
+			st.Active, st.Enabled, st.State = serviceStatusLinux(unit)
+		}
+		out = append(out, st)
+	}
+	return out
+}
+
+// serviceStatusLinux queries systemd for the unit's active and enabled states.
+func serviceStatusLinux(unit string) (active, enabled bool, state string) {
+	state = "unknown"
+	if err := exec.Command("systemctl", "is-active", "--quiet", unit).Run(); err == nil {
+		active = true
+		state = "active"
+	} else {
+		// is-active exits 3 for inactive, 1 for failed/other — distinguish them.
+		if svcExitCode(err) == 3 {
+			state = "inactive"
+		} else {
+			// Check whether it's explicitly failed.
+			if exec.Command("systemctl", "is-failed", "--quiet", unit).Run() == nil {
+				state = "failed"
+			} else {
+				state = "inactive"
+			}
+		}
+	}
+	if exec.Command("systemctl", "is-enabled", "--quiet", unit).Run() == nil {
+		enabled = true
+	}
+	return
+}
+
+// serviceStatusFreeBSD queries rc.d for the service's running and enabled states.
+func serviceStatusFreeBSD(unit string) (active, enabled bool, state string) {
+	state = "unknown"
+	if exec.Command("service", unit, "status").Run() == nil {
+		active = true
+		state = "active"
+	} else {
+		state = "inactive"
+	}
+	// sysrc -n <key> prints the value from rc.conf; "YES" means enabled.
+	key := strings.ReplaceAll(unit, "-", "_") + "_enable"
+	if out, err := exec.Command("sysrc", "-n", key).Output(); err == nil {
+		if strings.TrimSpace(string(out)) == "YES" {
+			enabled = true
+		}
+	}
+	return
+}
+
+// svcExitCode extracts the process exit code from an *exec.ExitError.
+func svcExitCode(err error) int {
+	if ee, ok := err.(*exec.ExitError); ok {
+		return ee.ExitCode()
+	}
+	return -1
+}

--- a/playbooks/service_control_freebsd.yml
+++ b/playbooks/service_control_freebsd.yml
@@ -1,0 +1,32 @@
+---
+# Required vars:
+#   service_name  — rc.d service name (e.g. samba_server, nfsd, ctld)
+#   action        — one of: start, stop, restart, enable, disable
+- name: Control rc.d service
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Assert required vars
+      ansible.builtin.assert:
+        that:
+          - service_name is defined and service_name != ""
+          - action in ['start', 'stop', 'restart', 'enable', 'disable']
+        fail_msg: "service_name and a valid action are required"
+
+    - name: "Enable {{ service_name }} in rc.conf"
+      ansible.builtin.command:
+        argv: ["sysrc", "{{ service_name }}_enable=YES"]
+      when: action == 'enable'
+      changed_when: true
+
+    - name: "Disable {{ service_name }} in rc.conf"
+      ansible.builtin.command:
+        argv: ["sysrc", "{{ service_name }}_enable=NO"]
+      when: action == 'disable'
+      changed_when: true
+
+    - name: "{{ action | capitalize }} {{ service_name }}"
+      ansible.builtin.command:
+        argv: ["service", "{{ service_name }}", "{{ action }}"]
+      when: action in ['start', 'stop', 'restart']
+      changed_when: true

--- a/playbooks/service_control_linux.yml
+++ b/playbooks/service_control_linux.yml
@@ -1,0 +1,25 @@
+---
+# Required vars:
+#   service_name  — systemd unit name (e.g. smbd, nfs-kernel-server, iscsid)
+#   action        — one of: start, stop, restart, enable, disable
+- name: Control systemd service
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Assert required vars
+      ansible.builtin.assert:
+        that:
+          - service_name is defined and service_name != ""
+          - action in ['start', 'stop', 'restart', 'enable', 'disable']
+        fail_msg: "service_name and a valid action are required"
+
+    - name: "{{ action | capitalize }} {{ service_name }}"
+      ansible.builtin.systemd:
+        name: "{{ service_name }}"
+        state: >-
+          {{ 'started' if action == 'start' else
+             ('stopped' if action == 'stop' else
+             ('restarted' if action == 'restart' else omit)) }}
+        enabled: >-
+          {{ true if action == 'enable' else
+             (false if action == 'disable' else omit) }}

--- a/static/app.js
+++ b/static/app.js
@@ -4,6 +4,7 @@ import { renderSysInfo, renderSoftware, renderNetwork, renderPools, renderIOStat
 import { renderDatasets } from './js/datasets.js';
 import { renderSnapshots } from './js/snapshots.js';
 import { renderUsers, renderGroups, renderSambaUsers, renderSMBHomes, renderTimeMachine } from './js/users.js';
+import { renderServices } from './js/services.js';
 import { api, esc, toast, showOpLog, showOpLogRunning } from './js/utils.js';
 
 // ── Store subscriptions ──────────────────────────────────────────────────────
@@ -22,6 +23,7 @@ subscribe(['groups'],                                           renderGroups);
 subscribe(['sambaUsers', 'sambaAvailable', 'users'],            renderSambaUsers);
 subscribe(['smbHomes', 'datasets'],                             renderSMBHomes);
 subscribe(['timeMachineShares'],                                renderTimeMachine);
+subscribe(['services'],                                         renderServices);
 subscribe(['schema'],                                           buildFormSelects);
 
 // ── Tabs ──────────────────────────────────────────────────────────────────────

--- a/static/index.html
+++ b/static/index.html
@@ -16,6 +16,7 @@
         <button class="tab-btn" data-tab="datasets">Datasets</button>
         <button class="tab-btn" data-tab="snapshots">Snapshots</button>
         <button class="tab-btn" data-tab="users">Users &amp; Groups</button>
+        <button class="tab-btn" data-tab="services">Services</button>
       </nav>
       <span id="sseStatus" class="sse-badge live">live</span>
       <span id="appVersion" class="app-version"></span>
@@ -138,6 +139,17 @@
       </div>
       <div id="smb-users-wrap">
         <div class="loading">Loading SMB users…</div>
+      </div>
+    </section>
+
+    <!-- SERVICES TAB -->
+    <section class="tab-pane" id="tab-services">
+      <div class="section-header">
+        <h2>Services</h2>
+        <span class="muted">Manage sharing services (Samba, NFS, iSCSI)</span>
+      </div>
+      <div id="services-wrap">
+        <div class="loading">Loading services…</div>
       </div>
     </section>
   </main>

--- a/static/js/loader.js
+++ b/static/js/loader.js
@@ -42,7 +42,7 @@ export async function loadAll() {
   try {
     // Use null as the sentinel for failed fetches so we can distinguish
     // "endpoint returned empty" from "fetch failed" and preserve last-known-good state.
-    const [pools, poolStatuses, version, sysinfo, network, datasets, snapshots, users, groups, smbData, smbShares, smbHomes, tmShares, iscsiTargets, scrubSchedules, autoSnapshotSchedules, schema] = await Promise.all([
+    const [pools, poolStatuses, version, sysinfo, network, datasets, snapshots, users, groups, smbData, smbShares, smbHomes, tmShares, iscsiTargets, scrubSchedules, autoSnapshotSchedules, schema, services] = await Promise.all([
       api('GET', '/api/pools').catch(() => null),
       api('GET', '/api/poolstatus').catch(() => null),
       api('GET', '/api/version').catch(() => null),
@@ -60,6 +60,7 @@ export async function loadAll() {
       api('GET', '/api/scrub-schedules').catch(() => null),
       api('GET', '/api/auto-snapshot-schedules').catch(() => null),
       api('GET', '/api/schema').catch(() => null),
+      api('GET', '/api/services').catch(() => null),
     ]);
     storeBatch(() => {
       if (pools !== null) storeSet('pools', pools);
@@ -87,6 +88,7 @@ export async function loadAll() {
       }
       if (autoSnapshotSchedules !== null) storeSet('autoSnapshot', autoSnapshotSchedules);
       if (schema !== null) storeSet('schema', schema);
+      if (services !== null) storeSet('services', services);
     });
   } catch (e) {
     toast('Load failed: ' + e.message, 'err');
@@ -121,6 +123,7 @@ const sseTopicMap = {
   'iostat':             'iostat',
   'user.query':         'users',
   'group.query':        'groups',
+  'service.query':      'services',
 };
 
 let _pollInterval = null;  // setInterval handle; null when SSE is active

--- a/static/js/services.js
+++ b/static/js/services.js
@@ -1,0 +1,69 @@
+import { state } from './store.js';
+import { esc, api, toast, showOpLogRunning, showOpLog } from './utils.js';
+
+export function renderServices() {
+  const wrap = document.getElementById('services-wrap');
+  if (!wrap) return;
+
+  const svcs = state.services || [];
+  if (!svcs.length) {
+    wrap.innerHTML = '<p class="muted">No managed services found.</p>';
+    return;
+  }
+
+  wrap.innerHTML = `
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th>Service</th>
+          <th>Unit</th>
+          <th>Status</th>
+          <th>Enabled</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${svcs.map(s => `
+          <tr>
+            <td>${esc(s.display_name)}</td>
+            <td class="mono">${esc(s.unit_name)}</td>
+            <td><span class="svc-badge ${esc(s.state)}">${esc(s.state)}</span></td>
+            <td>${s.enabled
+              ? '<span class="svc-enabled">yes</span>'
+              : '<span class="svc-disabled">no</span>'
+            }</td>
+            <td class="svc-actions">
+              ${s.active
+                ? `<button class="btn-del" data-svc="${esc(s.name)}" data-action="stop">Stop</button>
+                   <button class="btn-edit" data-svc="${esc(s.name)}" data-action="restart">Restart</button>`
+                : `<button class="btn-edit" data-svc="${esc(s.name)}" data-action="start">Start</button>`
+              }
+              ${s.enabled
+                ? `<button class="btn-del" data-svc="${esc(s.name)}" data-action="disable">Disable</button>`
+                : `<button class="btn-edit" data-svc="${esc(s.name)}" data-action="enable">Enable</button>`
+              }
+            </td>
+          </tr>`).join('')}
+      </tbody>
+    </table>`;
+
+  wrap.querySelectorAll('[data-action]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const svc = btn.dataset.svc;
+      const action = btn.dataset.action;
+
+      if (svc === 'nfs' && action === 'stop') {
+        if (!confirm('Stopping NFS will disconnect all mounted clients. Continue?')) return;
+      }
+
+      showOpLogRunning(`${action} ${svc}`);
+      try {
+        const res = await api('POST', `/api/services/${svc}/${action}`);
+        showOpLog(`${action} ${svc}`, res?.tasks);
+        toast(`${svc} ${action} OK`, 'ok');
+      } catch (err) {
+        showOpLog(`${action} ${svc}`, err.tasks, err.message);
+      }
+    });
+  });
+}

--- a/static/js/store.js
+++ b/static/js/store.js
@@ -30,6 +30,7 @@ export const state = {
   selectedSnaps: new Set(),     // full snapshot names checked for batch delete
   schema: null,                 // GET /api/schema response
   network: null,                // GET /api/network response
+  services: [],                 // GET /api/services — [{name, display_name, unit_name, active, enabled, state}]
 };
 
 // ── Reactive store ──────────────────────────────────────────────────────────

--- a/static/style.css
+++ b/static/style.css
@@ -776,3 +776,13 @@ dialog label select:focus { border-color: var(--accent); }
 .btn-iscsi:hover { background: var(--surface); color: var(--text); }
 .btn-iscsi.active { background: color-mix(in srgb, var(--accent) 15%, var(--surface2)); color: var(--accent); border-color: var(--accent-dim); }
 .btn-iscsi.active:hover { background: color-mix(in srgb, var(--accent) 25%, var(--surface2)); }
+
+/* ── Services tab ───────────────────────────────────────────────────────────── */
+.svc-badge { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+.svc-badge.active   { background: #0d3d2e; color: var(--green); }
+.svc-badge.inactive { background: var(--surface2); color: var(--text-muted); }
+.svc-badge.failed   { background: #3d1010; color: var(--red); }
+.svc-badge.unknown  { background: var(--surface2); color: var(--text-muted); }
+.svc-enabled  { color: var(--green); }
+.svc-disabled { color: var(--text-muted); }
+.svc-actions { display: flex; gap: 4px; flex-wrap: wrap; }

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -60,6 +60,8 @@ All endpoints are served at `http://<host>:8080`. The API is JSON-over-HTTP; all
 | GET    | `/api/iscsi-targets`           | List all iSCSI targets |
 | POST   | `/api/iscsi-targets`           | Create an iSCSI target for a zvol |
 | DELETE | `/api/iscsi-targets`           | Remove an iSCSI target |
+| GET    | `/api/services`                | List status of all managed services |
+| POST   | `/api/services/{name}/{action}` | Control a service (start/stop/restart/enable/disable) |
 
 ---
 
@@ -300,6 +302,39 @@ Returns Ansible task steps.
 ### DELETE /api/iscsi-targets?iqn=\<iqn\>&zvol=\<zvol\>
 
 Remove an iSCSI target and its backstore. Both query parameters are required.
+
+Returns Ansible task steps.
+
+---
+
+## Services
+
+Manage the sharing daemons dumpstore controls (Samba, NFS, iSCSI). Status reads happen directly via `systemctl`/`service` — no Ansible overhead. Mutations (start/stop/restart/enable/disable) go through playbooks with op-log.
+
+Logical service names: `samba`, `nfs`, `iscsi`.
+
+### GET /api/services
+
+Returns the status of all managed services.
+
+```json
+[
+  {
+    "name": "samba",
+    "display_name": "Samba (SMB)",
+    "unit_name": "smbd",
+    "active": true,
+    "enabled": true,
+    "state": "active"
+  }
+]
+```
+
+`state` values: `active`, `inactive`, `failed`, `unknown`.
+
+### POST /api/services/{name}/{action}
+
+Control a service. Valid actions: `start`, `stop`, `restart`, `enable`, `disable`.
 
 Returns Ansible task steps.
 


### PR DESCRIPTION
Closes #58

## Summary
- New **Services tab** with start/stop/restart/enable/disable controls for Samba, NFS, and iSCSI
- `GET /api/services` reads status directly via `systemctl`/`service` (no Ansible overhead); `POST /api/services/{name}/{action}` runs `service_control_linux.yml` (systemd) or `service_control_freebsd.yml` (rc.d) with full op-log
- Status updates via SSE (`service.query` topic) every 10 s on change
- NFS stop shows a client-disconnect warning before proceeding
- Buttons use the existing `btn-edit`/`btn-del` theme

## Test plan
- [ ] `GET /api/services` returns all three services with `name`, `state`, `enabled`, `unit_name`
- [ ] Start an inactive service → op-log dialog shown, badge updates on next SSE tick
- [ ] Stop a running service → op-log shown, toast shown
- [ ] Restart → works end to end
- [ ] Enable/disable → `systemctl is-enabled` reflects the change
- [ ] Stop NFS → confirmation warning fires before API call
- [ ] Invalid service name → 400; invalid action → 400
- [ ] `go build ./...` and `go vet ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)