### PR TITLE
fix: FreeBSD build and rc script fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **FreeBSD rc script** — rewrote `contrib/dumpstore.rc` to follow the standard `daemon(8)` pattern (`-p` child pidfile + `procname`); fixes start/restart failures caused by stale supervisor processes, missing PATH for `ansible-playbook`, and silent crashes (output now goes to `/var/log/dumpstore.log` and syslog via `-S -T dumpstore`)
+- **FreeBSD build** — added `-buildvcs=false` to `go build` in both `Makefile` and `install.sh` to fix VCS stamping failure in jails and on certain mount types
+
 ### Added
 - **TLS / HTTPS support** — `--tls` flag enables HTTPS; self-signed ECDSA-P256 cert generation via `tls_gencert.yml` (openssl); path loader (`PATCH /api/tls/config`) validates and loads existing certs (Let's Encrypt, Certbot, acme.sh); ACME issuance and renewal via `lego` (`POST /api/tls/acme/issue`, `POST /api/tls/acme/renew`); HTTP→HTTPS redirect listener on `--http-port` (default 80); TLS status card in Users tab with cert CN, SANs, expiry countdown; `lego` is an optional dependency (warn if missing and ACME is configured)
 - **Service management** — new Services tab with start/stop/restart/enable/disable controls for Samba, NFS, and iSCSI; `GET /api/services` returns live status for all three; mutations go through `service_control_linux.yml` (systemd) or `service_control_freebsd.yml` (rc.d) with full op-log display; status updates via SSE every 10 s; NFS stop shows a client-disconnect warning

--- a/contrib/dumpstore.rc
+++ b/contrib/dumpstore.rc
@@ -8,10 +8,11 @@
 #   dumpstore_enable="YES"
 #
 # Optional rc.conf knobs (with defaults shown):
-#   dumpstore_addr=":8080"
-#   dumpstore_dir="/usr/local/lib/dumpstore"
-#   dumpstore_config="/etc/dumpstore/dumpstore.conf"
-#   dumpstore_logfile="/var/log/dumpstore.log"
+#   dumpstore_enable (bool):   Set to YES to enable dumpstore.
+#   dumpstore_addr (str):      Listen address. Default: ":8080"
+#   dumpstore_dir (path):      Base directory. Default: /usr/local/lib/dumpstore
+#   dumpstore_config (path):   Config file. Default: /etc/dumpstore/dumpstore.conf
+#   dumpstore_logfile (path):  Log file. Default: /var/log/dumpstore.log
 
 . /etc/rc.subr
 
@@ -27,55 +28,22 @@ load_rc_config ${name}
 : ${dumpstore_config:="/etc/dumpstore/dumpstore.conf"}
 : ${dumpstore_logfile:="/var/log/dumpstore.log"}
 
-_bin="${dumpstore_dir}/dumpstore"
-_supervisor_pid="/var/run/${name}-supervisor.pid"
-_child_pid="/var/run/${name}.pid"
+pidfile="/var/run/${name}.pid"
+procname="${dumpstore_dir}/dumpstore"
+command="/usr/sbin/daemon"
+command_args="-p ${pidfile} -o ${dumpstore_logfile} -m 3 \
+    ${procname} \
+    -addr ${dumpstore_addr} \
+    -dir ${dumpstore_dir} \
+    -config ${dumpstore_config}"
 
-start_cmd="${name}_start"
-stop_cmd="${name}_stop"
-status_cmd="${name}_status"
-restart_cmd="${name}_restart"
-extra_commands="status"
+start_precmd="${name}_prestart"
 
-dumpstore_start() {
-    echo "Starting ${name}."
-    /usr/sbin/daemon \
-        -P ${_supervisor_pid} \
-        -p ${_child_pid} \
-        -r \
-        -o ${dumpstore_logfile} \
-        -m 3 \
-        ${_bin} \
-        -addr ${dumpstore_addr} \
-        -dir ${dumpstore_dir} \
-        -config ${dumpstore_config}
-}
-
-dumpstore_stop() {
-    echo "Stopping ${name}."
-    if [ -f "${_supervisor_pid}" ]; then
-        kill "$(cat ${_supervisor_pid})" 2>/dev/null || true
-        rm -f "${_supervisor_pid}"
+dumpstore_prestart()
+{
+    if [ ! -e ${pidfile} ]; then
+        install -m 0600 /dev/null ${pidfile}
     fi
-    if [ -f "${_child_pid}" ]; then
-        kill "$(cat ${_child_pid})" 2>/dev/null || true
-        rm -f "${_child_pid}"
-    fi
-}
-
-dumpstore_status() {
-    if [ -f "${_supervisor_pid}" ] && kill -0 "$(cat ${_supervisor_pid})" 2>/dev/null; then
-        echo "${name} is running as pid $(cat ${_child_pid} 2>/dev/null)."
-    else
-        echo "${name} is not running."
-        return 1
-    fi
-}
-
-dumpstore_restart() {
-    dumpstore_stop
-    sleep 1
-    dumpstore_start
 }
 
 run_rc_command "$1"

--- a/contrib/dumpstore.rc
+++ b/contrib/dumpstore.rc
@@ -27,15 +27,55 @@ load_rc_config ${name}
 : ${dumpstore_config:="/etc/dumpstore/dumpstore.conf"}
 : ${dumpstore_logfile:="/var/log/dumpstore.log"}
 
-# procname is the real binary; command is the daemon(8) supervisor.
-# rc.subr uses procname for status/stop checks.
-procname="${dumpstore_dir}/dumpstore"
-pidfile="/var/run/${name}.pid"
-command="/usr/sbin/daemon"
-command_args="-P ${pidfile} -r -o ${dumpstore_logfile} -m 3 \
-    ${procname} \
-    -addr ${dumpstore_addr} \
-    -dir ${dumpstore_dir} \
-    -config ${dumpstore_config}"
+_bin="${dumpstore_dir}/dumpstore"
+_supervisor_pid="/var/run/${name}-supervisor.pid"
+_child_pid="/var/run/${name}.pid"
+
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
+status_cmd="${name}_status"
+restart_cmd="${name}_restart"
+extra_commands="status"
+
+dumpstore_start() {
+    echo "Starting ${name}."
+    /usr/sbin/daemon \
+        -P ${_supervisor_pid} \
+        -p ${_child_pid} \
+        -r \
+        -o ${dumpstore_logfile} \
+        -m 3 \
+        ${_bin} \
+        -addr ${dumpstore_addr} \
+        -dir ${dumpstore_dir} \
+        -config ${dumpstore_config}
+}
+
+dumpstore_stop() {
+    echo "Stopping ${name}."
+    if [ -f "${_supervisor_pid}" ]; then
+        kill "$(cat ${_supervisor_pid})" 2>/dev/null || true
+        rm -f "${_supervisor_pid}"
+    fi
+    if [ -f "${_child_pid}" ]; then
+        kill "$(cat ${_child_pid})" 2>/dev/null || true
+        rm -f "${_child_pid}"
+    fi
+}
+
+dumpstore_status() {
+    if [ -f "${_supervisor_pid}" ] && kill -0 "$(cat ${_supervisor_pid})" 2>/dev/null; then
+        echo "${name} is running as pid $(cat ${_child_pid} 2>/dev/null)."
+    else
+        echo "${name} is not running."
+        return 1
+    fi
+}
+
+dumpstore_restart() {
+    dumpstore_stop
+    sleep 1
+    dumpstore_start
+}
 
 run_rc_command "$1"

--- a/contrib/dumpstore.rc
+++ b/contrib/dumpstore.rc
@@ -33,9 +33,9 @@ pidfile="/var/run/${name}.pid"
 # Use daemon(8) to background the process, write a pidfile, and auto-restart.
 # -P  write PID of the daemon wrapper to pidfile
 # -r  restart the child if it exits
-# -o  redirect stdout to log file
-# -e  redirect stderr to log file
+# -o  redirect output to log file
+# -m 3  capture both stdout and stderr (mask: 1=stdout, 2=stderr, 3=both)
 command="/usr/sbin/daemon"
-command_args="-P ${pidfile} -r -o ${dumpstore_logfile} -e ${dumpstore_logfile} ${_bin} -addr ${dumpstore_addr} -dir ${dumpstore_dir} -config ${dumpstore_config}"
+command_args="-P ${pidfile} -r -o ${dumpstore_logfile} -m 3 ${_bin} -addr ${dumpstore_addr} -dir ${dumpstore_dir} -config ${dumpstore_config}"
 
 run_rc_command "$1"

--- a/contrib/dumpstore.rc
+++ b/contrib/dumpstore.rc
@@ -37,6 +37,8 @@ command_args="-p ${pidfile} -o ${dumpstore_logfile} -m 3 \
     -dir ${dumpstore_dir} \
     -config ${dumpstore_config}"
 
+export PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
+
 start_precmd="${name}_prestart"
 
 dumpstore_prestart()

--- a/contrib/dumpstore.rc
+++ b/contrib/dumpstore.rc
@@ -10,6 +10,8 @@
 # Optional rc.conf knobs (with defaults shown):
 #   dumpstore_addr=":8080"
 #   dumpstore_dir="/usr/local/lib/dumpstore"
+#   dumpstore_config="/etc/dumpstore/dumpstore.conf"
+#   dumpstore_logfile="/var/log/dumpstore.log"
 
 . /etc/rc.subr
 
@@ -22,6 +24,8 @@ load_rc_config ${name}
 : ${dumpstore_enable:="NO"}
 : ${dumpstore_addr:=":8080"}
 : ${dumpstore_dir:="/usr/local/lib/dumpstore"}
+: ${dumpstore_config:="/etc/dumpstore/dumpstore.conf"}
+: ${dumpstore_logfile:="/var/log/dumpstore.log"}
 
 _bin="${dumpstore_dir}/dumpstore"
 pidfile="/var/run/${name}.pid"
@@ -29,8 +33,9 @@ pidfile="/var/run/${name}.pid"
 # Use daemon(8) to background the process, write a pidfile, and auto-restart.
 # -P  write PID of the daemon wrapper to pidfile
 # -r  restart the child if it exits
-# -f  redirect stdin/stdout/stderr to /dev/null
+# -o  redirect stdout to log file
+# -e  redirect stderr to log file
 command="/usr/sbin/daemon"
-command_args="-P ${pidfile} -r -f ${_bin} -addr ${dumpstore_addr} -dir ${dumpstore_dir}"
+command_args="-P ${pidfile} -r -o ${dumpstore_logfile} -e ${dumpstore_logfile} ${_bin} -addr ${dumpstore_addr} -dir ${dumpstore_dir} -config ${dumpstore_config}"
 
 run_rc_command "$1"

--- a/contrib/dumpstore.rc
+++ b/contrib/dumpstore.rc
@@ -31,7 +31,7 @@ load_rc_config ${name}
 pidfile="/var/run/${name}.pid"
 procname="${dumpstore_dir}/dumpstore"
 command="/usr/sbin/daemon"
-command_args="-p ${pidfile} -o ${dumpstore_logfile} -m 3 \
+command_args="-p ${pidfile} -o ${dumpstore_logfile} -m 3 -S -T ${name} \
     ${procname} \
     -addr ${dumpstore_addr} \
     -dir ${dumpstore_dir} \

--- a/contrib/dumpstore.rc
+++ b/contrib/dumpstore.rc
@@ -27,15 +27,15 @@ load_rc_config ${name}
 : ${dumpstore_config:="/etc/dumpstore/dumpstore.conf"}
 : ${dumpstore_logfile:="/var/log/dumpstore.log"}
 
-_bin="${dumpstore_dir}/dumpstore"
+# procname is the real binary; command is the daemon(8) supervisor.
+# rc.subr uses procname for status/stop checks.
+procname="${dumpstore_dir}/dumpstore"
 pidfile="/var/run/${name}.pid"
-
-# Use daemon(8) to background the process, write a pidfile, and auto-restart.
-# -P  write PID of the daemon wrapper to pidfile
-# -r  restart the child if it exits
-# -o  redirect output to log file
-# -m 3  capture both stdout and stderr (mask: 1=stdout, 2=stderr, 3=both)
 command="/usr/sbin/daemon"
-command_args="-P ${pidfile} -r -o ${dumpstore_logfile} -m 3 ${_bin} -addr ${dumpstore_addr} -dir ${dumpstore_dir} -config ${dumpstore_config}"
+command_args="-P ${pidfile} -r -o ${dumpstore_logfile} -m 3 \
+    ${procname} \
+    -addr ${dumpstore_addr} \
+    -dir ${dumpstore_dir} \
+    -config ${dumpstore_config}"
 
 run_rc_command "$1"


### PR DESCRIPTION
## Summary
- `-buildvcs=false` added to `Makefile` and `install.sh` to fix `go build` VCS stamping failure in FreeBSD jails/mounts
- Rewrote `contrib/dumpstore.rc` following the standard FreeBSD `daemon(8)` pattern (`-p` child pidfile + `procname`) — fixes start/restart failures, missing `ansible-playbook` in PATH, and silent crashes
- Output now goes to `/var/log/dumpstore.log` and syslog (`-S -T dumpstore`)

## Test plan
- [ ] `./install.sh` completes without error on FreeBSD
- [ ] `service dumpstore start` starts the service
- [ ] `service dumpstore status` shows running
- [ ] `service dumpstore restart` works cleanly
- [ ] Logs appear in `/var/log/dumpstore.log` and `grep dumpstore /var/log/messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)