### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - go
+    groups:
+      go-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- Adds \`.github/dependabot.yml\` covering the two ecosystems present in the repo: \`gomod\` and \`github-actions\`.
- Weekly schedule, minor+patch updates grouped into one PR per ecosystem, majors stay separate.
- \`open-pull-requests-limit: 5\` per ecosystem (Dependabot default).
- Labels PRs with \`dependencies\` plus an ecosystem tag for filtering.

## Test plan

- [x] YAML syntactically valid
- [ ] Dependabot picks up the config on merge and opens its first batch of PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)