### PR TITLE
feat: automated dev VM environment (Linux + FreeBSD with ZFS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Added
+- **Dev VM environment** — `make vm-linux-start/deploy` and `make vm-freebsd-start/deploy` spin up headless Lima VMs (Ubuntu 24.04 + FreeBSD 15) with ZFS, Ansible, and Go pre-installed; source is packed and `make install` runs natively inside the VM; Linux UI at http://localhost:8080, FreeBSD at http://localhost:8081; VMs use dedicated extra disks for ZFS (`dumpstore-linux-data`, `dumpstore-freebsd-data`); default credentials admin/admin; closes #83
+
+### Changed
+- **Makefile** — BSD/GNU make compatible (no `$(shell ...)` at parse time); `check-prereqs` now auto-installs Go (from go.dev) and Ansible (`apt-get`/`pkg`) if absent; `install.sh` reduced to a thin root-check wrapper around `make install`
+- **FreeBSD VM port forwarding** — SSH tunnel (`-L 8081:127.0.0.1:8080`) set up in `vm-freebsd-start` as Lima's guest agent is Linux/Darwin-only; torn down in `vm-freebsd-stop`
+
+### Fixed
+- **SMB apply with no dirs** — `DirsToCreate()` returned Go `nil` slice, marshalled to JSON `null`, which caused Ansible's `from_json` to return Python `None` and fail the loop; fixed by initialising to `[]string{}`; added `| default([])` guard in `smb_apply.yml`
+
 ---
 
 ## [v0.1.10] — 2026-04-14

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -46,6 +46,7 @@
 
 | Feature                            | Priority | Issue | Notes                                                                                                                    |
 |------------------------------------|----------|-------|--------------------------------------------------------------------------------------------------------------------------|
+| Dev VM environment                 | High     | [#83](https://github.com/langerma/dumpstore/issues/83) | Automated Lima VMs (Linux + FreeBSD) with ZFS; one-command deploy for local testing |
 | UPS / NUT integration              | Low      | [#52](https://github.com/langerma/dumpstore/issues/52) | UPS status display; graceful shutdown on low battery via `upsc` |
 | Drive replacement                  | High     | [#55](https://github.com/langerma/dumpstore/issues/55) | Replace faulted disks, monitor resilver progress, offline/online devices |
 | Scheduled replication              | High     | [#53](https://github.com/langerma/dumpstore/issues/53) | Cron-based ZFS send/receive jobs with retention; depends on [#26](https://github.com/langerma/dumpstore/issues/26) |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,7 @@
 | Samba full ownership       | v0.1.10 | dumpstore owns smb.conf entirely — rendered from Go template on every write; directories auto-created; init gate blocks sub-features until Samba is bootstrapped; FreeBSD smb4.conf created on first init; resolves #75 #77 #78 #79 #81 |
 | FreeBSD-compliant paths    | v0.1.10 | `/usr/local/etc/dumpstore/` on FreeBSD, `/etc/dumpstore/` on Linux — `internal/platform.ConfigDir(goos)` as single source of truth; usershares, TLS certs, rc.d script, Makefile, install.sh all updated |
 | SMB init status badge      | v0.1.10 | Users & Groups tab shows green "Initialised" badge with last-applied timestamp, or red "Not initialised"; `GET /api/smb/status` now includes `conf_mtime` |
+| Dev VM environment         | v0.1.11 | `make vm-linux-start/deploy` and `make vm-freebsd-start/deploy`; Ubuntu 24.04 + FreeBSD 15 with ZFS + Ansible; default admin/admin; closes #83 |
 
 ---
 
@@ -46,8 +47,8 @@
 
 | Feature                            | Priority | Issue | Notes                                                                                                                    |
 |------------------------------------|----------|-------|--------------------------------------------------------------------------------------------------------------------------|
-| Dev VM environment                 | High     | [#83](https://github.com/langerma/dumpstore/issues/83) | Automated Lima VMs (Linux + FreeBSD) with ZFS; one-command deploy for local testing |
 | UPS / NUT integration              | Low      | [#52](https://github.com/langerma/dumpstore/issues/52) | UPS status display; graceful shutdown on low battery via `upsc` |
+
 | Drive replacement                  | High     | [#55](https://github.com/langerma/dumpstore/issues/55) | Replace faulted disks, monitor resilver progress, offline/online devices |
 | Scheduled replication              | High     | [#53](https://github.com/langerma/dumpstore/issues/53) | Cron-based ZFS send/receive jobs with retention; depends on [#26](https://github.com/langerma/dumpstore/issues/26) |
 | Pool create/import/export          | Medium   | [#23](https://github.com/langerma/dumpstore/issues/23) | Create pools (mirror, raidz1/2/3, draid); import/export existing pools |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ BINARY  := dumpstore
 INSTALL := /usr/local/lib/dumpstore
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 
-.PHONY: all build clean dev install uninstall check-prereqs
+.PHONY: all build clean dev install uninstall check-prereqs \
+        vm-linux-start vm-linux-stop vm-linux-ssh vm-linux-deploy vm-linux-destroy \
+        vm-freebsd-start vm-freebsd-stop vm-freebsd-ssh vm-freebsd-deploy vm-freebsd-destroy
 
 all: build
 
@@ -67,6 +69,119 @@ install: check-prereqs build
 	        echo "  Start manually: $(INSTALL)/$(BINARY) -addr :8080 -dir $(INSTALL) -config $$CONFIG_DIR/dumpstore.conf"; \
 	        ;; \
 	esac
+
+# ---------------------------------------------------------------------------
+# Dev VMs (Lima — requires: brew install lima)
+# Linux UI:  http://localhost:8080
+# FreeBSD UI: http://localhost:8081
+# ---------------------------------------------------------------------------
+
+VM_LINUX   := dumpstore-linux
+VM_FREEBSD := dumpstore-freebsd
+
+# Build a linux/arm64 binary for deployment into the Linux VM
+build-linux:
+	GOOS=linux GOARCH=arm64 go build -buildvcs=false \
+	  -ldflags="-s -w -X main.version=$(VERSION)" -o $(BINARY)-linux .
+
+# Build a freebsd/arm64 binary for deployment into the FreeBSD VM
+build-freebsd:
+	GOOS=freebsd GOARCH=arm64 go build -buildvcs=false \
+	  -ldflags="-s -w -X main.version=$(VERSION)" -o $(BINARY)-freebsd .
+
+vm-linux-start:
+	@command -v limactl >/dev/null 2>&1 || { \
+	  echo "error: limactl not found. Install Lima via:" >&2; \
+	  echo "  brew:      brew install lima" >&2; \
+	  echo "  MacPorts:  sudo port install lima" >&2; \
+	  echo "  manual:    https://github.com/lima-vm/lima/releases" >&2; \
+	  exit 1; }
+	@if limactl list -q | grep -qx "$(VM_LINUX)"; then \
+	  echo "==> Starting existing VM $(VM_LINUX)..."; \
+	  limactl start $(VM_LINUX); \
+	else \
+	  echo "==> Creating and provisioning VM $(VM_LINUX) (first run, takes a few minutes)..."; \
+	  limactl create --name=$(VM_LINUX) dev/lima-linux.yaml; \
+	  limactl start $(VM_LINUX); \
+	fi
+	@echo "==> Linux VM ready. UI will be at http://localhost:8080 after deploy."
+	@echo "    Run: make vm-linux-deploy"
+
+vm-linux-stop:
+	limactl stop $(VM_LINUX)
+
+vm-linux-ssh:
+	limactl shell $(VM_LINUX)
+
+vm-linux-deploy: build-linux
+	@echo "==> Deploying to $(VM_LINUX)..."
+	limactl copy $(BINARY)-linux $(VM_LINUX):/tmp/dumpstore
+	limactl copy -r playbooks   $(VM_LINUX):/tmp/playbooks
+	limactl copy -r static      $(VM_LINUX):/tmp/static
+	@rm -f $(BINARY)-linux
+	limactl shell --tty=false $(VM_LINUX) -- sudo sh -c '\
+	  install -d /usr/local/lib/dumpstore && \
+	  install -m 0755 /tmp/dumpstore /usr/local/lib/dumpstore/dumpstore && \
+	  rm -rf /usr/local/lib/dumpstore/playbooks /usr/local/lib/dumpstore/static && \
+	  cp -r /tmp/playbooks /usr/local/lib/dumpstore/ && \
+	  cp -r /tmp/static    /usr/local/lib/dumpstore/ && \
+	  install -d -m 0700 /etc/dumpstore && \
+	  if ! grep -q password_hash /etc/dumpstore/dumpstore.conf 2>/dev/null; then \
+	    /usr/local/lib/dumpstore/dumpstore --set-password --config /etc/dumpstore/dumpstore.conf; \
+	  fi && \
+	  systemctl restart dumpstore 2>/dev/null || /usr/local/lib/dumpstore/dumpstore \
+	    -addr :8080 -dir /usr/local/lib/dumpstore -config /etc/dumpstore/dumpstore.conf &'
+	@echo "==> Deployed. Open http://localhost:8080"
+
+vm-linux-destroy:
+	limactl delete --force $(VM_LINUX)
+
+vm-freebsd-start:
+	@command -v limactl >/dev/null 2>&1 || { \
+	  echo "error: limactl not found. Install Lima via:" >&2; \
+	  echo "  brew:      brew install lima" >&2; \
+	  echo "  MacPorts:  sudo port install lima" >&2; \
+	  echo "  manual:    https://github.com/lima-vm/lima/releases" >&2; \
+	  exit 1; }
+	@if limactl list -q | grep -qx "$(VM_FREEBSD)"; then \
+	  echo "==> Starting existing VM $(VM_FREEBSD)..."; \
+	  limactl start $(VM_FREEBSD); \
+	else \
+	  echo "==> Creating and provisioning VM $(VM_FREEBSD) (first run, takes a few minutes)..."; \
+	  limactl create --name=$(VM_FREEBSD) dev/lima-freebsd.yaml; \
+	  limactl start $(VM_FREEBSD); \
+	fi
+	@echo "==> FreeBSD VM ready. UI will be at http://localhost:8081 after deploy."
+	@echo "    Run: make vm-freebsd-deploy"
+
+vm-freebsd-stop:
+	limactl stop $(VM_FREEBSD)
+
+vm-freebsd-ssh:
+	limactl shell $(VM_FREEBSD)
+
+vm-freebsd-deploy: build-freebsd
+	@echo "==> Deploying to $(VM_FREEBSD)..."
+	limactl copy $(BINARY)-freebsd $(VM_FREEBSD):/tmp/dumpstore
+	limactl copy -r playbooks      $(VM_FREEBSD):/tmp/playbooks
+	limactl copy -r static         $(VM_FREEBSD):/tmp/static
+	@rm -f $(BINARY)-freebsd
+	limactl shell --tty=false $(VM_FREEBSD) -- sudo sh -c '\
+	  install -d /usr/local/lib/dumpstore && \
+	  install -m 0755 /tmp/dumpstore /usr/local/lib/dumpstore/dumpstore && \
+	  rm -rf /usr/local/lib/dumpstore/playbooks /usr/local/lib/dumpstore/static && \
+	  cp -r /tmp/playbooks /usr/local/lib/dumpstore/ && \
+	  cp -r /tmp/static    /usr/local/lib/dumpstore/ && \
+	  install -d -m 0700 /usr/local/etc/dumpstore && \
+	  if ! grep -q password_hash /usr/local/etc/dumpstore/dumpstore.conf 2>/dev/null; then \
+	    /usr/local/lib/dumpstore/dumpstore --set-password --config /usr/local/etc/dumpstore/dumpstore.conf; \
+	  fi && \
+	  service dumpstore restart 2>/dev/null || /usr/local/lib/dumpstore/dumpstore \
+	    -addr :8080 -dir /usr/local/lib/dumpstore -config /usr/local/etc/dumpstore/dumpstore.conf &'
+	@echo "==> Deployed. Open http://localhost:8081"
+
+vm-freebsd-destroy:
+	limactl delete --force $(VM_FREEBSD)
 
 uninstall:
 	@set -e; \

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,13 @@
 BINARY  := dumpstore
 INSTALL := /usr/local/lib/dumpstore
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-
-.PHONY: all build clean dev install uninstall check-prereqs \
+.PHONY: all build clean dev install uninstall check-prereqs install-go install-ansible \
         vm-linux-start vm-linux-stop vm-linux-ssh vm-linux-deploy vm-linux-destroy \
         vm-freebsd-start vm-freebsd-stop vm-freebsd-ssh vm-freebsd-deploy vm-freebsd-destroy
 
 all: build
 
 build:
-	go build -buildvcs=false -ldflags="-s -w -X main.version=$(VERSION)" -o $(BINARY) .
+	go build -buildvcs=false -ldflags="-s -w -X main.version=$$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o $(BINARY) .
 
 # Run locally on macOS (or any machine without ZFS/Ansible).
 # Fake CLI stubs in dev/bin/ intercept zfs, zpool, and ansible-playbook.
@@ -20,10 +18,42 @@ dev:
 clean:
 	rm -f $(BINARY)
 
-check-prereqs:
-	@command -v go               >/dev/null 2>&1 || { echo "error: 'go' not found in PATH — please install Go first" >&2; exit 1; }
-	@command -v ansible-playbook >/dev/null 2>&1 || { echo "error: 'ansible-playbook' not found — please install Ansible first" >&2; exit 1; }
-	@command -v lego             >/dev/null 2>&1 || echo "  [warn] lego not found — ACME cert issuance will not be available"
+install-go:
+	@if command -v go >/dev/null 2>&1; then \
+	  echo "==> Go already installed: $$(go version)"; \
+	else \
+	  echo "==> Installing Go..."; \
+	  OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+	  ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); \
+	  if command -v curl >/dev/null 2>&1; then \
+	    FETCH="curl -fsSL"; \
+	  elif command -v fetch >/dev/null 2>&1; then \
+	    FETCH="fetch -qo -"; \
+	  else \
+	    echo "error: neither curl nor fetch found" >&2; exit 1; \
+	  fi; \
+	  GOVERSION=$$($$FETCH "https://go.dev/VERSION?m=text" | head -1); \
+	  $$FETCH "https://go.dev/dl/$${GOVERSION}.$${OS}-$${ARCH}.tar.gz" | tar -C /usr/local -xz; \
+	  echo 'export PATH=$$PATH:/usr/local/go/bin' > /etc/profile.d/go.sh 2>/dev/null || true; \
+	  export PATH=$$PATH:/usr/local/go/bin; \
+	  echo "==> Installed $$(go version)"; \
+	fi
+
+check-prereqs: install-go install-ansible
+	@command -v lego >/dev/null 2>&1 || echo "  [warn] lego not found — ACME cert issuance will not be available"
+
+install-ansible:
+	@if command -v ansible-playbook >/dev/null 2>&1; then \
+	  echo "==> Ansible already installed: $$(ansible-playbook --version | head -1)"; \
+	else \
+	  echo "==> Installing Ansible..."; \
+	  OS=$$(uname -s); \
+	  case "$$OS" in \
+	    FreeBSD) pkg install -y py311-ansible ;; \
+	    Linux)   apt-get install -y -qq ansible ;; \
+	    *) echo "error: 'ansible-playbook' not found — please install Ansible" >&2; exit 1 ;; \
+	  esac; \
+	fi
 
 install: check-prereqs build
 	@set -e; \
@@ -79,15 +109,6 @@ install: check-prereqs build
 VM_LINUX   := dumpstore-linux
 VM_FREEBSD := dumpstore-freebsd
 
-# Build a linux/arm64 binary for deployment into the Linux VM
-build-linux:
-	GOOS=linux GOARCH=arm64 go build -buildvcs=false \
-	  -ldflags="-s -w -X main.version=$(VERSION)" -o $(BINARY)-linux .
-
-# Build a freebsd/arm64 binary for deployment into the FreeBSD VM
-build-freebsd:
-	GOOS=freebsd GOARCH=arm64 go build -buildvcs=false \
-	  -ldflags="-s -w -X main.version=$(VERSION)" -o $(BINARY)-freebsd .
 
 vm-linux-start:
 	@command -v limactl >/dev/null 2>&1 || { \
@@ -100,6 +121,8 @@ vm-linux-start:
 	  echo "==> Starting existing VM $(VM_LINUX)..."; \
 	  limactl start $(VM_LINUX); \
 	else \
+	  echo "==> Creating ZFS data disk..."; \
+	  limactl disk create dumpstore-linux-data --size 10GiB 2>/dev/null || true; \
 	  echo "==> Creating and provisioning VM $(VM_LINUX) (first run, takes a few minutes)..."; \
 	  limactl create --name=$(VM_LINUX) dev/lima-linux.yaml; \
 	  limactl start $(VM_LINUX); \
@@ -113,28 +136,25 @@ vm-linux-stop:
 vm-linux-ssh:
 	limactl shell $(VM_LINUX)
 
-vm-linux-deploy: build-linux
-	@echo "==> Deploying to $(VM_LINUX)..."
-	limactl copy $(BINARY)-linux $(VM_LINUX):/tmp/dumpstore
-	limactl copy -r playbooks   $(VM_LINUX):/tmp/playbooks
-	limactl copy -r static      $(VM_LINUX):/tmp/static
-	@rm -f $(BINARY)-linux
-	limactl shell --tty=false $(VM_LINUX) -- sudo sh -c '\
-	  install -d /usr/local/lib/dumpstore && \
-	  install -m 0755 /tmp/dumpstore /usr/local/lib/dumpstore/dumpstore && \
-	  rm -rf /usr/local/lib/dumpstore/playbooks /usr/local/lib/dumpstore/static && \
-	  cp -r /tmp/playbooks /usr/local/lib/dumpstore/ && \
-	  cp -r /tmp/static    /usr/local/lib/dumpstore/ && \
-	  install -d -m 0700 /etc/dumpstore && \
-	  if ! grep -q password_hash /etc/dumpstore/dumpstore.conf 2>/dev/null; then \
-	    /usr/local/lib/dumpstore/dumpstore --set-password --config /etc/dumpstore/dumpstore.conf; \
-	  fi && \
-	  systemctl restart dumpstore 2>/dev/null || /usr/local/lib/dumpstore/dumpstore \
-	    -addr :8080 -dir /usr/local/lib/dumpstore -config /etc/dumpstore/dumpstore.conf &'
-	@echo "==> Deployed. Open http://localhost:8080"
+vm-linux-deploy:
+	@echo "==> Packing source..."
+	COPYFILE_DISABLE=1 tar --no-xattrs -czf /tmp/dumpstore-src.tar.gz \
+	  --exclude='.git' --exclude='dumpstore' --exclude='*.tar.gz' \
+	  -C $(CURDIR) .
+	@echo "==> Copying source to $(VM_LINUX)..."
+	limactl copy /tmp/dumpstore-src.tar.gz $(VM_LINUX):/tmp/dumpstore-src.tar.gz
+	@rm -f /tmp/dumpstore-src.tar.gz
+	@echo "==> Running make install in VM..."
+	limactl shell --tty=false $(VM_LINUX) -- sudo sh -c \
+	  'rm -rf /tmp/dumpstore-src && mkdir /tmp/dumpstore-src && \
+	   tar -xzf /tmp/dumpstore-src.tar.gz -C /tmp/dumpstore-src && \
+	   cd /tmp/dumpstore-src && \
+	   PATH=/usr/local/go/bin:$$PATH make install'
+	@echo "==> Deployed. Open http://localhost:8080  (admin / admin)"
 
 vm-linux-destroy:
-	limactl delete --force $(VM_LINUX)
+	limactl delete --force $(VM_LINUX) || true
+	limactl disk delete dumpstore-linux-data 2>/dev/null || true
 
 vm-freebsd-start:
 	@command -v limactl >/dev/null 2>&1 || { \
@@ -147,41 +167,45 @@ vm-freebsd-start:
 	  echo "==> Starting existing VM $(VM_FREEBSD)..."; \
 	  limactl start $(VM_FREEBSD); \
 	else \
+	  echo "==> Creating ZFS data disk..."; \
+	  limactl disk create dumpstore-freebsd-data --size 10GiB 2>/dev/null || true; \
 	  echo "==> Creating and provisioning VM $(VM_FREEBSD) (first run, takes a few minutes)..."; \
 	  limactl create --name=$(VM_FREEBSD) dev/lima-freebsd.yaml; \
 	  limactl start $(VM_FREEBSD); \
 	fi
+	@echo "==> Setting up port forwarding (localhost:8081 -> VM:8080)..."
+	@ssh -F $(HOME)/.lima/$(VM_FREEBSD)/ssh.config \
+	  -L 8081:127.0.0.1:8080 -N -f -o ExitOnForwardFailure=yes \
+	  lima-$(VM_FREEBSD) 2>/dev/null || true
 	@echo "==> FreeBSD VM ready. UI will be at http://localhost:8081 after deploy."
 	@echo "    Run: make vm-freebsd-deploy"
 
 vm-freebsd-stop:
+	@pkill -f "ssh.*8081:127.0.0.1:8080" 2>/dev/null || true
 	limactl stop $(VM_FREEBSD)
 
 vm-freebsd-ssh:
 	limactl shell $(VM_FREEBSD)
 
-vm-freebsd-deploy: build-freebsd
-	@echo "==> Deploying to $(VM_FREEBSD)..."
-	limactl copy $(BINARY)-freebsd $(VM_FREEBSD):/tmp/dumpstore
-	limactl copy -r playbooks      $(VM_FREEBSD):/tmp/playbooks
-	limactl copy -r static         $(VM_FREEBSD):/tmp/static
-	@rm -f $(BINARY)-freebsd
-	limactl shell --tty=false $(VM_FREEBSD) -- sudo sh -c '\
-	  install -d /usr/local/lib/dumpstore && \
-	  install -m 0755 /tmp/dumpstore /usr/local/lib/dumpstore/dumpstore && \
-	  rm -rf /usr/local/lib/dumpstore/playbooks /usr/local/lib/dumpstore/static && \
-	  cp -r /tmp/playbooks /usr/local/lib/dumpstore/ && \
-	  cp -r /tmp/static    /usr/local/lib/dumpstore/ && \
-	  install -d -m 0700 /usr/local/etc/dumpstore && \
-	  if ! grep -q password_hash /usr/local/etc/dumpstore/dumpstore.conf 2>/dev/null; then \
-	    /usr/local/lib/dumpstore/dumpstore --set-password --config /usr/local/etc/dumpstore/dumpstore.conf; \
-	  fi && \
-	  service dumpstore restart 2>/dev/null || /usr/local/lib/dumpstore/dumpstore \
-	    -addr :8080 -dir /usr/local/lib/dumpstore -config /usr/local/etc/dumpstore/dumpstore.conf &'
-	@echo "==> Deployed. Open http://localhost:8081"
+vm-freebsd-deploy:
+	@echo "==> Packing source..."
+	COPYFILE_DISABLE=1 tar --no-xattrs -czf /tmp/dumpstore-src.tar.gz \
+	  --exclude='.git' --exclude='dumpstore' --exclude='*.tar.gz' \
+	  -C $(CURDIR) .
+	@echo "==> Copying source to $(VM_FREEBSD)..."
+	limactl copy /tmp/dumpstore-src.tar.gz $(VM_FREEBSD):/tmp/dumpstore-src.tar.gz
+	@rm -f /tmp/dumpstore-src.tar.gz
+	@echo "==> Running make install in VM..."
+	limactl shell --tty=false $(VM_FREEBSD) -- sudo sh -c \
+	  'rm -rf /tmp/dumpstore-src && mkdir /tmp/dumpstore-src && \
+	   tar --no-xattrs -xzf /tmp/dumpstore-src.tar.gz -C /tmp/dumpstore-src && \
+	   cd /tmp/dumpstore-src && \
+	   PATH=/usr/local/go/bin:/usr/local/bin:$$PATH make install'
+	@echo "==> Deployed. Open http://localhost:8081  (admin / admin)"
 
 vm-freebsd-destroy:
-	limactl delete --force $(VM_FREEBSD)
+	limactl delete --force $(VM_FREEBSD) || true
+	limactl disk delete dumpstore-freebsd-data 2>/dev/null || true
 
 uninstall:
 	@set -e; \

--- a/README.md
+++ b/README.md
@@ -496,6 +496,50 @@ sudo ./dumpstore -addr :8080 -dir .
 
 `-dir` must point to the directory that contains `playbooks/` and `static/`. It defaults to the directory of the executable.
 
+## Local development
+
+### Stub mode (no ZFS required)
+
+Run against fake CLI stubs on macOS or any machine without ZFS/Ansible:
+
+```bash
+make dev
+```
+
+`dev/bin/` stubs intercept `zfs`, `zpool`, and `ansible-playbook` with static responses so the full UI renders and write dialogs show op-logs.
+
+### VM mode (real ZFS, Linux and FreeBSD)
+
+Spin up headless Lima VMs with ZFS and Ansible pre-provisioned. Requires [Lima](https://github.com/lima-vm/lima):
+
+```bash
+brew install lima        # Homebrew
+sudo port install lima   # MacPorts
+# or download from https://github.com/lima-vm/lima/releases
+```
+
+**Linux (Ubuntu 24.04, port 8080):**
+
+```bash
+make vm-linux-start    # create + boot (first run provisions the VM, ~5 min)
+make vm-linux-deploy   # cross-compile arm64 binary, rsync, start service
+make vm-linux-ssh      # open a shell inside the VM
+make vm-linux-stop     # suspend
+make vm-linux-destroy  # tear down completely
+```
+
+**FreeBSD 14 (port 8081):**
+
+```bash
+make vm-freebsd-start
+make vm-freebsd-deploy
+make vm-freebsd-ssh
+make vm-freebsd-stop
+make vm-freebsd-destroy
+```
+
+Both VMs run arm64. The Linux VM uses Apple's Virtualization framework (fast). The FreeBSD VM uses QEMU (Apple VZ does not support FreeBSD yet). Both get a `tank` ZFS pool on a dedicated 10 GiB disk created at first boot. Port forwards are fixed — Linux on `:8080`, FreeBSD on `:8081` — so both can be up simultaneously.
+
 ## Uninstall
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -522,13 +522,13 @@ sudo port install lima   # MacPorts
 
 ```bash
 make vm-linux-start    # create + boot (first run provisions the VM, ~5 min)
-make vm-linux-deploy   # cross-compile arm64 binary, rsync, start service
+make vm-linux-deploy   # pack source, copy to VM, run make install natively
 make vm-linux-ssh      # open a shell inside the VM
 make vm-linux-stop     # suspend
 make vm-linux-destroy  # tear down completely
 ```
 
-**FreeBSD 14 (port 8081):**
+**FreeBSD 15 (port 8081):**
 
 ```bash
 make vm-freebsd-start
@@ -538,7 +538,7 @@ make vm-freebsd-stop
 make vm-freebsd-destroy
 ```
 
-Both VMs run arm64. The Linux VM uses Apple's Virtualization framework (fast). The FreeBSD VM uses QEMU (Apple VZ does not support FreeBSD yet). Both get a `tank` ZFS pool on a dedicated 10 GiB disk created at first boot. Port forwards are fixed — Linux on `:8080`, FreeBSD on `:8081` — so both can be up simultaneously.
+Both VMs run arm64 via QEMU. Each gets a dedicated 10 GiB extra disk for ZFS (`tank` pool created at first boot). Deployment packs the source tree on the host, copies it into the VM, and runs `make install` natively — no cross-compilation. Port forwards are fixed: Linux on `:8080`, FreeBSD on `:8081`, so both can be up simultaneously. Default credentials: **admin / admin**.
 
 ## Uninstall
 

--- a/dev/lima-freebsd.yaml
+++ b/dev/lima-freebsd.yaml
@@ -1,0 +1,67 @@
+# Lima VM — FreeBSD 14 with ZFS + Ansible
+# Used for dumpstore development and integration testing on FreeBSD.
+# Uses QEMU backend — Apple Virtualization framework does not support FreeBSD.
+#
+# Prerequisites: brew install lima
+# Usage:        make vm-freebsd-start
+
+vmType: qemu
+os: FreeBSD
+arch: aarch64
+
+cpus: 2
+memory: 2GiB
+disk: 20GiB
+
+# Extra disk for a second ZFS pool (zroot already exists from base install)
+additionalDisks:
+  - name: zfsdata
+    size: 10GiB
+    format: false   # raw, unformatted — ZFS will own it
+
+images:
+  - location: "https://download.freebsd.org/releases/VM-IMAGES/14.2-RELEASE/aarch64/Latest/FreeBSD-14.2-RELEASE-arm64-aarch64-ZFS.img.xz"
+    arch: aarch64
+
+# Forward dumpstore UI port to host
+portForwards:
+  - guestPort: 8080
+    hostPort: 8081   # 8081 to avoid clash when both VMs are up simultaneously
+
+mounts: []
+
+provision:
+  - mode: system
+    script: |
+      #!/bin/sh
+      set -eu
+
+      echo "==> Installing pkg dependencies..."
+      # Bootstrap pkg if not already present
+      ASSUME_ALWAYS_YES=yes pkg bootstrap -f 2>/dev/null || true
+      pkg update -q
+
+      echo "==> Installing Ansible + Python..."
+      pkg install -y ansible python311
+
+      echo "==> Installing optional tools..."
+      pkg install -y smartmontools rsync
+
+      echo "==> Enabling ZFS in rc.conf..."
+      sysrc zfs_enable="YES"
+
+      echo "==> Creating second ZFS pool on /dev/vtbd1..."
+      # Wait for the extra disk to appear
+      for i in $(seq 1 10); do
+        [ -c /dev/vtbd1 ] && break
+        sleep 2
+      done
+      if [ -c /dev/vtbd1 ]; then
+        zpool create -f tank /dev/vtbd1
+        zfs create tank/data
+        echo "==> ZFS pool 'tank' created."
+      else
+        echo "WARN: /dev/vtbd1 not found — extra pool not created. zroot is still available."
+      fi
+
+      echo "==> Provisioning complete."

--- a/dev/lima-freebsd.yaml
+++ b/dev/lima-freebsd.yaml
@@ -1,8 +1,8 @@
-# Lima VM — FreeBSD 14 with ZFS + Ansible
+# Lima VM — FreeBSD 15 with ZFS + Ansible
 # Used for dumpstore development and integration testing on FreeBSD.
 # Uses QEMU backend — Apple Virtualization framework does not support FreeBSD.
 #
-# Prerequisites: brew install lima
+# Prerequisites: brew install lima   (or MacPorts: sudo port install lima)
 # Usage:        make vm-freebsd-start
 
 vmType: qemu
@@ -15,12 +15,11 @@ disk: 20GiB
 
 # Extra disk for a second ZFS pool (zroot already exists from base install)
 additionalDisks:
-  - name: zfsdata
-    size: 10GiB
+  - name: dumpstore-freebsd-data
     format: false   # raw, unformatted — ZFS will own it
 
 images:
-  - location: "https://download.freebsd.org/releases/VM-IMAGES/14.2-RELEASE/aarch64/Latest/FreeBSD-14.2-RELEASE-arm64-aarch64-ZFS.img.xz"
+  - location: "https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/aarch64/Latest/FreeBSD-15.0-RELEASE-arm64-aarch64-BASIC-CLOUDINIT-zfs.qcow2.xz"
     arch: aarch64
 
 # Forward dumpstore UI port to host
@@ -49,6 +48,10 @@ provision:
 
       echo "==> Enabling ZFS in rc.conf..."
       sysrc zfs_enable="YES"
+
+      echo "==> Writing default dev config (admin/admin)..."
+      install -d -m 0700 /usr/local/etc/dumpstore
+      python3.11 -c 'import json,os; cfg={"username":"admin","password_hash":"$2a$10$7Kfic7R28U4V1ePxnvrA.OkJwiahwkmbRrnEDEKW6RbvC/G86Q8nC","session_ttl":"24h","trusted_proxies":[],"unprotected_paths":["/metrics"],"tls_enabled":False,"tls_cert_path":"","tls_key_path":"","acme_enabled":False,"acme_email":"","acme_domain":""}; f=open("/usr/local/etc/dumpstore/dumpstore.conf","w"); json.dump(cfg,f,indent=2); f.close(); os.chmod("/usr/local/etc/dumpstore/dumpstore.conf",0o600)'
 
       echo "==> Creating second ZFS pool on /dev/vtbd1..."
       # Wait for the extra disk to appear

--- a/dev/lima-linux.yaml
+++ b/dev/lima-linux.yaml
@@ -1,0 +1,66 @@
+# Lima VM — Ubuntu 24.04 LTS with ZFS + Ansible
+# Used for dumpstore development and integration testing on Linux.
+#
+# Prerequisites: brew install lima
+# Usage:        make vm-linux-start
+
+vmType: qemu
+os: Linux
+arch: aarch64
+
+cpus: 2
+memory: 2GiB
+disk: 20GiB
+
+# Extra disk for ZFS pool (separate from the OS disk)
+additionalDisks:
+  - name: zfsdata
+    size: 10GiB
+    format: false   # raw, unformatted — ZFS will own it
+
+images:
+  - location: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img"
+    arch: aarch64
+
+# Forward dumpstore UI port to host
+portForwards:
+  - guestPort: 8080
+    hostPort: 8080
+
+mounts: []
+
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+
+      export DEBIAN_FRONTEND=noninteractive
+
+      echo "==> Updating apt..."
+      apt-get update -qq
+
+      echo "==> Installing ZFS..."
+      apt-get install -y -qq zfsutils-linux
+
+      echo "==> Installing Ansible + Python..."
+      apt-get install -y -qq ansible python3 python3-pip
+
+      echo "==> Installing optional tools..."
+      apt-get install -y -qq smartmontools rsync
+
+      echo "==> Creating ZFS pool on /dev/vdb..."
+      # Wait for the extra disk to appear
+      for i in $(seq 1 10); do
+        [ -b /dev/vdb ] && break
+        sleep 2
+      done
+      if [ -b /dev/vdb ]; then
+        zpool create -f tank /dev/vdb
+        zfs create tank/data
+        echo "==> ZFS pool 'tank' created."
+      else
+        echo "WARN: /dev/vdb not found — ZFS pool not created. Run: zpool create -f tank <disk>"
+      fi
+
+      echo "==> Provisioning complete."

--- a/dev/lima-linux.yaml
+++ b/dev/lima-linux.yaml
@@ -1,7 +1,8 @@
 # Lima VM — Ubuntu 24.04 LTS with ZFS + Ansible
 # Used for dumpstore development and integration testing on Linux.
+# Default credentials: admin / admin
 #
-# Prerequisites: brew install lima
+# Prerequisites: brew install lima   (or MacPorts: sudo port install lima)
 # Usage:        make vm-linux-start
 
 vmType: qemu
@@ -14,8 +15,7 @@ disk: 20GiB
 
 # Extra disk for ZFS pool (separate from the OS disk)
 additionalDisks:
-  - name: zfsdata
-    size: 10GiB
+  - name: dumpstore-linux-data
     format: false   # raw, unformatted — ZFS will own it
 
 images:
@@ -44,13 +44,16 @@ provision:
       apt-get install -y -qq zfsutils-linux
 
       echo "==> Installing Ansible + Python..."
-      apt-get install -y -qq ansible python3 python3-pip
+      apt-get install -y -qq ansible python3
 
       echo "==> Installing optional tools..."
-      apt-get install -y -qq smartmontools rsync
+      apt-get install -y -qq smartmontools rsync make
+
+      echo "==> Writing default dev config (admin/admin)..."
+      install -d -m 0700 /etc/dumpstore
+      python3 -c 'import json,os; cfg={"username":"admin","password_hash":"$2a$10$7Kfic7R28U4V1ePxnvrA.OkJwiahwkmbRrnEDEKW6RbvC/G86Q8nC","session_ttl":"24h","trusted_proxies":[],"unprotected_paths":["/metrics"],"tls_enabled":False,"tls_cert_path":"","tls_key_path":"","acme_enabled":False,"acme_email":"","acme_domain":""}; f=open("/etc/dumpstore/dumpstore.conf","w"); json.dump(cfg,f,indent=2); f.close(); os.chmod("/etc/dumpstore/dumpstore.conf",0o600)'
 
       echo "==> Creating ZFS pool on /dev/vdb..."
-      # Wait for the extra disk to appear
       for i in $(seq 1 10); do
         [ -b /dev/vdb ] && break
         sleep 2

--- a/docs/index.html
+++ b/docs/index.html
@@ -747,7 +747,8 @@
 cd dumpstore
 sudo ./install.sh</pre>
         <p class="install-note">
-          The script checks prerequisites, compiles the binary, copies everything to
+          Thin wrapper around <code>make install</code>. Auto-installs Go and Ansible
+          if absent, compiles the binary, copies everything to
           <code>/usr/local/lib/dumpstore/</code>, prompts for an admin password,
           then registers and starts the service —
           systemd on Linux, rc.d on FreeBSD.

--- a/internal/smb/config.go
+++ b/internal/smb/config.go
@@ -231,7 +231,7 @@ func parseFromBytes(data []byte) (SMBConfig, error) {
 // DirsToCreate returns all directory paths referenced by this config that
 // must exist before the config is applied.
 func (c *SMBConfig) DirsToCreate() []string {
-	var dirs []string
+	dirs := []string{}
 	if c.Homes != nil && c.Homes.Path != "" {
 		// Strip %U and similar substitutions to get the base directory
 		base := strings.TrimSuffix(c.Homes.Path, "/%U")

--- a/playbooks/smb_apply.yml
+++ b/playbooks/smb_apply.yml
@@ -30,8 +30,8 @@
         state: directory
         owner: root
         mode: "0755"
-      loop: "{{ dirs | from_json }}"
-      when: (dirs | from_json) | length > 0
+      loop: "{{ dirs | from_json | default([]) }}"
+      when: (dirs | from_json | default([])) | length > 0
 
     - name: Deploy smb.conf atomically
       ansible.builtin.copy:

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -63,7 +63,7 @@ ansible-playbook playbooks/smb_setup.yml
 
 ## Install script (recommended)
 
-Clone the repository and run `install.sh` as root. It checks prerequisites, builds the binary, installs everything to `/usr/local/lib/dumpstore/`, **prompts for an admin password**, and registers the service.
+Clone the repository and run `install.sh` as root. It is a thin wrapper around `make install`, which auto-installs Go and Ansible if absent, builds the binary, installs everything to `/usr/local/lib/dumpstore/`, **prompts for an admin password**, and registers the service.
 
 ```bash
 git clone https://github.com/langerma/dumpstore.git


### PR DESCRIPTION
## Summary

- Adds `make vm-linux-start/deploy` and `make vm-freebsd-start/deploy` targets that spin up headless Lima VMs (Ubuntu 24.04 + FreeBSD 15) with ZFS, Ansible, and Go pre-installed
- Source is packed on the host and `make install` runs natively inside the VM — no cross-compilation needed
- Linux UI at http://localhost:8080, FreeBSD at http://localhost:8081; default credentials admin/admin
- FreeBSD port forwarding via explicit SSH tunnel (`-L 8081:127.0.0.1:8080`) since Lima ships no FreeBSD guest agent
- Makefile is now BSD/GNU make compatible; `check-prereqs` auto-installs Go (from go.dev) and Ansible (`apt-get`/`pkg`) if absent
- `install.sh` reduced to a thin root-check wrapper around `make install`
- Fix: `DirsToCreate()` returned Go `nil` slice → JSON `null` → Ansible `from_json` returned Python `None` → loop failed on SMB apply with no directories; fixed by initialising to `[]string{}` and adding `| default([])` in `smb_apply.yml`

## Test plan

- [x] `make vm-linux-start` — VM provisions without error
- [x] `make vm-linux-deploy` — installs dumpstore; UI accessible at http://localhost:8080 (admin/admin)
- [x] `make vm-freebsd-start` — VM provisions without error; SSH tunnel to port 8081 established
- [x] `make vm-freebsd-deploy` — installs dumpstore; UI accessible at http://localhost:8081 (admin/admin)
- [x] `make vm-linux-destroy && make vm-freebsd-destroy` — clean teardown
- [x] `make install` on a clean Linux system with no Go/Ansible — prereqs auto-install
- [x] SMB apply with no home path / no TM shares — no Ansible loop failure

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)