### PR TITLE
feat: TLS/HTTPS support (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 ## [Unreleased]
 
 ### Added
+- **TLS / HTTPS support** — `--tls` flag enables HTTPS; self-signed ECDSA-P256 cert generation via `tls_gencert.yml` (openssl); path loader (`PATCH /api/tls/config`) validates and loads existing certs (Let's Encrypt, Certbot, acme.sh); ACME issuance and renewal via `lego` (`POST /api/tls/acme/issue`, `POST /api/tls/acme/renew`); HTTP→HTTPS redirect listener on `--http-port` (default 80); TLS status card in Users tab with cert CN, SANs, expiry countdown; `lego` is an optional dependency (warn if missing and ACME is configured)
 - **Service management** — new Services tab with start/stop/restart/enable/disable controls for Samba, NFS, and iSCSI; `GET /api/services` returns live status for all three; mutations go through `service_control_linux.yml` (systemd) or `service_control_freebsd.yml` (rc.d) with full op-log display; status updates via SSE every 10 s; NFS stop shows a client-disconnect warning
 - **Network interface overview** — `GET /api/network` returns all interfaces with name, state (up/down), MAC, MTU, IPv4/IPv6 addresses, link speed, and RX/TX byte counters; displayed as a Network section in the Pools tab with state badges and muted virtual/loopback rows; Linux reads speed and counters from `/sys/class/net`; FreeBSD parses a single `ifconfig -a` call for speed
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -35,6 +35,7 @@
 | Authentication           | v0.1.9 | Session-based login, bcrypt password, `--set-password` CLI, trusted proxy delegation (`X-Remote-User`), per-IP rate limiting   |
 | Network interface overview | v0.1.10 | Read-only view of all interfaces: state badge, MAC, MTU, IPs, link speed, RX/TX counters; Linux via `/sys/class/net`, FreeBSD via `ifconfig -a` |
 | Service management         | v0.1.11 | Start/stop/restart/enable/disable Samba, NFS, iSCSI from the Services tab; live status via SSE; systemd on Linux, rc.d on FreeBSD; op-log for all mutations |
+| TLS / HTTPS                | v0.1.12 | `--tls` flag; self-signed cert generation (openssl via Ansible); path loader for existing certs; ACME issuance/renewal via `lego`; HTTP→HTTPS redirect; cert status card with expiry countdown |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ dumpstore runs as root (required for ZFS). See [SECURITY.md](SECURITY.md) for no
 | SMB sharing (optional) | `samba` (`smbd`, `net`, `pdbedit`); for ZFS ACL passthrough via `sharesmb` also install `samba-vfs-modules` (Debian/Ubuntu) or `samba-vfs` (RHEL/Fedora) | `samba` pkg |
 | NFSv4 ACLs (optional)  | `nfs4-acl-tools` pkg (`nfs4_getfacl`/`nfs4_setfacl`)      | `nfs4-acl-tools` port                        |
 | iSCSI (optional)       | `targetcli-fb` (`targetcli`)                               | built-in `ctld`                              |
+| TLS / ACME (optional)  | `openssl` (usually pre-installed); `lego` for ACME         | same                                         |
 | Build                  | Go 1.22+                                                  | Go 1.22+                                     |
 
 Go and Ansible are the only hard requirements. ZFS must be available on the target machine; the binary itself builds and runs on any platform.
@@ -352,6 +353,17 @@ dnf install targetcli
 # FreeBSD — iSCSI targets (ctld is built-in, just enable the service)
 sysrc ctld_enable=YES
 service ctld start
+
+# ACME cert issuance via Let's Encrypt (lego) — only needed if using --tls with ACME
+# Debian/Ubuntu
+apt install lego
+# or download a release binary: https://github.com/go-acme/lego/releases
+
+# RHEL/Fedora
+dnf install lego
+
+# FreeBSD
+pkg install lego
 ```
 
 ## Contributing

--- a/docs/index.html
+++ b/docs/index.html
@@ -566,6 +566,13 @@
       </div>
       <div class="pool-card">
         <div class="pool-card-header">
+          <span class="pool-name">TLS / HTTPS</span>
+          <span class="health-badge badge-blue">--tls</span>
+        </div>
+        <p>Enable HTTPS with <code>--tls</code>. Generate a self-signed ECDSA-P256 certificate via the UI (openssl, via Ansible), load an existing cert from disk (Let's Encrypt, Certbot, acme.sh), or issue and renew automatically via <strong>lego</strong> (ACME / Let's Encrypt). HTTP redirects to HTTPS automatically. Cert status card shows CN, SANs, and expiry countdown.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
           <span class="pool-name">S.M.A.R.T. health</span>
           <span class="health-badge badge-green">smartctl</span>
         </div>

--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,7 @@ do_install() {
     need go
     need ansible-playbook
     need git
+    command -v lego >/dev/null 2>&1 || echo "  [warn] lego not found — ACME cert issuance (Let's Encrypt) will not be available"
 
     # Check we're in the repo root
     [ -f "main.go" ]    || die "run this script from the dumpstore repository root"

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -268,6 +268,12 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/auth/change-username", h.changeUsername)
 	mux.HandleFunc("GET /api/services", h.getServices)
 	mux.HandleFunc("POST /api/services/{service}/{action}", h.mutateService)
+
+	mux.HandleFunc("GET /api/tls/status", h.getTLSStatus)
+	mux.HandleFunc("POST /api/tls/gencert", h.tlsGenCert)
+	mux.HandleFunc("PATCH /api/tls/config", h.tlsSetConfig)
+	mux.HandleFunc("POST /api/tls/acme/issue", h.tlsAcmeIssue)
+	mux.HandleFunc("POST /api/tls/acme/renew", h.tlsAcmeRenew)
 }
 
 func (h *Handler) getSysInfo(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/tls_handlers.go
+++ b/internal/api/tls_handlers.go
@@ -1,0 +1,343 @@
+package api
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"time"
+)
+
+var (
+	reDomain = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
+	reEmail  = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
+	reTLSPath = regexp.MustCompile(`^/[^\x00;|&$` + "`" + `]+$`)
+)
+
+type tlsStatusResponse struct {
+	Enabled      bool     `json:"enabled"`
+	CertPath     string   `json:"cert_path,omitempty"`
+	KeyPath      string   `json:"key_path,omitempty"`
+	CN           string   `json:"cn,omitempty"`
+	SANs         []string `json:"sans,omitempty"`
+	ExpiresAt    string   `json:"expires_at,omitempty"`
+	DaysRemaining int     `json:"days_remaining,omitempty"`
+	SelfSigned   bool     `json:"self_signed,omitempty"`
+	ACMEEmail    string   `json:"acme_email,omitempty"`
+	ACMEDomain   string   `json:"acme_domain,omitempty"`
+}
+
+// getTLSStatus returns the current TLS configuration and cert metadata.
+func (h *Handler) getTLSStatus(w http.ResponseWriter, r *http.Request) {
+	resp := tlsStatusResponse{
+		Enabled:    h.authCfg.TLSEnabled,
+		CertPath:   h.authCfg.TLSCertPath,
+		KeyPath:    h.authCfg.TLSKeyPath,
+		ACMEEmail:  h.authCfg.ACMEEmail,
+		ACMEDomain: h.authCfg.ACMEDomain,
+	}
+
+	if h.authCfg.TLSCertPath != "" {
+		if meta, err := parseCertMeta(h.authCfg.TLSCertPath); err == nil {
+			resp.CN = meta.cn
+			resp.SANs = meta.sans
+			resp.ExpiresAt = meta.expiresAt.Format(time.RFC3339)
+			resp.DaysRemaining = int(time.Until(meta.expiresAt).Hours() / 24)
+			resp.SelfSigned = meta.selfSigned
+		}
+	}
+
+	writeJSON(r.Context(), w, resp)
+}
+
+// tlsGenCert generates a self-signed certificate via the tls_gencert.yml playbook.
+func (h *Handler) tlsGenCert(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Hostname string `json:"hostname"`
+		CertDir  string `json:"cert_dir"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid request body"), nil)
+		return
+	}
+	if req.Hostname == "" {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("hostname is required"), nil)
+		return
+	}
+	if !reDomain.MatchString(req.Hostname) {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid hostname"), nil)
+		return
+	}
+	if req.CertDir == "" {
+		req.CertDir = "/etc/dumpstore/tls"
+	}
+	if !reTLSPath.MatchString(req.CertDir) {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid cert_dir"), nil)
+		return
+	}
+
+	out, err := h.runOp("tls_gencert.yml", map[string]string{
+		"hostname": req.Hostname,
+		"cert_dir": req.CertDir,
+	})
+	if err != nil {
+		if out != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
+		} else {
+			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
+		}
+		return
+	}
+
+	certPath := req.CertDir + "/cert.pem"
+	keyPath := req.CertDir + "/key.pem"
+
+	cfgOut, cfgErr := h.runOp("tls_set_config.yml", map[string]string{
+		"config_path": h.configPath,
+		"cert_path":   certPath,
+		"key_path":    keyPath,
+		"enabled":     "true",
+	})
+	if cfgErr != nil {
+		steps := out.Steps()
+		if cfgOut != nil {
+			steps = append(steps, cfgOut.Steps()...)
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, cfgErr, steps)
+		return
+	}
+
+	h.authCfg.TLSCertPath = certPath
+	h.authCfg.TLSKeyPath = keyPath
+	h.authCfg.TLSEnabled = true
+
+	auditLog(r.Context(), r, "tls.gencert", req.Hostname, nil)
+
+	steps := out.Steps()
+	steps = append(steps, cfgOut.Steps()...)
+	writeJSON(r.Context(), w, map[string]any{"tasks": steps})
+}
+
+// tlsSetConfig validates and persists an existing cert+key pair.
+func (h *Handler) tlsSetConfig(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		CertPath string `json:"cert_path"`
+		KeyPath  string `json:"key_path"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid request body"), nil)
+		return
+	}
+	if req.CertPath == "" || req.KeyPath == "" {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("cert_path and key_path are required"), nil)
+		return
+	}
+	if !reTLSPath.MatchString(req.CertPath) || !reTLSPath.MatchString(req.KeyPath) {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid path"), nil)
+		return
+	}
+
+	// Validate the cert+key pair before persisting.
+	if _, err := tls.LoadX509KeyPair(req.CertPath, req.KeyPath); err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid cert/key pair: %w", err), nil)
+		return
+	}
+
+	out, err := h.runOp("tls_set_config.yml", map[string]string{
+		"config_path": h.configPath,
+		"cert_path":   req.CertPath,
+		"key_path":    req.KeyPath,
+		"enabled":     "true",
+	})
+	if err != nil {
+		if out != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
+		} else {
+			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
+		}
+		return
+	}
+
+	h.authCfg.TLSCertPath = req.CertPath
+	h.authCfg.TLSKeyPath = req.KeyPath
+	h.authCfg.TLSEnabled = true
+
+	auditLog(r.Context(), r, "tls.set_config", req.CertPath, nil)
+	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})
+}
+
+// tlsAcmeIssue issues a certificate via ACME using lego.
+func (h *Handler) tlsAcmeIssue(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Email   string `json:"email"`
+		Domain  string `json:"domain"`
+		CertDir string `json:"cert_dir"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid request body"), nil)
+		return
+	}
+	if req.Email == "" || req.Domain == "" {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("email and domain are required"), nil)
+		return
+	}
+	if !reEmail.MatchString(req.Email) {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid email address"), nil)
+		return
+	}
+	if !reDomain.MatchString(req.Domain) {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid domain name"), nil)
+		return
+	}
+	if req.CertDir == "" {
+		req.CertDir = "/etc/dumpstore/tls/acme"
+	}
+	if !reTLSPath.MatchString(req.CertDir) {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid cert_dir"), nil)
+		return
+	}
+
+	out, err := h.runOp("tls_acme_issue.yml", map[string]string{
+		"email":    req.Email,
+		"domain":   req.Domain,
+		"cert_dir": req.CertDir,
+	})
+	if err != nil {
+		if out != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
+		} else {
+			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
+		}
+		return
+	}
+
+	// lego stores certs at <cert_dir>/certificates/<domain>.crt and .key
+	certPath := req.CertDir + "/certificates/" + req.Domain + ".crt"
+	keyPath := req.CertDir + "/certificates/" + req.Domain + ".key"
+
+	cfgOut, cfgErr := h.runOp("tls_set_config.yml", map[string]string{
+		"config_path": h.configPath,
+		"cert_path":   certPath,
+		"key_path":    keyPath,
+		"enabled":     "true",
+	})
+	if cfgErr != nil {
+		steps := out.Steps()
+		if cfgOut != nil {
+			steps = append(steps, cfgOut.Steps()...)
+		}
+		writeError(r.Context(), w, http.StatusInternalServerError, cfgErr, steps)
+		return
+	}
+
+	h.authCfg.TLSCertPath = certPath
+	h.authCfg.TLSKeyPath = keyPath
+	h.authCfg.TLSEnabled = true
+	h.authCfg.ACMEEnabled = true
+	h.authCfg.ACMEEmail = req.Email
+	h.authCfg.ACMEDomain = req.Domain
+
+	auditLog(r.Context(), r, "tls.acme_issue", req.Domain, nil)
+
+	steps := out.Steps()
+	steps = append(steps, cfgOut.Steps()...)
+	writeJSON(r.Context(), w, map[string]any{"tasks": steps})
+}
+
+// tlsAcmeRenew renews the ACME certificate using stored config.
+func (h *Handler) tlsAcmeRenew(w http.ResponseWriter, r *http.Request) {
+	if !h.authCfg.ACMEEnabled {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("ACME is not configured"), nil)
+		return
+	}
+	if h.authCfg.ACMEEmail == "" || h.authCfg.ACMEDomain == "" {
+		writeError(r.Context(), w, http.StatusBadRequest, errors.New("ACME email and domain are not set"), nil)
+		return
+	}
+
+	// Derive cert_dir from stored cert path (parent of certificates/<domain>.crt)
+	certDir := "/etc/dumpstore/tls/acme"
+	if h.authCfg.TLSCertPath != "" {
+		// Walk up two levels from <cert_dir>/certificates/<domain>.crt
+		certDir = certDirFromCertPath(h.authCfg.TLSCertPath)
+	}
+
+	out, err := h.runOp("tls_acme_renew.yml", map[string]string{
+		"email":    h.authCfg.ACMEEmail,
+		"domain":   h.authCfg.ACMEDomain,
+		"cert_dir": certDir,
+	})
+	if err != nil {
+		if out != nil {
+			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
+		} else {
+			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
+		}
+		return
+	}
+
+	auditLog(r.Context(), r, "tls.acme_renew", h.authCfg.ACMEDomain, nil)
+	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})
+}
+
+// certDirFromCertPath derives the lego root dir from a cert path of the form
+// <certDir>/certificates/<domain>.crt
+func certDirFromCertPath(certPath string) string {
+	// Strip /certificates/<domain>.crt — go up two path segments
+	for i := len(certPath) - 1; i >= 0; i-- {
+		if certPath[i] == '/' {
+			certPath = certPath[:i]
+			break
+		}
+	}
+	for i := len(certPath) - 1; i >= 0; i-- {
+		if certPath[i] == '/' {
+			return certPath[:i]
+		}
+	}
+	return "/etc/dumpstore/tls/acme"
+}
+
+type certMeta struct {
+	cn         string
+	sans       []string
+	expiresAt  time.Time
+	selfSigned bool
+}
+
+func parseCertMeta(certPath string) (*certMeta, error) {
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("failed to decode PEM block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var sans []string
+	for _, name := range cert.DNSNames {
+		sans = append(sans, name)
+	}
+	for _, ip := range cert.IPAddresses {
+		sans = append(sans, ip.String())
+	}
+
+	selfSigned := cert.Issuer.String() == cert.Subject.String()
+
+	return &certMeta{
+		cn:         cert.Subject.CommonName,
+		sans:       sans,
+		expiresAt:  cert.NotAfter,
+		selfSigned: selfSigned,
+	}, nil
+}

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -32,11 +32,21 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 
 // Config holds all authentication configuration persisted to disk.
 type Config struct {
-	Username          string   `json:"username"`
-	PasswordHash      string   `json:"password_hash"`
-	SessionTTL        Duration `json:"session_ttl"`
-	TrustedProxies    []string `json:"trusted_proxies"`
-	UnprotectedPaths  []string `json:"unprotected_paths"`
+	Username         string   `json:"username"`
+	PasswordHash     string   `json:"password_hash"`
+	SessionTTL       Duration `json:"session_ttl"`
+	TrustedProxies   []string `json:"trusted_proxies"`
+	UnprotectedPaths []string `json:"unprotected_paths"`
+
+	// TLS configuration
+	TLSEnabled  bool   `json:"tls_enabled"`
+	TLSCertPath string `json:"tls_cert_path"`
+	TLSKeyPath  string `json:"tls_key_path"`
+
+	// ACME (Let's Encrypt via lego)
+	ACMEEnabled bool   `json:"acme_enabled"`
+	ACMEEmail   string `json:"acme_email"`
+	ACMEDomain  string `json:"acme_domain"`
 }
 
 // defaults fills zero-value fields with sensible defaults.

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -683,6 +683,7 @@ func softwareVersions() []SoftwareTool {
 		{Name: "zfs-auto-snapshot", Version: probePresence("zfs-auto-snapshot")},
 		{Name: "Samba (smbd)", Version: probeVersion("smbd", "--version")},
 		{Name: "iSCSI backend", Version: probeISCSIBackend()},
+		{Name: "lego (ACME)", Version: probeVersion("lego", "--version")},
 		{Name: "Package manager", Version: detectPkgManager()},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -32,12 +32,15 @@ var version = "dev"
 
 func main() {
 	var (
-		addr        = flag.String("addr", ":8080", "Listen address")
+		addr        = flag.String("addr", ":8080", "Listen address (used when --tls is not set)")
 		baseDir     = flag.String("dir", "", "Base directory (contains playbooks/ and static/); defaults to executable location")
 		debug       = flag.Bool("debug", false, "Enable debug log level")
 		showVersion = flag.Bool("version", false, "Print version and exit")
 		configPath  = flag.String("config", "/etc/dumpstore/dumpstore.conf", "Config file path")
 		setPassword = flag.Bool("set-password", false, "Set admin password and exit")
+		tlsFlag     = flag.Bool("tls", false, "Enable HTTPS (requires tls_cert_path and tls_key_path in config)")
+		tlsPort     = flag.String("tls-port", "443", "HTTPS listen port")
+		httpPort    = flag.String("http-port", "80", "HTTP listen port for redirect to HTTPS (used when --tls is set)")
 	)
 	flag.Parse()
 
@@ -88,6 +91,11 @@ func main() {
 		slog.Error("failed to load config", "err", err)
 		os.Exit(1)
 	}
+	if cfg.ACMEEnabled {
+		if _, err := exec.LookPath("lego"); err != nil {
+			slog.Warn("lego not found in PATH — ACME cert issuance/renewal will fail")
+		}
+	}
 	if cfg.PasswordHash == "" {
 		slog.Warn("no password configured — binding to loopback only; run with --set-password to configure authentication")
 		*addr = "127.0.0.1:8080"
@@ -112,21 +120,56 @@ func main() {
 	mux.Handle("/", http.FileServer(http.Dir(staticDir)))
 
 	authMW := auth.NewMiddleware(cfg, store)
-	srv := &http.Server{Addr: *addr, Handler: requestLogger(authMW.Wrap(mux))}
+	handler := requestLogger(authMW.Wrap(mux))
 
-	// Shut down the HTTP server when the signal context is cancelled.
-	go func() {
-		<-ctx.Done()
-		slog.Info("dumpstore shutting down")
-		if err := srv.Shutdown(context.Background()); err != nil {
-			slog.Error("server shutdown error", "err", err)
+	if *tlsFlag && cfg.TLSCertPath != "" && cfg.TLSKeyPath != "" {
+		httpsAddr := ":" + *tlsPort
+		srv := &http.Server{Addr: httpsAddr, Handler: handler}
+
+		// HTTP redirect server: plain HTTP → HTTPS.
+		redirectAddr := ":" + *httpPort
+		redirectSrv := &http.Server{
+			Addr: redirectAddr,
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				target := "https://" + r.Host + r.URL.RequestURI()
+				http.Redirect(w, r, target, http.StatusMovedPermanently)
+			}),
 		}
-	}()
 
-	slog.Info("dumpstore starting", "addr", *addr, "base", *baseDir)
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		slog.Error("server stopped", "err", err)
-		os.Exit(1)
+		go func() {
+			<-ctx.Done()
+			slog.Info("dumpstore shutting down")
+			srv.Shutdown(context.Background())        //nolint:errcheck
+			redirectSrv.Shutdown(context.Background()) //nolint:errcheck
+		}()
+
+		go func() {
+			if err := redirectSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				slog.Error("redirect server stopped", "err", err)
+			}
+		}()
+
+		slog.Info("dumpstore starting (TLS)", "https_addr", httpsAddr, "redirect_addr", redirectAddr, "base", *baseDir)
+		if err := srv.ListenAndServeTLS(cfg.TLSCertPath, cfg.TLSKeyPath); err != nil && err != http.ErrServerClosed {
+			slog.Error("server stopped", "err", err)
+			os.Exit(1)
+		}
+	} else {
+		srv := &http.Server{Addr: *addr, Handler: handler}
+
+		go func() {
+			<-ctx.Done()
+			slog.Info("dumpstore shutting down")
+			if err := srv.Shutdown(context.Background()); err != nil {
+				slog.Error("server shutdown error", "err", err)
+			}
+		}()
+
+		slog.Info("dumpstore starting", "addr", *addr, "base", *baseDir)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server stopped", "err", err)
+			os.Exit(1)
+		}
 	}
 }
 

--- a/playbooks/tls_acme_issue.yml
+++ b/playbooks/tls_acme_issue.yml
@@ -1,0 +1,46 @@
+---
+# tls_acme_issue.yml — issue a TLS certificate via ACME (Let's Encrypt) using lego.
+#
+# Required extra vars:
+#   email    : ACME account email (e.g. admin@example.com)
+#   domain   : domain name to issue cert for (e.g. mynas.example.com)
+#   cert_dir : directory to store lego output (e.g. /etc/dumpstore/tls/acme)
+#
+# Uses TLS-ALPN-01 challenge (--tls flag) on port 443.
+# Ensure dumpstore is not already listening on port 443 when running this.
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Assert required vars are defined
+      ansible.builtin.assert:
+        that:
+          - email is defined and email | length > 0
+          - domain is defined and domain | length > 0
+          - cert_dir is defined and cert_dir | length > 0
+        fail_msg: "email, domain, and cert_dir are required"
+
+    - name: Assert lego is available
+      ansible.builtin.command:
+        cmd: which lego
+      register: lego_check
+      failed_when: lego_check.rc != 0
+      changed_when: false
+      ignore_errors: false
+
+    - name: Create ACME cert directory
+      ansible.builtin.file:
+        path: "{{ cert_dir }}"
+        state: directory
+        mode: "0700"
+
+    - name: Issue certificate via ACME (TLS-ALPN-01)
+      ansible.builtin.command:
+        cmd: >
+          lego
+          --email {{ email }}
+          --domains {{ domain }}
+          --path {{ cert_dir }}
+          --tls
+          run
+      register: lego_result
+      changed_when: lego_result.rc == 0

--- a/playbooks/tls_acme_renew.yml
+++ b/playbooks/tls_acme_renew.yml
@@ -1,0 +1,37 @@
+---
+# tls_acme_renew.yml — renew a TLS certificate via ACME (Let's Encrypt) using lego.
+#
+# Required extra vars:
+#   email    : ACME account email (must match the one used during issue)
+#   domain   : domain name to renew cert for
+#   cert_dir : lego directory used during issue (e.g. /etc/dumpstore/tls/acme)
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Assert required vars are defined
+      ansible.builtin.assert:
+        that:
+          - email is defined and email | length > 0
+          - domain is defined and domain | length > 0
+          - cert_dir is defined and cert_dir | length > 0
+        fail_msg: "email, domain, and cert_dir are required"
+
+    - name: Assert lego is available
+      ansible.builtin.command:
+        cmd: which lego
+      register: lego_check
+      failed_when: lego_check.rc != 0
+      changed_when: false
+
+    - name: Renew certificate via ACME (TLS-ALPN-01)
+      ansible.builtin.command:
+        cmd: >
+          lego
+          --email {{ email }}
+          --domains {{ domain }}
+          --path {{ cert_dir }}
+          --tls
+          renew
+          --days 30
+      register: lego_result
+      changed_when: lego_result.rc == 0

--- a/playbooks/tls_gencert.yml
+++ b/playbooks/tls_gencert.yml
@@ -1,0 +1,40 @@
+---
+# tls_gencert.yml — generate a self-signed ECDSA-P256 TLS certificate.
+#
+# Required extra vars:
+#   hostname  : CN and DNS SAN for the certificate (e.g. mynas.local)
+#   cert_dir  : directory to write cert.pem and key.pem (e.g. /etc/dumpstore/tls)
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Assert required vars are defined
+      ansible.builtin.assert:
+        that:
+          - hostname is defined and hostname | length > 0
+          - cert_dir is defined and cert_dir | length > 0
+        fail_msg: "hostname and cert_dir are required"
+
+    - name: Create TLS directory
+      ansible.builtin.file:
+        path: "{{ cert_dir }}"
+        state: directory
+        mode: "0700"
+
+    - name: Generate self-signed ECDSA-P256 certificate
+      ansible.builtin.command:
+        cmd: >
+          openssl req -x509
+          -newkey ec -pkeyopt ec_paramgen_curve:P-256
+          -keyout {{ cert_dir }}/key.pem
+          -out {{ cert_dir }}/cert.pem
+          -days 3650
+          -nodes
+          -subj "/CN={{ hostname }}"
+          -addext "subjectAltName=IP:127.0.0.1,DNS:{{ hostname }}"
+        creates: "{{ cert_dir }}/cert.pem"
+      register: gencert_result
+
+    - name: Restrict key file permissions
+      ansible.builtin.file:
+        path: "{{ cert_dir }}/key.pem"
+        mode: "0600"

--- a/playbooks/tls_set_config.yml
+++ b/playbooks/tls_set_config.yml
@@ -1,0 +1,45 @@
+---
+# tls_set_config.yml — persist TLS cert paths and enabled flag to dumpstore config.
+#
+# Required extra vars:
+#   config_path : absolute path to dumpstore.conf
+#   cert_path   : absolute path to cert.pem
+#   key_path    : absolute path to key.pem
+#   enabled     : "true" or "false"
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Assert required vars are defined
+      ansible.builtin.assert:
+        that:
+          - config_path is defined and config_path | length > 0
+          - cert_path is defined and cert_path | length > 0
+          - key_path is defined and key_path | length > 0
+          - enabled is defined
+        fail_msg: "config_path, cert_path, key_path, and enabled are required"
+
+    - name: Update TLS config in dumpstore config file
+      ansible.builtin.shell:
+        cmd: |
+          python3 -c "
+          import json, os
+          path = os.environ['CONFIG_PATH']
+          try:
+              with open(path) as f:
+                  cfg = json.load(f)
+          except FileNotFoundError:
+              cfg = {}
+          cfg['tls_cert_path'] = os.environ['CERT_PATH']
+          cfg['tls_key_path']  = os.environ['KEY_PATH']
+          cfg['tls_enabled']   = os.environ['ENABLED'] == 'true'
+          tmp = path + '.tmp'
+          with open(tmp, 'w') as f:
+              json.dump(cfg, f, indent=2)
+          os.chmod(tmp, 0o600)
+          os.rename(tmp, path)
+          "
+      environment:
+        CONFIG_PATH: "{{ config_path }}"
+        CERT_PATH:   "{{ cert_path }}"
+        KEY_PATH:    "{{ key_path }}"
+        ENABLED:     "{{ enabled }}"

--- a/static/app.js
+++ b/static/app.js
@@ -117,6 +117,106 @@ document.getElementById('changeUsernameForm').addEventListener('submit', async e
   } catch (err) { showOpLog('Change Username', err.tasks, err.message); }
 });
 
+// ── TLS / HTTPS ───────────────────────────────────────────────────────────────
+async function loadTLSStatus() {
+  const wrap = document.getElementById('tls-status-wrap');
+  try {
+    const d = await api('GET', '/api/tls/status');
+    if (!d.enabled || !d.cert_path) {
+      wrap.innerHTML = `<p class="muted">HTTPS is not enabled. Configure a certificate below, then restart dumpstore with <code>--tls</code>.</p>`;
+      return;
+    }
+    const expiry   = new Date(d.expires_at);
+    const days     = d.days_remaining;
+    const daysHtml = days < 30
+      ? `<span style="color:var(--yellow)">${days} days</span>`
+      : `${days} days`;
+    const sans = (d.sans || []).map(s => esc(s)).join(', ') || '—';
+    wrap.innerHTML = `
+      <table class="data-table" style="max-width:540px">
+        <tbody>
+          <tr><td class="muted" style="width:140px">Status</td><td><span class="health-badge health-ONLINE">HTTPS active</span></td></tr>
+          <tr><td class="muted">CN</td><td>${esc(d.cn || '—')}</td></tr>
+          <tr><td class="muted">SANs</td><td>${sans}</td></tr>
+          <tr><td class="muted">Expires</td><td>${esc(expiry.toLocaleDateString())} (${daysHtml})</td></tr>
+          <tr><td class="muted">Type</td><td>${d.self_signed ? 'Self-signed' : d.acme_domain ? 'ACME / Let\'s Encrypt' : 'Custom'}</td></tr>
+          ${d.acme_domain ? `<tr><td class="muted">ACME domain</td><td>${esc(d.acme_domain)}</td></tr>` : ''}
+          <tr><td class="muted">Cert path</td><td><code>${esc(d.cert_path)}</code></td></tr>
+        </tbody>
+      </table>
+      ${d.acme_domain ? `<button class="btn-secondary" style="margin-top:0.75rem" id="tlsAcmeRenewBtn">Renew (ACME)</button>` : ''}`;
+    document.getElementById('tlsAcmeRenewBtn')?.addEventListener('click', tlsAcmeRenew);
+  } catch { wrap.innerHTML = '<p class="muted">Could not load TLS status.</p>'; }
+}
+
+// Generate self-signed cert dialog
+const tlsGencertDialog = document.getElementById('tlsGencertDialog');
+document.getElementById('tlsGencertBtn').addEventListener('click', () => tlsGencertDialog.showModal());
+document.getElementById('tlsGencertCancelBtn').addEventListener('click', () => tlsGencertDialog.close());
+document.getElementById('tlsGencertForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const hostname = document.getElementById('tls-gencert-hostname').value.trim();
+  const certDir  = document.getElementById('tls-gencert-certdir').value.trim();
+  if (!hostname) { toast('Hostname is required.', 'err'); return; }
+  tlsGencertDialog.close();
+  showOpLogRunning('Generate TLS Certificate');
+  try {
+    const result = await api('POST', '/api/tls/gencert', { hostname, cert_dir: certDir });
+    showOpLog('Generate TLS Certificate', result?.tasks);
+    toast('Certificate generated. Restart dumpstore with --tls to activate HTTPS.', 'ok');
+    loadTLSStatus();
+  } catch (err) { showOpLog('Generate TLS Certificate', err.tasks, err.message); }
+});
+
+// Load existing cert dialog
+const tlsPathDialog = document.getElementById('tlsPathDialog');
+document.getElementById('tlsPathBtn').addEventListener('click', () => tlsPathDialog.showModal());
+document.getElementById('tlsPathCancelBtn').addEventListener('click', () => tlsPathDialog.close());
+document.getElementById('tlsPathForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const certPath = document.getElementById('tls-path-cert').value.trim();
+  const keyPath  = document.getElementById('tls-path-key').value.trim();
+  if (!certPath || !keyPath) { toast('Both cert and key paths are required.', 'err'); return; }
+  tlsPathDialog.close();
+  showOpLogRunning('Load TLS Certificate');
+  try {
+    const result = await api('PATCH', '/api/tls/config', { cert_path: certPath, key_path: keyPath });
+    showOpLog('Load TLS Certificate', result?.tasks);
+    toast('Certificate loaded. Restart dumpstore with --tls to activate HTTPS.', 'ok');
+    loadTLSStatus();
+  } catch (err) { showOpLog('Load TLS Certificate', err.tasks, err.message); }
+});
+
+// ACME / Let's Encrypt dialog
+const tlsAcmeDialog = document.getElementById('tlsAcmeDialog');
+document.getElementById('tlsAcmeBtn').addEventListener('click', () => tlsAcmeDialog.showModal());
+document.getElementById('tlsAcmeCancelBtn').addEventListener('click', () => tlsAcmeDialog.close());
+document.getElementById('tlsAcmeForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const email   = document.getElementById('tls-acme-email').value.trim();
+  const domain  = document.getElementById('tls-acme-domain').value.trim();
+  const certDir = document.getElementById('tls-acme-certdir').value.trim();
+  if (!email || !domain) { toast('Email and domain are required.', 'err'); return; }
+  tlsAcmeDialog.close();
+  showOpLogRunning('Issue ACME Certificate');
+  try {
+    const result = await api('POST', '/api/tls/acme/issue', { email, domain, cert_dir: certDir });
+    showOpLog('Issue ACME Certificate', result?.tasks);
+    toast('Certificate issued. Restart dumpstore with --tls to activate HTTPS.', 'ok');
+    loadTLSStatus();
+  } catch (err) { showOpLog('Issue ACME Certificate', err.tasks, err.message); }
+});
+
+async function tlsAcmeRenew() {
+  showOpLogRunning('Renew ACME Certificate');
+  try {
+    const result = await api('POST', '/api/tls/acme/renew');
+    showOpLog('Renew ACME Certificate', result?.tasks);
+    toast('Certificate renewed. Restart dumpstore to load the new cert.', 'ok');
+    loadTLSStatus();
+  } catch (err) { showOpLog('Renew ACME Certificate', err.tasks, err.message); }
+}
+
 // ── Boot ──────────────────────────────────────────────────────────────────────
 // Perform an immediate REST load so the UI is populated on first paint,
 // then open the SSE stream. The SSE onopen handler cancels REST polling.
@@ -130,5 +230,6 @@ document.getElementById('changeUsernameForm').addEventListener('submit', async e
 setInterval(loadAll, 60_000);
 initAuthHeader();
 initAuthConfig();
+loadTLSStatus();
 loadAll();
 startSSE();

--- a/static/index.html
+++ b/static/index.html
@@ -105,6 +105,15 @@
         <div class="loading">Loading…</div>
       </div>
       <div class="section-header" style="margin-top:2rem">
+        <h2>TLS / HTTPS</h2>
+        <button class="btn-secondary" id="tlsGencertBtn">Generate self-signed</button>
+        <button class="btn-secondary" id="tlsPathBtn">Load existing cert</button>
+        <button class="btn-secondary" id="tlsAcmeBtn">Let's Encrypt (ACME)</button>
+      </div>
+      <div id="tls-status-wrap">
+        <div class="loading">Loading…</div>
+      </div>
+      <div class="section-header" style="margin-top:2rem">
         <h2>Local Users</h2>
         <button class="btn-secondary" id="toggleSystemUsersBtn">Show system</button>
         <button class="btn-primary" id="newUserBtn">+ New User</button>
@@ -942,6 +951,72 @@
       <div class="dialog-actions">
         <button type="button" id="changeUsernameCancelBtn" class="btn-secondary">Cancel</button>
         <button type="submit" class="btn-primary">Update Username</button>
+      </div>
+    </form>
+  </dialog>
+
+  <!-- TLS: GENERATE SELF-SIGNED CERT DIALOG -->
+  <dialog id="tlsGencertDialog">
+    <form id="tlsGencertForm" method="dialog">
+      <h3>Generate Self-Signed Certificate</h3>
+      <fieldset class="form-section">
+        <legend>Certificate settings</legend>
+        <label>Hostname (CN / DNS SAN)
+          <input type="text" id="tls-gencert-hostname" placeholder="mynas.local" spellcheck="false">
+        </label>
+        <label>Certificate directory
+          <input type="text" id="tls-gencert-certdir" value="/etc/dumpstore/tls" spellcheck="false">
+        </label>
+        <p class="field-note" style="margin-top:0.5rem">Generates an ECDSA-P256 certificate valid for 10 years. Restart dumpstore with <code>--tls</code> to activate HTTPS.</p>
+      </fieldset>
+      <div class="dialog-actions">
+        <button type="button" id="tlsGencertCancelBtn" class="btn-secondary">Cancel</button>
+        <button type="submit" class="btn-primary">Generate</button>
+      </div>
+    </form>
+  </dialog>
+
+  <!-- TLS: LOAD EXISTING CERT DIALOG -->
+  <dialog id="tlsPathDialog">
+    <form id="tlsPathForm" method="dialog">
+      <h3>Load Existing Certificate</h3>
+      <fieldset class="form-section">
+        <legend>Certificate paths</legend>
+        <label>Certificate file (PEM)
+          <input type="text" id="tls-path-cert" placeholder="/etc/letsencrypt/live/example.com/fullchain.pem" spellcheck="false">
+        </label>
+        <label>Key file (PEM)
+          <input type="text" id="tls-path-key" placeholder="/etc/letsencrypt/live/example.com/privkey.pem" spellcheck="false">
+        </label>
+        <p class="field-note" style="margin-top:0.5rem">The cert/key pair will be validated before saving. Restart dumpstore with <code>--tls</code> to activate HTTPS.</p>
+      </fieldset>
+      <div class="dialog-actions">
+        <button type="button" id="tlsPathCancelBtn" class="btn-secondary">Cancel</button>
+        <button type="submit" class="btn-primary">Validate &amp; Apply</button>
+      </div>
+    </form>
+  </dialog>
+
+  <!-- TLS: ACME / LET'S ENCRYPT DIALOG -->
+  <dialog id="tlsAcmeDialog">
+    <form id="tlsAcmeForm" method="dialog">
+      <h3>Issue Certificate via Let's Encrypt</h3>
+      <fieldset class="form-section">
+        <legend>ACME settings</legend>
+        <label>Email address
+          <input type="email" id="tls-acme-email" placeholder="admin@example.com" spellcheck="false">
+        </label>
+        <label>Domain name
+          <input type="text" id="tls-acme-domain" placeholder="mynas.example.com" spellcheck="false">
+        </label>
+        <label>Certificate directory
+          <input type="text" id="tls-acme-certdir" value="/etc/dumpstore/tls/acme" spellcheck="false">
+        </label>
+        <p class="field-note" style="margin-top:0.5rem">Uses TLS-ALPN-01 challenge on port 443. Requires <code>lego</code> in PATH and the domain to resolve to this machine.</p>
+      </fieldset>
+      <div class="dialog-actions">
+        <button type="button" id="tlsAcmeCancelBtn" class="btn-secondary">Cancel</button>
+        <button type="submit" class="btn-primary">Issue Certificate</button>
       </div>
     </form>
   </dialog>


### PR DESCRIPTION
## Summary

- **Self-signed cert generation** via Ansible (`tls_gencert.yml`) — openssl ECDSA-P256, 10-year validity, written to `/etc/dumpstore/tls/`
- **Path loader** (`PATCH /api/tls/config`) — validates existing cert+key pair with `tls.X509KeyPair` before saving; works with Let's Encrypt, Certbot, acme.sh
- **ACME via lego** (`tls_acme_issue.yml` / `tls_acme_renew.yml`) — TLS-ALPN-01 challenge, no port-80 conflict; `POST /api/tls/acme/issue` and `POST /api/tls/acme/renew`
- **HTTP→HTTPS redirect** listener on `--http-port` (default 80) when `--tls` is set
- **TLS status card** in Users tab — shows CN, SANs, expiry countdown (warning if < 30 days), cert type; three action dialogs (generate, load, ACME)
- **`lego` added to Installed Software tab** — shows version or N/A; optional dependency with startup warning if ACME is configured but lego is missing
- Session cookie `Secure` flag was already handled via `r.TLS != nil` — no change needed

## New flags

```
--tls            Enable HTTPS (requires tls_cert_path and tls_key_path in config)
--tls-port       HTTPS listen port (default: 443)
--http-port      HTTP redirect port (default: 80, used when --tls is set)
```

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/tls/status` | Cert metadata (CN, SANs, expiry, type) |
| `POST` | `/api/tls/gencert` | Generate self-signed cert via Ansible |
| `PATCH` | `/api/tls/config` | Load existing cert+key paths |
| `POST` | `/api/tls/acme/issue` | Issue cert via lego (ACME) |
| `POST` | `/api/tls/acme/renew` | Renew cert via lego |

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] Start without `--tls` — plain HTTP works as before
- [ ] Generate self-signed cert via UI → op-log shows, cert appears in `/etc/dumpstore/tls/`
- [ ] Load existing cert via path loader → rejects mismatched pairs, accepts valid ones
- [ ] Start with `--tls` → HTTPS on 443, `curl http://localhost/` returns 301
- [ ] Session cookie has `Secure` flag in HTTPS mode
- [ ] `lego (ACME)` row appears in Installed Software tab

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)