### PR TITLE
feat: replace bcrypt with argon2id for password hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented here.
 
+## [Unreleased]
+
+### Changed
+
+- **Password hashing: bcrypt → argon2id** ⚠️ **BREAKING** — existing `password_hash` in `dumpstore.conf` is no longer valid after upgrade. Upgrade path: stop the service, install the new binary, run `dumpstore --set-password`, start the service. Argon2id parameters: `time=3, memory=64 MiB, threads=4` (OWASP minimum). If a bcrypt hash is detected at login, a warning is emitted to the journal. Closes #67
+
+---
+
 ## [v0.1.11] — 2026-04-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,12 +54,15 @@
 ## Build & Check
 
 ```bash
-go build ./...   # must always pass before committing
-go vet ./...     # must always pass
+go build ./...             # must always pass before committing
+go vet ./...               # must always pass
+go test ./...              # unit tests (no external dependencies)
+go test -run TestFoo ./internal/api/   # run a single test by name
+go test -tags integration ./tests/integration/...  # integration tests (requires live VM)
 ```
 
 External Go dependencies (both are official golang.org/x packages, same governance as stdlib):
-- `golang.org/x/crypto/bcrypt` — password hashing for authentication
+- `golang.org/x/crypto/argon2` — password hashing for authentication (argon2id, PHC string format)
 - `golang.org/x/term` — echo-disabled password prompting in `--set-password`
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,7 @@ install: check-prereqs build
 	cp -r static    $(INSTALL)/; \
 	echo "==> Configuring authentication..."; \
 	install -d -m 0700 $$CONFIG_DIR; \
-	if ! grep -q '"password_hash"' $$CONFIG_DIR/dumpstore.conf 2>/dev/null || \
-	     grep -q '"password_hash": ""' $$CONFIG_DIR/dumpstore.conf 2>/dev/null; then \
+	if ! grep -qF '"password_hash": "$$argon2id$$' $$CONFIG_DIR/dumpstore.conf 2>/dev/null; then \
 	    echo "Set admin password (used to log in to the web UI):"; \
 	    $(INSTALL)/$(BINARY) --set-password --config $$CONFIG_DIR/dumpstore.conf; \
 	else \

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ sudo make uninstall
 │   ├── auth/
 │   │   ├── config.go                # Load/save dumpstore.conf (username, password hash, TLS, trusted proxies)
 │   │   ├── config_handlers.go       # API handlers for auth config changes (username, password)
-│   │   ├── login.go                 # Session-based login handler; bcrypt password verify
+│   │   ├── login.go                 # Session-based login handler; argon2id password verify
 │   │   ├── middleware.go            # Auth middleware: session cookie + X-Remote-User trusted proxy
 │   │   ├── ratelimit.go             # Per-IP rate limiter for login endpoint
 │   │   ├── session.go               # In-memory session store
@@ -648,7 +648,7 @@ sudo make uninstall
 │   ├── tls_acme_issue.yml           # Issue certificate via ACME / lego
 │   ├── tls_acme_renew.yml           # Renew ACME certificate
 │   │
-│   ├── auth_set_password.yml        # Update bcrypt password hash in dumpstore.conf
+│   ├── auth_set_password.yml        # Update argon2id password hash in dumpstore.conf
 │   ├── auth_set_username.yml        # Update username in dumpstore.conf
 │   │
 │   ├── service_control_linux.yml    # systemctl start/stop/restart/enable/disable

--- a/docs/index.html
+++ b/docs/index.html
@@ -642,7 +642,7 @@
           <span class="pool-name">Authentication</span>
           <span class="health-badge badge-green">security</span>
         </div>
-        <p>Session-based login with a bcrypt-hashed password stored in <code>/etc/dumpstore/dumpstore.conf</code> (Linux) / <code>/usr/local/etc/dumpstore/dumpstore.conf</code> (FreeBSD). Set up during install via <code>--set-password</code>. Per-IP rate limiting (10 attempts/60 s). Reverse proxy delegation via <code>X-Remote-User</code> from trusted CIDRs. No password configured? The service binds to loopback only until one is set. Change password or username any time from the Users &amp; Groups tab.</p>
+        <p>Session-based login with a argon2id-hashed password stored in <code>/etc/dumpstore/dumpstore.conf</code> (Linux) / <code>/usr/local/etc/dumpstore/dumpstore.conf</code> (FreeBSD). Set up during install via <code>--set-password</code>. Per-IP rate limiting (10 attempts/60 s). Reverse proxy delegation via <code>X-Remote-User</code> from trusted CIDRs. No password configured? The service binds to loopback only until one is set. Change password or username any time from the Users &amp; Groups tab.</p>
       </div>
     </div>
 
@@ -873,7 +873,7 @@ sudo ./dumpstore -addr :8080 -dir .</pre>
       <div class="divider"></div>
     </div>
     <p style="max-width:640px;line-height:1.6;color:var(--text-muted)">
-      dumpstore has built-in session-based authentication. A bcrypt-hashed password is set during install and stored in
+      dumpstore has built-in session-based authentication. A argon2id-hashed password is set during install and stored in
       <code>/etc/dumpstore/dumpstore.conf</code> (Linux) / <code>/usr/local/etc/dumpstore/dumpstore.conf</code> (FreeBSD). If no password is configured the service binds to <code>127.0.0.1</code> only.
       dumpstore runs as root (required for ZFS). See <a href="https://github.com/langerma/dumpstore/blob/main/SECURITY.md" style="color:var(--accent)">SECURITY.md</a>
       for notes on TLS and the recommended deployment topology.

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -3,8 +3,6 @@ package auth
 import (
 	"encoding/json"
 	"net/http"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
 const sessionCookieName = "dumpstore_session"
@@ -45,7 +43,7 @@ func handleLogin(cfg *Config, store *SessionStore, rl *RateLimiter) http.Handler
 
 		valid := username == cfg.Username &&
 			cfg.PasswordHash != "" &&
-			bcrypt.CompareHashAndPassword([]byte(cfg.PasswordHash), []byte(password)) == nil
+			verifyPassword(cfg.PasswordHash, []byte(password)) == nil
 
 		if !valid {
 			http.Redirect(w, r, "/login?error=Invalid+username+or+password.", http.StatusFound)

--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -1,0 +1,118 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// argon2id parameters — OWASP minimum recommended values.
+const (
+	argonTime    = 3
+	argonMemory  = 64 * 1024 // 64 MiB
+	argonThreads = 4
+	argonKeyLen  = 32
+	argonSaltLen = 16
+)
+
+var errBcryptHash = errors.New("bcrypt hash detected")
+
+// hashPassword hashes password with argon2id and returns a PHC string:
+//
+//	$argon2id$v=19$m=65536,t=3,p=4$<base64-salt>$<base64-hash>
+func hashPassword(password []byte) (string, error) {
+	salt := make([]byte, argonSaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("generate salt: %w", err)
+	}
+	hash := argon2.IDKey(password, salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	return encodePHC(salt, hash), nil
+}
+
+// verifyPassword checks password against a PHC string produced by hashPassword.
+// If hash looks like a bcrypt hash, it logs a warning and returns an error so
+// the operator knows to run --set-password after upgrading.
+func verifyPassword(hash string, password []byte) error {
+	if strings.HasPrefix(hash, "$2a$") || strings.HasPrefix(hash, "$2b$") {
+		slog.Warn("bcrypt password hash detected — run --set-password to reset after upgrading")
+		return errors.New("unsupported hash format")
+	}
+	salt, expected, err := decodePHC(hash)
+	if err != nil {
+		return fmt.Errorf("parse hash: %w", err)
+	}
+	got := argon2.IDKey(password, salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	if subtle.ConstantTimeCompare(got, expected) != 1 {
+		return errors.New("password mismatch")
+	}
+	return nil
+}
+
+// encodePHC encodes salt and hash as a PHC string.
+func encodePHC(salt, hash []byte) string {
+	b64 := base64.RawStdEncoding
+	return fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		argonMemory, argonTime, argonThreads,
+		b64.EncodeToString(salt),
+		b64.EncodeToString(hash),
+	)
+}
+
+// decodePHC parses a PHC string and returns the salt and hash.
+// Only the fixed parameters produced by hashPassword are accepted.
+func decodePHC(s string) (salt, hash []byte, err error) {
+	// expected: $argon2id$v=19$m=65536,t=3,p=4$<salt>$<hash>
+	parts := strings.Split(s, "$")
+	if len(parts) != 6 || parts[0] != "" || parts[1] != "argon2id" {
+		return nil, nil, errors.New("invalid PHC format")
+	}
+
+	var v int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &v); err != nil || v != argon2.Version {
+		return nil, nil, errors.New("unsupported argon2 version")
+	}
+
+	var m, t, p uint32
+	params := parts[3]
+	for _, kv := range strings.Split(params, ",") {
+		pair := strings.SplitN(kv, "=", 2)
+		if len(pair) != 2 {
+			return nil, nil, errors.New("invalid params")
+		}
+		n, err := strconv.ParseUint(pair[1], 10, 32)
+		if err != nil {
+			return nil, nil, fmt.Errorf("param %s: %w", pair[0], err)
+		}
+		switch pair[0] {
+		case "m":
+			m = uint32(n)
+		case "t":
+			t = uint32(n)
+		case "p":
+			p = uint32(n)
+		}
+	}
+	if m != argonMemory || t != argonTime || p != argonThreads {
+		return nil, nil, errors.New("unexpected argon2id parameters")
+	}
+
+	b64 := base64.RawStdEncoding
+	salt, err = b64.DecodeString(parts[4])
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode salt: %w", err)
+	}
+	hash, err = b64.DecodeString(parts[5])
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode hash: %w", err)
+	}
+	return salt, hash, nil
+}

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHashPasswordFormat(t *testing.T) {
+	hash, err := hashPassword([]byte("hunter2"))
+	if err != nil {
+		t.Fatalf("hashPassword: %v", err)
+	}
+	if !strings.HasPrefix(hash, "$argon2id$") {
+		t.Errorf("expected PHC prefix, got %q", hash[:min(len(hash), 20)])
+	}
+}
+
+func TestVerifyPasswordCorrect(t *testing.T) {
+	hash, err := hashPassword([]byte("correct-horse"))
+	if err != nil {
+		t.Fatalf("hashPassword: %v", err)
+	}
+	if err := verifyPassword(hash, []byte("correct-horse")); err != nil {
+		t.Errorf("verifyPassword with correct password: %v", err)
+	}
+}
+
+func TestVerifyPasswordWrong(t *testing.T) {
+	hash, err := hashPassword([]byte("correct-horse"))
+	if err != nil {
+		t.Fatalf("hashPassword: %v", err)
+	}
+	if err := verifyPassword(hash, []byte("wrong")); err == nil {
+		t.Error("verifyPassword with wrong password: expected error, got nil")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	passwords := []string{"simple", "P@$$w0rd!", "a", strings.Repeat("x", 72)}
+	for _, pw := range passwords {
+		hash, err := hashPassword([]byte(pw))
+		if err != nil {
+			t.Fatalf("hashPassword(%q): %v", pw, err)
+		}
+		if err := verifyPassword(hash, []byte(pw)); err != nil {
+			t.Errorf("round-trip failed for %q: %v", pw, err)
+		}
+	}
+}
+
+func TestHashesAreUnique(t *testing.T) {
+	h1, _ := hashPassword([]byte("same"))
+	h2, _ := hashPassword([]byte("same"))
+	if h1 == h2 {
+		t.Error("two hashes of the same password should differ (random salt)")
+	}
+}
+
+func TestVerifyBcryptHashReturnsError(t *testing.T) {
+	bcryptHash := "$2b$12$somefakebcrypthashvalue.thatislong.enough"
+	err := verifyPassword(bcryptHash, []byte("anything"))
+	if err == nil {
+		t.Error("expected error for bcrypt hash, got nil")
+	}
+}
+
+func TestVerifyInvalidHashReturnsError(t *testing.T) {
+	for _, bad := range []string{"", "notaphcstring", "$argon2id$garbage"} {
+		if err := verifyPassword(bad, []byte("pw")); err == nil {
+			t.Errorf("verifyPassword(%q): expected error, got nil", bad)
+		}
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/auth/setpassword.go
+++ b/internal/auth/setpassword.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/term"
 )
 
@@ -43,7 +42,7 @@ func SetPassword(configPath string) error {
 		return errors.New("passwords do not match")
 	}
 
-	hash, err := bcrypt.GenerateFromPassword(pass1, 12)
+	hash, err := hashPassword(pass1)
 	if err != nil {
 		return fmt.Errorf("hash password: %w", err)
 	}
@@ -52,7 +51,7 @@ func SetPassword(configPath string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-	cfg.PasswordHash = string(hash)
+	cfg.PasswordHash = hash
 
 	if err := SaveConfig(configPath, cfg); err != nil {
 		return fmt.Errorf("save config: %w", err)


### PR DESCRIPTION
## Summary

- Replaces `bcrypt` with `argon2id` for password hashing, closes #67
- **Breaking change** — existing `password_hash` in `dumpstore.conf` is invalid after upgrade; operator must run `--set-password`
- No new module dependency — `golang.org/x/crypto/argon2` is already part of the existing `golang.org/x/crypto` module

## Changes

- `internal/auth/password.go` (new) — `hashPassword` / `verifyPassword` with PHC string encoding; bcrypt hash detection logs a `slog.Warn` so the operator gets a clear journal hint
- `internal/auth/login.go` — swap `bcrypt.CompareHashAndPassword` → `verifyPassword`; drop bcrypt import
- `internal/auth/setpassword.go` — swap `bcrypt.GenerateFromPassword` → `hashPassword`; drop bcrypt import
- `internal/auth/password_test.go` (new) — 7 unit tests: format, correct/wrong password, round-trip, unique salts, bcrypt sentinel, invalid hash
- `CHANGELOG.md` — new `[Unreleased]` entry with breaking change note and upgrade steps
- `CLAUDE.md` — update dependency note: `argon2` replaces `bcrypt`

## Argon2id parameters

```
time=3, memory=64 MiB, threads=4, keyLen=32
```
OWASP minimum. Hash stored as PHC string: `$argon2id$v=19$m=65536,t=3,p=4$<salt>$<hash>`

## Upgrade path

1. Stop the service
2. Install the new binary
3. Run `dumpstore --set-password`
4. Start the service

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all packages green, 7 new auth tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)