### PR TITLE
fix(autosnap): tolerate missing zfs-auto-snapshot timers on takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Auto-snapshot takeover no longer fails on hosts missing zfs-auto-snapshot timers** — the Linux takeover task now enumerates installed `zfs-auto-snapshot-*.timer` units via `systemctl list-unit-files` and only stops/disables units that actually exist, instead of relying on fragile error-message matching. A new op-log task reports the per-timer outcome (stopped and disabled / not present). Closes #93.
+
 ### Security
 
 - **Logout cookie now sets `Secure` on TLS** — the session-clearing cookie in `handleLogout` previously omitted the `Secure` attribute (the login cookie already had it). Aligns the clearing cookie with the login cookie. Closes #94.

--- a/playbooks/auto_snapshot_takeover.yml
+++ b/playbooks/auto_snapshot_takeover.yml
@@ -9,27 +9,53 @@
 - name: Take over auto-snapshot execution from the OS daemon
   hosts: localhost
   gather_facts: true
+  vars:
+    autosnap_known_timers:
+      - zfs-auto-snapshot-frequent.timer
+      - zfs-auto-snapshot-hourly.timer
+      - zfs-auto-snapshot-daily.timer
+      - zfs-auto-snapshot-weekly.timer
+      - zfs-auto-snapshot-monthly.timer
+    # first column of each `systemctl list-unit-files` row, restricted to
+    # the known timer names so stray matches can never be acted on
+    autosnap_installed_timers: >-
+      {{ (autosnap_timer_scan.stdout_lines | default([]))
+         | map('split') | map('first')
+         | select('in', autosnap_known_timers) | list }}
   tasks:
     # ── Linux ────────────────────────────────────────────────────────────
+    # A missing timer unit is not an error — it means there is nothing to
+    # take over for that frequency. Enumerate what is actually installed
+    # and only touch those units.
+    - name: Linux — detect installed zfs-auto-snapshot systemd timers
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - list-unit-files
+          - --no-legend
+          - zfs-auto-snapshot-*.timer
+      register: autosnap_timer_scan
+      changed_when: false
+      # newer systemd exits non-zero when no unit file matches the pattern
+      failed_when: false
+      when: ansible_system == "Linux"
+
     - name: Linux — stop and disable zfs-auto-snapshot systemd timers
       ansible.builtin.systemd:
         name: "{{ item }}"
         enabled: false
         state: stopped
-      loop:
-        - zfs-auto-snapshot-frequent.timer
-        - zfs-auto-snapshot-hourly.timer
-        - zfs-auto-snapshot-daily.timer
-        - zfs-auto-snapshot-weekly.timer
-        - zfs-auto-snapshot-monthly.timer
+      loop: "{{ autosnap_installed_timers }}"
       when: ansible_system == "Linux"
-      register: linux_systemd
-      failed_when:
-        # systemctl returns non-zero if the unit doesn't exist (package not
-        # installed) — that's the desired state, so swallow it.
-        - linux_systemd.failed | default(false)
-        - "'could not be found' not in (linux_systemd.msg | default(''))"
-        - "'not loaded' not in (linux_systemd.msg | default(''))"
+
+    - name: Linux — report per-timer takeover outcome
+      ansible.builtin.debug:
+        msg: >-
+          {% for t in autosnap_known_timers -%}
+          {{ t }}: {{ 'stopped and disabled' if t in autosnap_installed_timers else 'not present' }}
+          {{- '; ' if not loop.last }}
+          {%- endfor %}
+      when: ansible_system == "Linux"
 
     - name: Linux — remove /etc/cron.d/zfs-auto-snapshot if present
       ansible.builtin.file:


### PR DESCRIPTION
## Summary

Fixes #93 — the Linux auto-snapshot takeover task failed with `One or more items failed` on hosts where some or all `zfs-auto-snapshot-*.timer` units are not installed.

## Root cause

The `failed_when` guard tried to swallow missing-unit errors by substring-matching the module message for `'could not be found'` / `'not loaded'`, but Ansible's systemd module emits `Could not find the requested service ...` — so the guard never matched and missing units failed the task.

## Fix

- New scan task enumerates installed unit files via `systemctl list-unit-files zfs-auto-snapshot-*.timer` (`failed_when: false` — newer systemd exits non-zero on no match)
- The stop/disable loop iterates only units that actually exist, restricted to the five known timer names so stray matches can never be acted on
- New report task shows per-timer outcome in the op-log: `stopped and disabled` / `not present`

## Verification

- `ansible-playbook --syntax-check` passes
- Jinja derivation exercised with a local test play covering: partial install + stray unit line (filtered), empty/skipped scan (FreeBSD path → empty list), and report message rendering — all assertions passed
- `go build ./...` / `go vet ./...` pass (no Go changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)