### PR TITLE
refactor: fix authCfg data race, reduce handler boilerplate, extract …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented here.
 - **Dev VM environment** — `make vm-linux-start/deploy` and `make vm-freebsd-start/deploy` spin up headless Lima VMs (Ubuntu 24.04 + FreeBSD 15) with ZFS, Ansible, and Go pre-installed; source is packed and `make install` runs natively inside the VM; Linux UI at http://localhost:8080, FreeBSD at http://localhost:8081; VMs use dedicated extra disks for ZFS (`dumpstore-linux-data`, `dumpstore-freebsd-data`); default credentials admin/admin; closes #83
 
 ### Changed
+- **authCfg thread safety** — added `sync.RWMutex` to protect concurrent reads/writes of in-memory auth config (`PasswordHash`, `Username`, TLS/ACME fields); eliminates a data race under concurrent requests
+- **Consistent JSON decoding** — all API endpoints now use the `decodeJSON` helper (rejects trailing garbage after the JSON value); 8 endpoints previously used raw `json.NewDecoder().Decode()`
+- **Handler boilerplate reduction** — new `writeRunOpError` helper replaces 33 instances of the 5-line error-handling pattern after `runOp` calls; ~165 lines removed
+- **Consistent SSE publish after mutations** — `createDataset`, `deleteDataset`, `createSnapshot`, `deleteSnapshot`, `deleteSnapshotBatch`, `startScrub`, and `cancelScrub` now immediately push SSE updates (previously relied on the 10 s poller); new `publishSnapshots()` and `publishPools()` helpers
+- **Logging extracted from main.go** — `journalHandler` and `requestLogger` middleware moved to new `internal/logging/` package (`NewJournalHandler`, `RequestLogger`); `main.go` reduced from 345 to 180 lines
 - **Makefile** — BSD/GNU make compatible (no `$(shell ...)` at parse time); `check-prereqs` now auto-installs Go (from go.dev) and Ansible (`apt-get`/`pkg`) if absent; `install.sh` reduced to a thin root-check wrapper around `make install`
 - **FreeBSD VM port forwarding** — SSH tunnel (`-L 8081:127.0.0.1:8080`) set up in `vm-freebsd-start` as Lima's guest agent is Linux/Darwin-only; torn down in `vm-freebsd-stop`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,12 +142,14 @@ Do not change this split without a good reason — it exists to avoid Ansible's 
 
 | File | Responsibility |
 |------|----------------|
-| `main.go` | Server setup, flag parsing, dependency check (`ansible-playbook` in PATH, `playbooks/` and `static/` dirs exist) |
+| `main.go` | Server setup, flag parsing, dependency check (`ansible-playbook` in PATH, `playbooks/` and `static/` dirs exist). Logging and request middleware live in `internal/logging/`. |
 | `internal/zfs/zfs.go` | `ListPools`, `ListDatasets`, `ListSnapshots`, `IOStats` — all direct CLI calls |
 | `internal/zfs/acl.go` | ACL helpers for POSIX and NFSv4 — `GetPosixACL`, `GetNFS4ACL` |
 | `internal/ansible/runner.go` | `Runner.Run` — executes a playbook and returns parsed `PlaybookOutput`; `RunAndGetStdout` — convenience wrapper |
 | `internal/ansible/metrics.go` | Prometheus counters/histograms for Ansible playbook runs |
-| `internal/api/handlers.go` | Shared infra: validation helpers, `Handler` struct, `RegisterRoutes`, `runOp`, `writeJSON`/`writeError`, `getSysInfo`, `getVersion`, `getEvents`, `getSchema` |
+| `internal/api/handlers.go` | Shared infra: validation helpers, `Handler` struct (with `authMu` RWMutex for config access), `RegisterRoutes`, `runOp`, `writeJSON`/`writeError`/`writeRunOpError`, `getSysInfo`, `getVersion`, `getEvents`, `getSchema` |
+| `internal/logging/handler.go` | `NewJournalHandler` — slog handler with systemd journal priority prefixes |
+| `internal/logging/middleware.go` | `RequestLogger` — HTTP middleware for per-request logging with req_id correlation |
 | `internal/api/zfs_handlers.go` | ZFS handlers: pools, datasets, snapshots, SMART, IOStat, chown, scrub, auto-snapshot |
 | `internal/api/user_handlers.go` | User + group handlers, SSH key management |
 | `internal/api/acl_handlers.go` | ACL handlers (POSIX + NFSv4) |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 │  • startup: checks ansible-playbook in PATH,                        │
 │             playbooks/ and static/ dirs exist                       │
 │  • signal.NotifyContext → graceful shutdown on SIGTERM/SIGINT       │
-│  • requestLogger middleware (method/path/status/ms/req_id)          │
+│  • logging.RequestLogger middleware (method/path/status/ms/req_id)  │
 │    ↳ reads X-Request-ID from proxy, generates one if absent,        │
 │      echoes it back on the response, stores in ctx for slog         │
 │  • GET /      → http.FileServer  (static/)                          │

--- a/internal/api/acl_handlers.go
+++ b/internal/api/acl_handlers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"dumpstore/internal/ansible"
 	"dumpstore/internal/zfs"
 )
 
@@ -182,11 +181,7 @@ func (h *Handler) setACLEntry(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp(playbook, vars)
 	auditLog(r.Context(), r, "acl.set", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"dataset": name, "ace": req.ACE, "tasks": out.Steps()})
@@ -304,11 +299,7 @@ func (h *Handler) removeACLEntry(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp(playbook, vars)
 	auditLog(r.Context(), r, "acl.remove", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"dataset": name, "entry": entry, "tasks": out.Steps()})

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"regexp"
@@ -18,11 +17,16 @@ func (h *Handler) changePassword(w http.ResponseWriter, r *http.Request) {
 		CurrentPassword string `json:"current_password"`
 		NewPassword     string `json:"new_password"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid request body"), nil)
 		return
 	}
-	if h.authCfg.PasswordHash == "" || bcrypt.CompareHashAndPassword([]byte(h.authCfg.PasswordHash), []byte(req.CurrentPassword)) != nil {
+
+	h.authMu.RLock()
+	pwHash := h.authCfg.PasswordHash
+	h.authMu.RUnlock()
+
+	if pwHash == "" || bcrypt.CompareHashAndPassword([]byte(pwHash), []byte(req.CurrentPassword)) != nil {
 		writeError(r.Context(), w, http.StatusUnauthorized, errors.New("current password is incorrect"), nil)
 		return
 	}
@@ -40,16 +44,16 @@ func (h *Handler) changePassword(w http.ResponseWriter, r *http.Request) {
 		"password_hash": string(hash),
 	})
 	if err != nil {
-		if out != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
-		} else {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
-		}
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	// Update in-memory config so subsequent logins use the new hash immediately.
+	h.authMu.Lock()
 	h.authCfg.PasswordHash = string(hash)
-	auditLog(r.Context(), r, "auth.change_password", h.authCfg.Username, nil)
+	username := h.authCfg.Username
+	h.authMu.Unlock()
+
+	auditLog(r.Context(), r, "auth.change_password", username, nil)
 	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})
 }
 
@@ -57,7 +61,7 @@ func (h *Handler) changeUsername(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Username string `json:"username"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid request body"), nil)
 		return
 	}
@@ -70,15 +74,15 @@ func (h *Handler) changeUsername(w http.ResponseWriter, r *http.Request) {
 		"username":    req.Username,
 	})
 	if err != nil {
-		if out != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
-		} else {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
-		}
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	auditLog(r.Context(), r, "auth.change_username", req.Username, nil)
+
+	h.authMu.Lock()
 	h.authCfg.Username = req.Username
+	h.authMu.Unlock()
+
 	// Invalidate all sessions — the username changed so everyone must re-login.
 	h.authStore.DeleteAll()
 	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -166,6 +166,7 @@ type Handler struct {
 	broker     *broker.Broker
 	userMu     sync.Mutex // serialises user/group write ops to avoid /etc/group lock contention
 	smbMu      sync.Mutex // serialises smb.conf read-modify-write cycles
+	authMu     sync.RWMutex // protects concurrent access to authCfg fields
 	authCfg    *auth.Config
 	authStore  *auth.SessionStore
 	configPath string
@@ -181,6 +182,20 @@ func NewHandler(runner *ansible.Runner, version string, b *broker.Broker, authCf
 		authStore:  authStore,
 		configPath: configPath,
 	}
+}
+
+// AuthCfgRead calls fn while holding the authCfg read lock.
+func (h *Handler) AuthCfgRead(fn func(*auth.Config)) {
+	h.authMu.RLock()
+	defer h.authMu.RUnlock()
+	fn(h.authCfg)
+}
+
+// AuthCfgWrite calls fn while holding the authCfg write lock.
+func (h *Handler) AuthCfgWrite(fn func(*auth.Config)) {
+	h.authMu.Lock()
+	defer h.authMu.Unlock()
+	fn(h.authCfg)
 }
 
 // auditLog emits a structured audit log line for every mutating API operation.
@@ -410,6 +425,17 @@ func writeJSON(ctx context.Context, w http.ResponseWriter, v any) {
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		slog.ErrorContext(ctx, "writeJSON encode failed", "err", err)
 	}
+}
+
+// writeRunOpError is a convenience wrapper for the common pattern of returning
+// an error from runOp. It extracts task steps from out (if non-nil) and writes
+// a 500 response.
+func writeRunOpError(ctx context.Context, w http.ResponseWriter, err error, out *ansible.PlaybookOutput) {
+	var steps []ansible.TaskStep
+	if out != nil {
+		steps = out.Steps()
+	}
+	writeError(ctx, w, http.StatusInternalServerError, err, steps)
 }
 
 func writeError(ctx context.Context, w http.ResponseWriter, code int, err error, steps []ansible.TaskStep) {

--- a/internal/api/iscsi_handlers.go
+++ b/internal/api/iscsi_handlers.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"dumpstore/internal/ansible"
 	"dumpstore/internal/iscsi"
 )
 
@@ -122,11 +121,7 @@ func (h *Handler) createISCSITarget(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "iscsi.create", req.Zvol, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"zvol": req.Zvol, "iqn": req.IQN, "tasks": out.Steps()})
@@ -160,11 +155,7 @@ func (h *Handler) deleteISCSITarget(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp(playbook, map[string]string{"iqn": iqn, "zvol": zvol})
 	auditLog(r.Context(), r, "iscsi.delete", zvol, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"iqn": iqn, "zvol": zvol, "tasks": out.Steps()})

--- a/internal/api/service_handlers.go
+++ b/internal/api/service_handlers.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"runtime"
 
-	"dumpstore/internal/ansible"
 	"dumpstore/internal/system"
 )
 
@@ -62,11 +61,7 @@ func (h *Handler) mutateService(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "service."+action, svc, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"service": svc, "tasks": out.Steps()})

--- a/internal/api/smb_handlers.go
+++ b/internal/api/smb_handlers.go
@@ -176,11 +176,7 @@ func (h *Handler) setSMBShare(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "smb_share.set", dataset, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"dataset": dataset, "sharename": req.Sharename, "tasks": out.Steps()})
@@ -210,11 +206,7 @@ func (h *Handler) deleteSMBShare(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "smb_share.delete", dataset, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"dataset": dataset, "sharename": sharename, "tasks": out.Steps()})
@@ -274,11 +266,7 @@ func (h *Handler) addSambaUser(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "smb_user.add", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"username": name, "tasks": out.Steps()})
@@ -305,11 +293,7 @@ func (h *Handler) removeSambaUser(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "smb_user.remove", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"username": name, "tasks": out.Steps()})
@@ -349,7 +333,7 @@ func (h *Handler) setSMBHomes(w http.ResponseWriter, r *http.Request) {
 		CreateMask    string `json:"create_mask"`
 		DirectoryMask string `json:"directory_mask"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err), nil)
 		return
 	}
@@ -426,11 +410,7 @@ func (h *Handler) setSMBHomes(w http.ResponseWriter, r *http.Request) {
 	out, err := h.applyConfig(r, &cfg)
 	auditLog(r.Context(), r, "smb_homes.set", req.Dataset, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{
@@ -462,11 +442,7 @@ func (h *Handler) deleteSMBHomes(w http.ResponseWriter, r *http.Request) {
 	out, err := h.applyConfig(r, &cfg)
 	auditLog(r.Context(), r, "smb_homes.delete", "", err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})
@@ -498,7 +474,7 @@ func (h *Handler) createTimeMachineShare(w http.ResponseWriter, r *http.Request)
 		MaxSize    string `json:"max_size"`
 		ValidUsers string `json:"valid_users"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid JSON: %w", err), nil)
 		return
 	}
@@ -564,11 +540,7 @@ func (h *Handler) createTimeMachineShare(w http.ResponseWriter, r *http.Request)
 	out, err := h.applyConfig(r, &cfg)
 	auditLog(r.Context(), r, "smb_timemachine.create", req.Dataset, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	shares := cfg.TimeMachine
@@ -613,11 +585,7 @@ func (h *Handler) deleteTimeMachineShare(w http.ResponseWriter, r *http.Request)
 	out, err := h.applyConfig(r, &cfg)
 	auditLog(r.Context(), r, "smb_timemachine.delete", sharename, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})

--- a/internal/api/tls_handlers.go
+++ b/internal/api/tls_handlers.go
@@ -3,7 +3,6 @@ package api
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -15,26 +14,27 @@ import (
 )
 
 var (
-	reDomain = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
-	reEmail  = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
+	reDomain  = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
+	reEmail   = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
 	reTLSPath = regexp.MustCompile(`^/[^\x00;|&$` + "`" + `]+$`)
 )
 
 type tlsStatusResponse struct {
-	Enabled      bool     `json:"enabled"`
-	CertPath     string   `json:"cert_path,omitempty"`
-	KeyPath      string   `json:"key_path,omitempty"`
-	CN           string   `json:"cn,omitempty"`
-	SANs         []string `json:"sans,omitempty"`
-	ExpiresAt    string   `json:"expires_at,omitempty"`
-	DaysRemaining int     `json:"days_remaining,omitempty"`
-	SelfSigned   bool     `json:"self_signed,omitempty"`
-	ACMEEmail    string   `json:"acme_email,omitempty"`
-	ACMEDomain   string   `json:"acme_domain,omitempty"`
+	Enabled       bool     `json:"enabled"`
+	CertPath      string   `json:"cert_path,omitempty"`
+	KeyPath       string   `json:"key_path,omitempty"`
+	CN            string   `json:"cn,omitempty"`
+	SANs          []string `json:"sans,omitempty"`
+	ExpiresAt     string   `json:"expires_at,omitempty"`
+	DaysRemaining int      `json:"days_remaining,omitempty"`
+	SelfSigned    bool     `json:"self_signed,omitempty"`
+	ACMEEmail     string   `json:"acme_email,omitempty"`
+	ACMEDomain    string   `json:"acme_domain,omitempty"`
 }
 
 // getTLSStatus returns the current TLS configuration and cert metadata.
 func (h *Handler) getTLSStatus(w http.ResponseWriter, r *http.Request) {
+	h.authMu.RLock()
 	resp := tlsStatusResponse{
 		Enabled:    h.authCfg.TLSEnabled,
 		CertPath:   h.authCfg.TLSCertPath,
@@ -42,9 +42,11 @@ func (h *Handler) getTLSStatus(w http.ResponseWriter, r *http.Request) {
 		ACMEEmail:  h.authCfg.ACMEEmail,
 		ACMEDomain: h.authCfg.ACMEDomain,
 	}
+	certPath := h.authCfg.TLSCertPath
+	h.authMu.RUnlock()
 
-	if h.authCfg.TLSCertPath != "" {
-		if meta, err := parseCertMeta(h.authCfg.TLSCertPath); err == nil {
+	if certPath != "" {
+		if meta, err := parseCertMeta(certPath); err == nil {
 			resp.CN = meta.cn
 			resp.SANs = meta.sans
 			resp.ExpiresAt = meta.expiresAt.Format(time.RFC3339)
@@ -62,7 +64,7 @@ func (h *Handler) tlsGenCert(w http.ResponseWriter, r *http.Request) {
 		Hostname string `json:"hostname"`
 		CertDir  string `json:"cert_dir"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid request body"), nil)
 		return
 	}
@@ -87,11 +89,7 @@ func (h *Handler) tlsGenCert(w http.ResponseWriter, r *http.Request) {
 		"cert_dir": req.CertDir,
 	})
 	if err != nil {
-		if out != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
-		} else {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
-		}
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 
@@ -113,9 +111,11 @@ func (h *Handler) tlsGenCert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.authMu.Lock()
 	h.authCfg.TLSCertPath = certPath
 	h.authCfg.TLSKeyPath = keyPath
 	h.authCfg.TLSEnabled = true
+	h.authMu.Unlock()
 
 	auditLog(r.Context(), r, "tls.gencert", req.Hostname, nil)
 
@@ -130,7 +130,7 @@ func (h *Handler) tlsSetConfig(w http.ResponseWriter, r *http.Request) {
 		CertPath string `json:"cert_path"`
 		KeyPath  string `json:"key_path"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid request body"), nil)
 		return
 	}
@@ -156,17 +156,15 @@ func (h *Handler) tlsSetConfig(w http.ResponseWriter, r *http.Request) {
 		"enabled":     "true",
 	})
 	if err != nil {
-		if out != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
-		} else {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
-		}
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 
+	h.authMu.Lock()
 	h.authCfg.TLSCertPath = req.CertPath
 	h.authCfg.TLSKeyPath = req.KeyPath
 	h.authCfg.TLSEnabled = true
+	h.authMu.Unlock()
 
 	auditLog(r.Context(), r, "tls.set_config", req.CertPath, nil)
 	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})
@@ -179,7 +177,7 @@ func (h *Handler) tlsAcmeIssue(w http.ResponseWriter, r *http.Request) {
 		Domain  string `json:"domain"`
 		CertDir string `json:"cert_dir"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeJSON(r, &req); err != nil {
 		writeError(r.Context(), w, http.StatusBadRequest, errors.New("invalid request body"), nil)
 		return
 	}
@@ -209,11 +207,7 @@ func (h *Handler) tlsAcmeIssue(w http.ResponseWriter, r *http.Request) {
 		"cert_dir": req.CertDir,
 	})
 	if err != nil {
-		if out != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
-		} else {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
-		}
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 
@@ -236,12 +230,14 @@ func (h *Handler) tlsAcmeIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.authMu.Lock()
 	h.authCfg.TLSCertPath = certPath
 	h.authCfg.TLSKeyPath = keyPath
 	h.authCfg.TLSEnabled = true
 	h.authCfg.ACMEEnabled = true
 	h.authCfg.ACMEEmail = req.Email
 	h.authCfg.ACMEDomain = req.Domain
+	h.authMu.Unlock()
 
 	auditLog(r.Context(), r, "tls.acme_issue", req.Domain, nil)
 
@@ -252,37 +248,40 @@ func (h *Handler) tlsAcmeIssue(w http.ResponseWriter, r *http.Request) {
 
 // tlsAcmeRenew renews the ACME certificate using stored config.
 func (h *Handler) tlsAcmeRenew(w http.ResponseWriter, r *http.Request) {
-	if !h.authCfg.ACMEEnabled {
+	h.authMu.RLock()
+	acmeEnabled := h.authCfg.ACMEEnabled
+	acmeEmail := h.authCfg.ACMEEmail
+	acmeDomain := h.authCfg.ACMEDomain
+	certPath := h.authCfg.TLSCertPath
+	h.authMu.RUnlock()
+
+	if !acmeEnabled {
 		writeError(r.Context(), w, http.StatusBadRequest, errors.New("ACME is not configured"), nil)
 		return
 	}
-	if h.authCfg.ACMEEmail == "" || h.authCfg.ACMEDomain == "" {
+	if acmeEmail == "" || acmeDomain == "" {
 		writeError(r.Context(), w, http.StatusBadRequest, errors.New("ACME email and domain are not set"), nil)
 		return
 	}
 
 	// Derive cert_dir from stored cert path (parent of certificates/<domain>.crt)
 	certDir := filepath.Dir(h.configPath) + "/tls/acme"
-	if h.authCfg.TLSCertPath != "" {
+	if certPath != "" {
 		// Walk up two levels from <cert_dir>/certificates/<domain>.crt
-		certDir = certDirFromCertPath(h.authCfg.TLSCertPath, h.configPath)
+		certDir = certDirFromCertPath(certPath, h.configPath)
 	}
 
 	out, err := h.runOp("tls_acme_renew.yml", map[string]string{
-		"email":    h.authCfg.ACMEEmail,
-		"domain":   h.authCfg.ACMEDomain,
+		"email":    acmeEmail,
+		"domain":   acmeDomain,
 		"cert_dir": certDir,
 	})
 	if err != nil {
-		if out != nil {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, out.Steps())
-		} else {
-			writeError(r.Context(), w, http.StatusInternalServerError, err, nil)
-		}
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 
-	auditLog(r.Context(), r, "tls.acme_renew", h.authCfg.ACMEDomain, nil)
+	auditLog(r.Context(), r, "tls.acme_renew", acmeDomain, nil)
 	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})
 }
 

--- a/internal/api/user_handlers.go
+++ b/internal/api/user_handlers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"dumpstore/internal/ansible"
 	"dumpstore/internal/system"
 )
 
@@ -98,11 +97,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp("user_create.yml", vars)
 	auditLog(r.Context(), r, "user.create", req.Username, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	h.publishUserGroup()
@@ -163,11 +158,7 @@ func (h *Handler) deleteUser(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "user.delete", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	h.publishUserGroup()
@@ -269,11 +260,7 @@ func (h *Handler) modifyUser(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "user.modify", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	h.publishUserGroup()
@@ -360,11 +347,7 @@ func (h *Handler) addSSHKey(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "sshkey.add", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})
@@ -418,11 +401,7 @@ func (h *Handler) removeSSHKey(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "sshkey.remove", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"tasks": out.Steps()})
@@ -456,11 +435,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "group.create", req.Groupname, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -515,11 +490,7 @@ func (h *Handler) deleteGroup(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "group.delete", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	h.publishUserGroup()
@@ -621,11 +592,7 @@ func (h *Handler) modifyGroup(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "group.modify", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	h.publishUserGroup()

--- a/internal/api/zfs_handlers.go
+++ b/internal/api/zfs_handlers.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"dumpstore/internal/ansible"
 	"dumpstore/internal/schema"
 	"dumpstore/internal/smart"
 	"dumpstore/internal/zfs"
@@ -132,11 +131,7 @@ func (h *Handler) setDatasetProps(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp("zfs_dataset_set.yml", vars)
 	auditLog(r.Context(), r, "dataset.modify", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	h.publishDatasets()
@@ -228,14 +223,11 @@ func (h *Handler) createDataset(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp("zfs_dataset_create.yml", vars)
 	auditLog(r.Context(), r, "dataset.create", req.Name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 
+	h.publishDatasets()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(map[string]any{
@@ -307,14 +299,11 @@ func (h *Handler) createSnapshot(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "snapshot.create", req.Dataset+"@"+req.SnapName, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 
+	h.publishSnapshots()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(map[string]any{
@@ -363,14 +352,11 @@ func (h *Handler) deleteDataset(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "dataset.destroy", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 
+	h.publishDatasets()
 	writeJSON(r.Context(), w, map[string]any{"name": name, "tasks": out.Steps()})
 }
 
@@ -405,14 +391,11 @@ func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "snapshot.destroy", snapshot, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 
+	h.publishSnapshots()
 	writeJSON(r.Context(), w, map[string]any{"snapshot": snapshot, "tasks": out.Steps()})
 }
 
@@ -453,13 +436,10 @@ func (h *Handler) deleteSnapshotBatch(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "snapshot.batch_destroy", strings.Join(body.Snapshots, ","), err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
+	h.publishSnapshots()
 	writeJSON(r.Context(), w, map[string]any{"snapshots": body.Snapshots, "tasks": out.Steps()})
 }
 
@@ -560,21 +540,34 @@ func (h *Handler) setDatasetOwnership(w http.ResponseWriter, r *http.Request) {
 	})
 	auditLog(r.Context(), r, "dataset.chown", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"dataset": name, "tasks": out.Steps()})
 }
 
 // publishDatasets re-reads the dataset list and immediately pushes
-// dataset.query to all SSE subscribers. Called after any dataset property change.
+// dataset.query to all SSE subscribers. Called after any dataset mutation.
 func (h *Handler) publishDatasets() {
 	if datasets, err := zfs.ListDatasets(); err == nil {
 		h.broker.Publish("dataset.query", datasets)
+	}
+}
+
+// publishSnapshots re-reads all snapshots and pushes snapshot.query to SSE subscribers.
+func (h *Handler) publishSnapshots() {
+	if snaps, err := zfs.ListSnapshots(); err == nil {
+		h.broker.Publish("snapshot.query", snaps)
+	}
+}
+
+// publishPools re-reads pool data and pushes pool.query and poolstatus to SSE subscribers.
+func (h *Handler) publishPools() {
+	if pools, err := zfs.ListPools(); err == nil {
+		h.broker.Publish("pool.query", pools)
+	}
+	if statuses, err := zfs.PoolStatuses(); err == nil {
+		h.broker.Publish("poolstatus", statuses)
 	}
 }
 
@@ -593,13 +586,10 @@ func (h *Handler) startScrub(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp("zfs_scrub_start.yml", map[string]string{"pool": pool})
 	auditLog(r.Context(), r, "scrub.start", pool, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
+	h.publishPools()
 	writeJSON(r.Context(), w, map[string]any{"pool": pool, "tasks": out.Steps()})
 }
 
@@ -618,13 +608,10 @@ func (h *Handler) cancelScrub(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp("zfs_scrub_cancel.yml", map[string]string{"pool": pool})
 	auditLog(r.Context(), r, "scrub.cancel", pool, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
+	h.publishPools()
 	writeJSON(r.Context(), w, map[string]any{"pool": pool, "tasks": out.Steps()})
 }
 
@@ -656,7 +643,7 @@ func (h *Handler) setScrubSchedule(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			ThresholdDays int `json:"threshold_days"`
 		}
-		_ = json.NewDecoder(r.Body).Decode(&req) // threshold_days optional
+		_ = decodeJSON(r, &req) // threshold_days optional
 		if req.ThresholdDays <= 0 {
 			req.ThresholdDays = 35
 		}
@@ -666,11 +653,7 @@ func (h *Handler) setScrubSchedule(w http.ResponseWriter, r *http.Request) {
 		})
 		auditLog(r.Context(), r, "scrub_schedule.set", pool, err)
 		if err != nil {
-			var steps []ansible.TaskStep
-			if out != nil {
-				steps = out.Steps()
-			}
-			writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+			writeRunOpError(r.Context(), w, err, out)
 			return
 		}
 		writeJSON(r.Context(), w, map[string]any{"pool": pool, "tasks": out.Steps()})
@@ -681,11 +664,7 @@ func (h *Handler) setScrubSchedule(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp("zfs_scrub_zfsutils_enable.yml", map[string]string{"pool": pool})
 	auditLog(r.Context(), r, "scrub_schedule.set", pool, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"pool": pool, "tasks": out.Steps()})
@@ -709,11 +688,7 @@ func (h *Handler) deleteScrubSchedule(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp(playbook, map[string]string{"pool": pool})
 	auditLog(r.Context(), r, "scrub_schedule.delete", pool, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	writeJSON(r.Context(), w, map[string]any{"pool": pool, "tasks": out.Steps()})
@@ -821,11 +796,7 @@ func (h *Handler) setAutoSnapshotProps(w http.ResponseWriter, r *http.Request) {
 	out, err := h.runOp("zfs_autosnap_set.yml", vars)
 	auditLog(r.Context(), r, "auto_snapshot.set", name, err)
 	if err != nil {
-		var steps []ansible.TaskStep
-		if out != nil {
-			steps = out.Steps()
-		}
-		writeError(r.Context(), w, http.StatusInternalServerError, err, steps)
+		writeRunOpError(r.Context(), w, err, out)
 		return
 	}
 	h.publishDatasets()

--- a/internal/logging/handler.go
+++ b/internal/logging/handler.go
@@ -1,0 +1,111 @@
+// Package logging provides the slog handler and HTTP request logging middleware
+// used by the dumpstore server.
+package logging
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+
+	"dumpstore/internal/api"
+)
+
+// journalHandler wraps slog.TextHandler and prepends a syslog-style priority
+// prefix (<N>) to each log line when running under systemd with
+// StandardOutput=journal. systemd parses these prefixes and stores the correct
+// PRIORITY field in the journal entry, which Loki/Promtail then uses as the
+// log level label. Without the prefix every line lands at PRIORITY=6 (info).
+//
+// When JOURNAL_STREAM is not set (e.g. terminal), the prefix is omitted so
+// output stays human-readable.
+type journalHandler struct {
+	mu      sync.Mutex
+	out     io.Writer
+	opts    slog.HandlerOptions
+	journal bool // true when stdout is connected to the systemd journal
+	pre     []func(slog.Handler) slog.Handler // WithAttrs/WithGroup calls to replay
+}
+
+// NewJournalHandler returns a slog.Handler that prepends syslog priority
+// prefixes when running under the systemd journal (JOURNAL_STREAM is set).
+// Falls back to plain slog.TextHandler otherwise.
+func NewJournalHandler(out io.Writer, opts *slog.HandlerOptions) slog.Handler {
+	if opts == nil {
+		opts = &slog.HandlerOptions{}
+	}
+	if os.Getenv("JOURNAL_STREAM") == "" {
+		// Not under systemd — plain text output, no prefix noise.
+		return slog.NewTextHandler(out, opts)
+	}
+	return &journalHandler{out: out, opts: *opts, journal: true}
+}
+
+func (h *journalHandler) Enabled(_ context.Context, l slog.Level) bool {
+	min := slog.LevelInfo
+	if h.opts.Level != nil {
+		min = h.opts.Level.Level()
+	}
+	return l >= min
+}
+
+func (h *journalHandler) Handle(ctx context.Context, r slog.Record) error {
+	// Inject req_id from context if present (set by RequestLogger middleware).
+	if id := api.ReqIDFromContext(ctx); id != "" {
+		r.AddAttrs(slog.String("req_id", id))
+	}
+	// Build the formatted line into a buffer using a temporary TextHandler.
+	// WithAttrs/WithGroup calls are replayed on each Handle so attrs are included.
+	var buf bytes.Buffer
+	var sh slog.Handler = slog.NewTextHandler(&buf, &h.opts)
+	for _, fn := range h.pre {
+		sh = fn(sh)
+	}
+	if err := sh.Handle(ctx, r); err != nil {
+		return err
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.journal {
+		fmt.Fprintf(h.out, "<%d>", journalPriority(r.Level))
+	}
+	_, err := h.out.Write(buf.Bytes())
+	return err
+}
+
+func (h *journalHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	nh := h.clone()
+	nh.pre = append(nh.pre, func(sh slog.Handler) slog.Handler { return sh.WithAttrs(attrs) })
+	return nh
+}
+
+func (h *journalHandler) WithGroup(name string) slog.Handler {
+	nh := h.clone()
+	nh.pre = append(nh.pre, func(sh slog.Handler) slog.Handler { return sh.WithGroup(name) })
+	return nh
+}
+
+func (h *journalHandler) clone() *journalHandler {
+	pre := make([]func(slog.Handler) slog.Handler, len(h.pre))
+	copy(pre, h.pre)
+	return &journalHandler{out: h.out, opts: h.opts, journal: h.journal, pre: pre}
+}
+
+// journalPriority maps slog levels to syslog priority numbers understood by the
+// systemd journal: 3=err, 4=warning, 6=info, 7=debug.
+func journalPriority(l slog.Level) int {
+	switch {
+	case l >= slog.LevelError:
+		return 3
+	case l >= slog.LevelWarn:
+		return 4
+	case l >= slog.LevelInfo:
+		return 6
+	default:
+		return 7
+	}
+}

--- a/internal/logging/middleware.go
+++ b/internal/logging/middleware.go
@@ -1,0 +1,72 @@
+package logging
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"dumpstore/internal/api"
+)
+
+// newReqID returns a random 16-character hex string for request correlation.
+func newReqID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// RequestLogger wraps a handler and emits one logfmt line per request.
+// It generates a unique req_id, stores it in the request context, and includes
+// it on the request log line so downstream slog calls can be correlated.
+func RequestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get("X-Request-ID")
+		if id == "" {
+			id = newReqID()
+		}
+		r = r.WithContext(api.WithReqID(r.Context(), id))
+		w.Header().Set("X-Request-ID", id)
+
+		start := time.Now()
+		rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rw, r)
+		elapsed := time.Since(start)
+
+		level := slog.LevelInfo
+		if rw.status >= 500 {
+			level = slog.LevelError
+		} else if rw.status >= 400 {
+			level = slog.LevelWarn
+		}
+		slog.Log(r.Context(), level, "request",
+			"req_id", id,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rw.status,
+			"duration_ms", elapsed.Milliseconds(),
+			"remote", r.RemoteAddr,
+		)
+		api.RecordHTTP(r.Method, r.URL.Path, rw.status, elapsed)
+	})
+}
+
+// statusRecorder captures the HTTP status code written by a handler.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+// Flush implements http.Flusher by forwarding to the underlying ResponseWriter
+// if it supports flushing. Required for SSE streaming to work through this middleware.
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,13 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"flag"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -15,14 +11,13 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"syscall"
-	"time"
 
 	"dumpstore/internal/ansible"
 	"dumpstore/internal/api"
 	"dumpstore/internal/auth"
 	"dumpstore/internal/broker"
+	"dumpstore/internal/logging"
 	"dumpstore/internal/platform"
 	"dumpstore/internal/schema"
 )
@@ -67,7 +62,7 @@ func main() {
 	// priority prefixes (<N>) so the journal stores the correct PRIORITY field.
 	// systemd sets JOURNAL_STREAM when stdout is connected to the journal.
 	// Without the prefix, every line lands at PRIORITY=6 (info) regardless of level.
-	slog.SetDefault(slog.New(newJournalHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+	slog.SetDefault(slog.New(logging.NewJournalHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
 
 	if *baseDir == "" {
 		exe, err := os.Executable()
@@ -122,7 +117,7 @@ func main() {
 	mux.Handle("/", http.FileServer(http.Dir(staticDir)))
 
 	authMW := auth.NewMiddleware(cfg, store)
-	handler := requestLogger(authMW.Wrap(mux))
+	handler := logging.RequestLogger(authMW.Wrap(mux))
 
 	if *tlsFlag && cfg.TLSCertPath != "" && cfg.TLSKeyPath != "" {
 		httpsAddr := ":" + *tlsPort
@@ -172,160 +167,6 @@ func main() {
 			slog.Error("server stopped", "err", err)
 			os.Exit(1)
 		}
-	}
-}
-
-// newReqID returns a random 16-character hex string for request correlation.
-func newReqID() string {
-	var b [8]byte
-	_, _ = rand.Read(b[:])
-	return hex.EncodeToString(b[:])
-}
-
-// requestLogger wraps a handler and emits one logfmt line per request.
-// It generates a unique req_id, stores it in the request context, and includes
-// it on the request log line so downstream slog calls can be correlated.
-func requestLogger(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id := r.Header.Get("X-Request-ID")
-		if id == "" {
-			id = newReqID()
-		}
-		r = r.WithContext(api.WithReqID(r.Context(), id))
-		w.Header().Set("X-Request-ID", id)
-
-		start := time.Now()
-		rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
-		next.ServeHTTP(rw, r)
-		elapsed := time.Since(start)
-
-		level := slog.LevelInfo
-		if rw.status >= 500 {
-			level = slog.LevelError
-		} else if rw.status >= 400 {
-			level = slog.LevelWarn
-		}
-		slog.Log(r.Context(), level, "request",
-			"req_id", id,
-			"method", r.Method,
-			"path", r.URL.Path,
-			"status", rw.status,
-			"duration_ms", elapsed.Milliseconds(),
-			"remote", r.RemoteAddr,
-		)
-		api.RecordHTTP(r.Method, r.URL.Path, rw.status, elapsed)
-	})
-}
-
-// statusRecorder captures the HTTP status code written by a handler.
-type statusRecorder struct {
-	http.ResponseWriter
-	status int
-}
-
-func (r *statusRecorder) WriteHeader(code int) {
-	r.status = code
-	r.ResponseWriter.WriteHeader(code)
-}
-
-// Flush implements http.Flusher by forwarding to the underlying ResponseWriter
-// if it supports flushing. Required for SSE streaming to work through this middleware.
-func (r *statusRecorder) Flush() {
-	if f, ok := r.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
-	}
-}
-
-// journalHandler wraps slog.TextHandler and prepends a syslog-style priority
-// prefix (<N>) to each log line when running under systemd with
-// StandardOutput=journal. systemd parses these prefixes and stores the correct
-// PRIORITY field in the journal entry, which Loki/Promtail then uses as the
-// log level label. Without the prefix every line lands at PRIORITY=6 (info).
-//
-// When JOURNAL_STREAM is not set (e.g. terminal), the prefix is omitted so
-// output stays human-readable.
-type journalHandler struct {
-	mu      sync.Mutex
-	out     io.Writer
-	opts    slog.HandlerOptions
-	journal bool // true when stdout is connected to the systemd journal
-	pre     []func(slog.Handler) slog.Handler // WithAttrs/WithGroup calls to replay
-}
-
-func newJournalHandler(out io.Writer, opts *slog.HandlerOptions) slog.Handler {
-	if opts == nil {
-		opts = &slog.HandlerOptions{}
-	}
-	if os.Getenv("JOURNAL_STREAM") == "" {
-		// Not under systemd — plain text output, no prefix noise.
-		return slog.NewTextHandler(out, opts)
-	}
-	return &journalHandler{out: out, opts: *opts, journal: true}
-}
-
-func (h *journalHandler) Enabled(_ context.Context, l slog.Level) bool {
-	min := slog.LevelInfo
-	if h.opts.Level != nil {
-		min = h.opts.Level.Level()
-	}
-	return l >= min
-}
-
-func (h *journalHandler) Handle(ctx context.Context, r slog.Record) error {
-	// Inject req_id from context if present (set by requestLogger middleware).
-	if id := api.ReqIDFromContext(ctx); id != "" {
-		r.AddAttrs(slog.String("req_id", id))
-	}
-	// Build the formatted line into a buffer using a temporary TextHandler.
-	// WithAttrs/WithGroup calls are replayed on each Handle so attrs are included.
-	var buf bytes.Buffer
-	var sh slog.Handler = slog.NewTextHandler(&buf, &h.opts)
-	for _, fn := range h.pre {
-		sh = fn(sh)
-	}
-	if err := sh.Handle(ctx, r); err != nil {
-		return err
-	}
-
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if h.journal {
-		fmt.Fprintf(h.out, "<%d>", journalPriority(r.Level))
-	}
-	_, err := h.out.Write(buf.Bytes())
-	return err
-}
-
-func (h *journalHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	nh := h.clone()
-	nh.pre = append(nh.pre, func(sh slog.Handler) slog.Handler { return sh.WithAttrs(attrs) })
-	return nh
-}
-
-func (h *journalHandler) WithGroup(name string) slog.Handler {
-	nh := h.clone()
-	nh.pre = append(nh.pre, func(sh slog.Handler) slog.Handler { return sh.WithGroup(name) })
-	return nh
-}
-
-func (h *journalHandler) clone() *journalHandler {
-	pre := make([]func(slog.Handler) slog.Handler, len(h.pre))
-	copy(pre, h.pre)
-	return &journalHandler{out: h.out, opts: h.opts, journal: h.journal, pre: pre}
-}
-
-// journalPriority maps slog levels to syslog priority numbers understood by the
-// systemd journal: 3=err, 4=warning, 6=info, 7=debug.
-func journalPriority(l slog.Level) int {
-	switch {
-	case l >= slog.LevelError:
-		return 3
-	case l >= slog.LevelWarn:
-		return 4
-	case l >= slog.LevelInfo:
-		return 6
-	default:
-		return 7
 	}
 }
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -22,8 +22,8 @@
 │  • startup: checks ansible-playbook in PATH,                        │
 │             playbooks/ and static/ dirs exist                       │
 │  • signal.NotifyContext → graceful shutdown on SIGTERM/SIGINT       │
-│  • requestLogger middleware: reads X-Request-ID from proxy (or      │
-│    generates one), stores in ctx, logs req_id on every request line │
+│  • logging.RequestLogger middleware: reads X-Request-ID from proxy  │
+│    (or generates one), stores in ctx, logs req_id on every line    │
 │  • GET /      → http.FileServer  (static/)                          │
 │  • /api/*     → api.Handler                                         │
 └───────────────────┬─────────────────────────────────────────────────┘


### PR DESCRIPTION
…logging

Fix a data race on the shared auth config and clean up five code quality issues that clashed with the project's core principles.

Bug fix:
- Add sync.RWMutex around all authCfg reads/writes in auth_handlers.go and tls_handlers.go. Previously, concurrent requests could race on PasswordHash, Username, and TLS/ACME fields.

Consistency:
- Replace all 8 remaining json.NewDecoder(r.Body).Decode() calls with the project's decodeJSON() helper, which rejects trailing garbage.
- Add missing SSE publish calls after createDataset, deleteDataset, createSnapshot, deleteSnapshot, deleteSnapshotBatch, startScrub, and cancelScrub. New publishSnapshots() and publishPools() helpers.

Boilerplate:
- Add writeRunOpError() helper; replaces 33 copies of the 5-line error-handling block after runOp calls (~165 lines removed).
- Remove now-unused ansible import from 4 handler files.

Structure:
- Extract journalHandler and requestLogger from main.go into new internal/logging/ package (NewJournalHandler, RequestLogger). main.go drops from 345 to 180 lines.

Docs updated: CHANGELOG.md, CLAUDE.md file map, README.md and wiki/Architecture.md diagrams.

## Summary

<!-- 1-3 bullet points describing what changed and why -->

## Test plan

<!-- Bulleted checklist of what to verify -->

## Docs updated

- [ ] `README.md` updated (or change doesn't affect routes/features/architecture)
- [ ] `docs/index.html` updated (or same reason)
- [ ] `wiki/` updated (or same reason)

<!-- If docs don't need updating, briefly explain why: -->
