### PR TITLE
fix(security): address code-scanning alerts

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   check-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Security
+
+- **Logout cookie now sets `Secure` on TLS** — the session-clearing cookie in `handleLogout` previously omitted the `Secure` attribute (the login cookie already had it). Aligns the clearing cookie with the login cookie. Closes #94.
+- **Login error param uses stdlib `html.EscapeString`** — replaced the in-tree `htmlEsc` helper with `html.EscapeString` so static analysers recognise the sanitiser. No behaviour change. Closes #95.
+- **GitHub Actions workflows pinned to least privilege** — `ci.yml` and `check-docs.yml` now declare `permissions: contents: read` explicitly instead of inheriting the broader default `GITHUB_TOKEN` scope. Closes #97.
+
 ---
 
 ## [v0.1.13] — 2026-05-25

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"html"
 	"net/http"
 )
 
@@ -77,6 +78,7 @@ func handleLogout(store *SessionStore) http.HandlerFunc {
 			HttpOnly: true,
 			SameSite: http.SameSiteStrictMode,
 			MaxAge:   -1,
+			Secure:   r.TLS != nil,
 		})
 		http.Redirect(w, r, "/login", http.StatusFound)
 	}
@@ -108,7 +110,7 @@ func handleWhoami(cfg *Config, store *SessionStore) http.HandlerFunc {
 func loginPage(username, errMsg string) string {
 	errHTML := ""
 	if errMsg != "" {
-		errHTML = `<p class="login-error">` + htmlEsc(errMsg) + `</p>`
+		errHTML = `<p class="login-error">` + html.EscapeString(errMsg) + `</p>`
 	}
 	return `<!DOCTYPE html>
 <html lang="en">
@@ -149,7 +151,7 @@ button:hover{opacity:.85;}
   ` + errHTML + `
   <form method="POST" action="/auth/login">
     <label><span>Username</span>
-      <input type="text" name="username" value="` + htmlEsc(username) + `" autocomplete="username" required>
+      <input type="text" name="username" value="` + html.EscapeString(username) + `" autocomplete="username" required>
     </label>
     <label><span>Password</span>
       <input type="password" name="password" autocomplete="current-password" required autofocus>
@@ -161,24 +163,3 @@ button:hover{opacity:.85;}
 </html>`
 }
 
-// htmlEsc escapes the five HTML special characters for safe inline injection.
-func htmlEsc(s string) string {
-	out := make([]byte, 0, len(s))
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '&':
-			out = append(out, '&', 'a', 'm', 'p', ';')
-		case '<':
-			out = append(out, '&', 'l', 't', ';')
-		case '>':
-			out = append(out, '&', 'g', 't', ';')
-		case '"':
-			out = append(out, '&', 'q', 'u', 'o', 't', ';')
-		case '\'':
-			out = append(out, '&', '#', '3', '9', ';')
-		default:
-			out = append(out, s[i])
-		}
-	}
-	return string(out)
-}

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -234,12 +234,16 @@ func (m *Manager) RunPipeline(jobType string, left, right []string) (Job, error)
 		return Job{}, fmt.Errorf("stderr pipe: %w", err)
 	}
 
-	leftCmd := exec.Command(left[0], left[1:]...)
+	// Callers build argv from validated input (see validZFSName / validRemoteSpec
+	// in internal/api). No shell is involved — argv[0] is a fixed binary name
+	// and argv[1:] are passed as discrete arguments, so shell metacharacters
+	// cannot reach a parser. CodeQL's taint tracker can't see the validators.
+	leftCmd := exec.Command(left[0], left[1:]...) //nolint:gosec // G204: argv pre-validated, no shell
 	leftCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	leftCmd.Stdout = dataW
 	leftCmd.Stderr = stderrW
 
-	rightCmd := exec.Command(right[0], right[1:]...)
+	rightCmd := exec.Command(right[0], right[1:]...) //nolint:gosec // G204: argv pre-validated, no shell
 	rightCmd.Stdin = dataR
 	rightCmd.Stdout = stdoutW
 	rightCmd.Stderr = stderrW


### PR DESCRIPTION
## Summary

Addresses the four issues filed from the open code-scanning alerts on https://github.com/langerma/dumpstore/security/code-scanning:

- Closes #94 — logout cookie now sets `Secure` on TLS (matches login cookie).
- Closes #95 — replace in-tree `htmlEsc` with stdlib `html.EscapeString` so CodeQL recognises the sanitiser on the login error param.
- Refs #96 — added justification comment on the two `exec.Command` calls in `jobs.RunPipeline`; argv is pre-validated (`validZFSName` / `validRemoteSpec`) and runs without a shell. CodeQL does not honour inline suppressions — **alerts #4 and #5 still need to be dismissed in the UI** as \"won't fix / used safely.\"
- Closes #97 — `ci.yml` and `check-docs.yml` now declare \`permissions: contents: read\` explicitly.

CHANGELOG \`## [Unreleased]\` gets a new \`### Security\` section.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] CI green
- [x] After merge: dismiss code-scanning alerts #4 and #5 in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)