### PR TITLE
feat(pools): drive replacement, device offline/online, resilver monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Drive replacement and resilver management** — replace a pool device straight from the vdev tree (`zpool replace` via new `zfs_disk_replace.yml`), with a replacement-device picker backed by the new `GET /api/devices` endpoint (physical block devices from `/sys/block` on Linux / `geom disk list` on FreeBSD, with best-effort "in use by pool" detection). Devices can be taken offline / brought online for maintenance (`zpool offline`/`zpool online` via new playbooks). While a resilver runs the pool card shows a progress bar with live percentage (from the existing poolstatus SSE stream) and a toast announces completion. New endpoints: `GET /api/devices`, `POST /api/pools/{pool}/replace`, `POST /api/pools/{pool}/offline`, `POST /api/pools/{pool}/online`. New package `internal/blockdev`. Closes #55.
+
 ### Fixed
 
 - **Auto-snapshot takeover no longer fails on hosts missing zfs-auto-snapshot timers** — the Linux takeover task now enumerates installed `zfs-auto-snapshot-*.timer` units via `systemctl list-unit-files` and only stops/disables units that actually exist, instead of relying on fragile error-message matching. A new op-log task reports the per-timer outcome (stopped and disabled / not present). Closes #93.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,8 @@ Do not change this split without a good reason — the Ansible side avoids Pytho
 | `internal/logging/handler.go` | `NewJournalHandler` — slog handler with systemd journal priority prefixes |
 | `internal/logging/middleware.go` | `RequestLogger` — HTTP middleware for per-request logging with req_id correlation |
 | `internal/api/zfs_handlers.go` | ZFS handlers: pools, datasets, snapshots, SMART, IOStat, chown, scrub, auto-snapshot |
+| `internal/api/device_handlers.go` | Block device list, `zpool replace`, device offline/online |
+| `internal/blockdev/blockdev.go` | `List` — physical block devices (`/sys/block` on Linux, `geom disk list` on FreeBSD); `MarkInUse` — best-effort vdev→device matching |
 | `internal/api/user_handlers.go` | User + group handlers, SSH key management |
 | `internal/api/acl_handlers.go` | ACL handlers (POSIX + NFSv4) |
 | `internal/api/smb_handlers.go` | SMB handlers: shares, users, homes, Time Machine |
@@ -188,6 +190,9 @@ Do not change this split without a good reason — the Ansible side avoids Pytho
 | `playbooks/zfs_snapshot_destroy.yml` | Destroys snapshot; vars: `snapshot`, `recursive` |
 | `playbooks/zfs_scrub_start.yml` | Starts pool scrub; vars: `pool` |
 | `playbooks/zfs_scrub_cancel.yml` | Cancels running pool scrub; vars: `pool` |
+| `playbooks/zfs_disk_replace.yml` | Replaces a pool device (`zpool replace`); vars: `pool`, `old_device`, `new_device` |
+| `playbooks/zfs_device_offline.yml` | Takes a device offline (`zpool offline`); vars: `pool`, `device` |
+| `playbooks/zfs_device_online.yml` | Brings a device online (`zpool online`); vars: `pool`, `device` |
 | `playbooks/acl_set_posix.yml` | Adds/updates a POSIX ACL entry; vars: `dataset`, `entry`, `recursive` |
 | `playbooks/acl_remove_posix.yml` | Removes a POSIX ACL entry; vars: `mountpoint`, `entry`, `recursive` |
 | `playbooks/acl_set_nfs4.yml` | Adds an NFSv4 ACL entry; vars: `dataset`, `entry`, `recursive` |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -48,6 +48,7 @@
 | Background jobs runner     | v0.1.13 | `internal/jobs.Manager` spawns long-running data-plane operations (`zfs send` piped into `zfs recv`) outside Ansible; per-job process group + 10 s SIGTERM→SIGKILL cancel; 64 KiB stdout/stderr tail; JSON record per job persisted under `/var/lib/dumpstore/jobs/` (Linux) or `/var/db/dumpstore/jobs/` (FreeBSD); `running` jobs marked `interrupted` after a service restart; live updates via `jobs.update` SSE topic; new Jobs tab |
 | Native auto-snapshot       | v0.1.13 | dumpstore executes `com.sun:auto-snapshot:*` snapshots itself via the built-in scheduler — replaces the `zfs-auto-snapshot` (Linux) / `zfstools` (FreeBSD) OS daemons. Property inheritance honoured correctly (closes #74). One-click takeover/release; legacy `zfs-auto-snap_*` naming preserved; closes #56 |
 | Scheduled replication      | v0.1.13 | Cron-scheduled `zfs send` → `zfs recv` tasks; new `internal/scheduler` (5-field cron, 1-min resolution) and `internal/replication` (JSON task store under StateDir, snapshot → hold → send → release → prune pipeline); per-run records with bounded history; manual "run now"; new Replication tab; runs surface in Jobs tab tagged `replication.run`; SSE topic `replication.update`; closes #53 |
+| Drive replacement          | v0.1.14 | Replace pool devices from the vdev tree with an unused-device picker (`zpool replace`); offline/online devices for maintenance; resilver progress bar + completion toast; `GET /api/devices` lists block devices with in-use detection (new `internal/blockdev`); closes #55 |
 
 ---
 
@@ -64,7 +65,6 @@
 | Feature                            | Priority | Issue | Notes                                                                                                                    |
 |------------------------------------|----------|-------|--------------------------------------------------------------------------------------------------------------------------|
 | wsdd configuration management      | Medium   | [#86](https://github.com/langerma/dumpstore/issues/86) | Enable/configure wsdd (WS-Discovery) for Windows network visibility of SMB shares |
-| Drive replacement                  | High     | [#55](https://github.com/langerma/dumpstore/issues/55) | Replace faulted disks, monitor resilver progress, offline/online devices |
 | Pool create/import/export          | Medium   | [#23](https://github.com/langerma/dumpstore/issues/23) | Create pools (mirror, raidz1/2/3, draid); import/export existing pools |
 | UI overhaul (datasets + snapshots) | Medium   | [#63](https://github.com/langerma/dumpstore/issues/63) | Purpose-driven redesign: dataset detail panel, pool/dataset hierarchy, snapshots grouped by dataset with filter/search |
 | Pool expansion                     | Medium   | [#57](https://github.com/langerma/dumpstore/issues/57) | Add vdevs, cache (L2ARC), log (SLOG), and spare devices to existing pools |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 - **System info** — hostname, OS, kernel, CPU, uptime, load averages, process stats
 - **Pool overview** — health badges, usage bars, fragmentation, deduplication ratio, vdev tree
 - **Pool scrub management** — trigger and cancel scrubs; last scrub time, status, and progress per pool; configure periodic scrub schedules (Linux: `zfsutils-linux`; FreeBSD: `periodic.conf`)
+- **Drive replacement & resilver monitoring** — replace a (faulted) device from the vdev tree with a picker of unused block devices (`zpool replace`); take devices offline / bring them online for maintenance; resilver progress bar with live percentage and a completion notification; faulted/degraded devices highlighted in the vdev tree
 - **I/O statistics** — live read/write IOPS and bandwidth per pool
 - **Disk health** — S.M.A.R.T. data per drive (temperature, power-on hours, reallocated sectors, pending sectors, uncorrectable errors)
 - **Dataset browser** — depth-indented collapsible tree, compression, quota, mountpoint; ACL, NFS, and SMB buttons light up when configured
@@ -598,6 +599,7 @@ sudo make uninstall
 │   ├── api/
 │   │   ├── handlers.go              # Handler struct, RegisterRoutes, validation helpers, writeJSON/writeError
 │   │   ├── zfs_handlers.go          # ZFS: pools, datasets, snapshots, scrub, chown, auto-snapshot
+│   │   ├── device_handlers.go       # Block devices, zpool replace, device offline/online
 │   │   ├── user_handlers.go         # Users, groups, SSH key management
 │   │   ├── acl_handlers.go          # POSIX + NFSv4 ACL handlers
 │   │   ├── smb_handlers.go          # SMB: init, shares, users, homes, Time Machine
@@ -618,6 +620,8 @@ sudo make uninstall
 │   │   └── services.go              # ListServices, ServiceStatus — systemd (Linux) and rc.d (FreeBSD)
 │   ├── iscsi/
 │   │   └── iscsi.go                 # ListTargets — targetcli saveconfig (Linux) / /etc/ctl.conf (FreeBSD)
+│   ├── blockdev/
+│   │   └── blockdev.go              # List physical block devices (/sys/block, geom disk list) + vdev in-use matching
 │   └── smart/
 │       └── smart.go                 # ListDrives — smartctl per-disk health data
 ├── playbooks/
@@ -636,6 +640,9 @@ sudo make uninstall
 │   ├── zfs_scrub_periodic_disable.yml  # Disable periodic scrub via FreeBSD periodic.conf
 │   ├── zfs_scrub_zfsutils_enable.yml   # Enable periodic scrub via zfsutils-linux cron
 │   ├── zfs_scrub_zfsutils_disable.yml  # Disable periodic scrub via zfsutils-linux cron
+│   ├── zfs_disk_replace.yml         # zpool replace <pool> <old> <new> (starts resilver)
+│   ├── zfs_device_offline.yml       # zpool offline <pool> <device>
+│   ├── zfs_device_online.yml        # zpool online <pool> <device>
 │   │
 │   ├── dataset_chown.yml            # Set owner/group on dataset mountpoint
 │   ├── acl_set_posix.yml            # Add/modify POSIX ACL entry (setfacl -m)
@@ -700,6 +707,10 @@ sudo make uninstall
 | GET    | `/api/snapshots`            | List all snapshots                    |
 | GET    | `/api/iostat`               | Pool I/O statistics (1-second sample) |
 | GET    | `/api/smart`                | S.M.A.R.T. health per disk            |
+| GET    | `/api/devices`              | List physical block devices (vdev candidates, in-use flag) |
+| POST   | `/api/pools/{pool}/replace` | Replace a pool device (`zpool replace`, starts resilver) |
+| POST   | `/api/pools/{pool}/offline` | Take a pool device offline (`zpool offline`) |
+| POST   | `/api/pools/{pool}/online`  | Bring a pool device online (`zpool online`) |
 | GET    | `/api/events`               | Server-Sent Events stream (see below) |
 | GET    | `/metrics`                  | Prometheus text exposition            |
 | POST   | `/api/datasets`             | Create a dataset or volume            |

--- a/docs/index.html
+++ b/docs/index.html
@@ -476,6 +476,13 @@
       </div>
       <div class="pool-card">
         <div class="pool-card-header">
+          <span class="pool-name">drive replacement</span>
+          <span class="health-badge badge-orange">resilver</span>
+        </div>
+        <p>Replace a (faulted) device straight from the vdev tree with a picker of unused disks. Offline/online devices for maintenance. Resilver progress bar with live percentage and completion notification.</p>
+      </div>
+      <div class="pool-card">
+        <div class="pool-card-header">
           <span class="pool-name">I/O statistics</span>
           <span class="health-badge badge-blue">live</span>
         </div>

--- a/internal/api/device_handlers.go
+++ b/internal/api/device_handlers.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+
+	"dumpstore/internal/blockdev"
+	"dumpstore/internal/zfs"
+)
+
+// getDevices handles GET /api/devices
+// Returns the physical block devices on this host, with in_use_by set to the
+// pool name for devices that currently back a vdev (best-effort matching).
+func (h *Handler) getDevices(w http.ResponseWriter, r *http.Request) {
+	devs, err := blockdev.List(runtime.GOOS)
+	if err != nil {
+		writeError(r.Context(), w, http.StatusInternalServerError, fmt.Errorf("listing block devices: %w", err), nil)
+		return
+	}
+	if statuses, err := zfs.PoolStatuses(); err == nil {
+		vdevByPool := make(map[string]string)
+		for _, st := range statuses {
+			for _, v := range st.Vdevs {
+				if v.Depth >= 1 {
+					vdevByPool[v.Name] = st.Name
+				}
+			}
+		}
+		blockdev.MarkInUse(devs, vdevByPool)
+	}
+	writeJSON(r.Context(), w, devs)
+}
+
+// replaceDevice handles POST /api/pools/{pool}/replace
+// Body: { "old_device": "...", "new_device": "..." }
+// Runs `zpool replace`, which starts a resilver onto the new device.
+func (h *Handler) replaceDevice(w http.ResponseWriter, r *http.Request) {
+	pool := r.PathValue("pool")
+	if !validPoolName(pool) {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid pool name"), nil)
+		return
+	}
+	var req struct {
+		OldDevice string `json:"old_device"`
+		NewDevice string `json:"new_device"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err), nil)
+		return
+	}
+	if !validVdevName(req.OldDevice) || !validVdevName(req.NewDevice) {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid device identifier"), nil)
+		return
+	}
+	if req.OldDevice == req.NewDevice {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("replacement device must differ from the old device"), nil)
+		return
+	}
+	out, err := h.runOp("zfs_disk_replace.yml", map[string]string{
+		"pool":       pool,
+		"old_device": req.OldDevice,
+		"new_device": req.NewDevice,
+	})
+	auditLog(r.Context(), r, "pool.replace_device", pool+" "+req.OldDevice+" -> "+req.NewDevice, err)
+	if err != nil {
+		writeRunOpError(r.Context(), w, err, out)
+		return
+	}
+	h.publishPools()
+	writeJSON(r.Context(), w, map[string]any{"pool": pool, "tasks": out.Steps()})
+}
+
+// offlineDevice handles POST /api/pools/{pool}/offline — body { "device": "..." }.
+func (h *Handler) offlineDevice(w http.ResponseWriter, r *http.Request) {
+	h.setDeviceState(w, r, "zfs_device_offline.yml", "pool.device_offline")
+}
+
+// onlineDevice handles POST /api/pools/{pool}/online — body { "device": "..." }.
+func (h *Handler) onlineDevice(w http.ResponseWriter, r *http.Request) {
+	h.setDeviceState(w, r, "zfs_device_online.yml", "pool.device_online")
+}
+
+// setDeviceState is the shared implementation of offlineDevice/onlineDevice.
+func (h *Handler) setDeviceState(w http.ResponseWriter, r *http.Request, playbook, action string) {
+	pool := r.PathValue("pool")
+	if !validPoolName(pool) {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid pool name"), nil)
+		return
+	}
+	var req struct {
+		Device string `json:"device"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err), nil)
+		return
+	}
+	if !validVdevName(req.Device) {
+		writeError(r.Context(), w, http.StatusBadRequest, fmt.Errorf("invalid device identifier"), nil)
+		return
+	}
+	out, err := h.runOp(playbook, map[string]string{"pool": pool, "device": req.Device})
+	auditLog(r.Context(), r, action, pool+" "+req.Device, err)
+	if err != nil {
+		writeRunOpError(r.Context(), w, err, out)
+		return
+	}
+	h.publishPools()
+	writeJSON(r.Context(), w, map[string]any{"pool": pool, "tasks": out.Steps()})
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -62,6 +62,12 @@ var (
 	// reRemoteSpec matches a `user@host` SSH destination. Host may be a
 	// hostname or IPv4 literal; IPv6 in brackets is not supported.
 	reRemoteSpec = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9._-]*@[a-zA-Z0-9.-]+$`)
+
+	// reVdevName matches a vdev identifier as accepted by zpool commands:
+	// a device path (/dev/sdb), a short device name (sdb, gpt/data,
+	// ata-FOO_BAR-part1) or a numeric guid printed by `zpool status` for
+	// missing devices.
+	reVdevName = regexp.MustCompile(`^/?[a-zA-Z0-9][a-zA-Z0-9/_.:-]*$`)
 )
 
 // validZFSName returns true if s is a safe ZFS dataset/pool path (no snapshot suffix).
@@ -81,6 +87,13 @@ func validShellPath(s string) bool { return reShellPath.MatchString(s) }
 
 // validRemoteSpec returns true if s is a safe `user@host` SSH destination.
 func validRemoteSpec(s string) bool { return reRemoteSpec.MatchString(s) }
+
+// validVdevName returns true if s is a safe vdev identifier (device path,
+// short device name, or guid).
+func validVdevName(s string) bool { return reVdevName.MatchString(s) }
+
+// validPoolName returns true if s is a safe pool name (no dataset path).
+func validPoolName(s string) bool { return validZFSName(s) && !strings.Contains(s, "/") }
 
 // validSSHKey returns true if s looks like an SSH public key (single line, known prefix).
 func validSSHKey(s string) bool {
@@ -292,6 +305,10 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/smb/timemachine", h.getTimeMachineShares)
 	mux.HandleFunc("POST /api/smb/timemachine", h.createTimeMachineShare)
 	mux.HandleFunc("DELETE /api/smb/timemachine/{sharename}", h.deleteTimeMachineShare)
+	mux.HandleFunc("GET /api/devices", h.getDevices)
+	mux.HandleFunc("POST /api/pools/{pool}/replace", h.replaceDevice)
+	mux.HandleFunc("POST /api/pools/{pool}/offline", h.offlineDevice)
+	mux.HandleFunc("POST /api/pools/{pool}/online", h.onlineDevice)
 	mux.HandleFunc("POST /api/scrub/{pool}", h.startScrub)
 	mux.HandleFunc("DELETE /api/scrub/{pool}", h.cancelScrub)
 	mux.HandleFunc("GET /api/scrub-schedules", h.listScrubSchedules)

--- a/internal/blockdev/blockdev.go
+++ b/internal/blockdev/blockdev.go
@@ -1,0 +1,174 @@
+// Package blockdev enumerates physical block devices for use as ZFS vdev
+// candidates (disk replacement, pool creation, pool expansion).
+package blockdev
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Device is one physical block device.
+type Device struct {
+	Name      string `json:"name"`       // short name, e.g. "sdb" / "ada1"
+	Path      string `json:"path"`       // device node, e.g. "/dev/sdb"
+	SizeBytes uint64 `json:"size_bytes"` // capacity in bytes
+	Model     string `json:"model"`      // hardware model string, if known
+	InUseBy   string `json:"in_use_by"`  // pool name when the device backs a vdev, "" otherwise
+}
+
+// List returns the physical block devices visible on this host.
+func List(goos string) ([]Device, error) {
+	if goos == "freebsd" {
+		out, err := run("geom", "disk", "list")
+		if err != nil {
+			return nil, err
+		}
+		return parseGeomDiskList(out), nil
+	}
+	return listLinux()
+}
+
+// skipLinuxDev matches virtual/pseudo block devices that can never back a vdev:
+// loopbacks, ramdisks, zvols, device-mapper nodes, optical drives, floppies,
+// network block devices and compressed-RAM devices.
+var skipLinuxDev = regexp.MustCompile(`^(loop|ram|zd|dm-|sr|fd|nbd|zram)`)
+
+// listLinux enumerates whole-disk devices from /sys/block.
+func listLinux() ([]Device, error) {
+	entries, err := os.ReadDir("/sys/block")
+	if err != nil {
+		return nil, fmt.Errorf("reading /sys/block: %w", err)
+	}
+	devs := make([]Device, 0, len(entries))
+	for _, e := range entries {
+		name := e.Name()
+		if skipLinuxDev.MatchString(name) {
+			continue
+		}
+		dev := Device{Name: name, Path: "/dev/" + name}
+		// size is reported in 512-byte sectors regardless of the device's
+		// logical block size
+		if b, err := os.ReadFile(filepath.Join("/sys/block", name, "size")); err == nil {
+			if sectors, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64); err == nil {
+				dev.SizeBytes = sectors * 512
+			}
+		}
+		if b, err := os.ReadFile(filepath.Join("/sys/block", name, "device", "model")); err == nil {
+			dev.Model = strings.TrimSpace(string(b))
+		}
+		devs = append(devs, dev)
+	}
+	return devs, nil
+}
+
+// parseGeomDiskList parses `geom disk list` output into devices.
+func parseGeomDiskList(out string) []Device {
+	devs := make([]Device, 0)
+	var cur *Device
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "Geom name: "):
+			if cur != nil {
+				devs = append(devs, *cur)
+			}
+			name := strings.TrimPrefix(trimmed, "Geom name: ")
+			cur = &Device{Name: name, Path: "/dev/" + name}
+		case cur == nil:
+			continue
+		case strings.HasPrefix(trimmed, "Mediasize: "):
+			// "Mediasize: 21474836480 (20G)"
+			f := strings.Fields(strings.TrimPrefix(trimmed, "Mediasize: "))
+			if len(f) > 0 {
+				if v, err := strconv.ParseUint(f[0], 10, 64); err == nil {
+					cur.SizeBytes = v
+				}
+			}
+		case strings.HasPrefix(trimmed, "descr: "):
+			cur.Model = strings.TrimPrefix(trimmed, "descr: ")
+		}
+	}
+	if cur != nil {
+		devs = append(devs, *cur)
+	}
+	return devs
+}
+
+// MarkInUse fills InUseBy on each device by matching pool vdev names against
+// the device names. vdevByPool maps a vdev name (as printed by `zpool status`)
+// to the pool that contains it. Matching is best-effort: vdev names that are
+// symlinks under /dev/disk/* (by-id, by-path, …) are resolved to their target
+// device, and partition suffixes are stripped (sdb2 → sdb, nvme0n1p1 → nvme0n1,
+// ada0p3 → ada0).
+func MarkInUse(devs []Device, vdevByPool map[string]string) {
+	resolved := make(map[string]string, len(vdevByPool))
+	for vdev, pool := range vdevByPool {
+		resolved[resolveVdevName(vdev)] = pool
+	}
+	for i := range devs {
+		for vdev, pool := range resolved {
+			if vdevMatchesDevice(vdev, devs[i].Name) {
+				devs[i].InUseBy = pool
+				break
+			}
+		}
+	}
+}
+
+// resolveVdevName turns a vdev name from `zpool status` into a short device
+// name where possible. zpool prints short names (sdb1, ata-FOO-part1, gpt/data)
+// relative to the import search path; absolute paths appear when a pool was
+// created with explicit paths.
+func resolveVdevName(name string) string {
+	if strings.HasPrefix(name, "/") {
+		if target, err := filepath.EvalSymlinks(name); err == nil {
+			return filepath.Base(target)
+		}
+		return filepath.Base(name)
+	}
+	for _, dir := range []string{"/dev/disk/by-id", "/dev/disk/by-path", "/dev/disk/by-partlabel", "/dev/gpt", "/dev"} {
+		p := filepath.Join(dir, name)
+		if target, err := filepath.EvalSymlinks(p); err == nil && target != p {
+			return filepath.Base(target)
+		}
+	}
+	return filepath.Base(name)
+}
+
+// rePartSuffix matches a trailing partition suffix: "2" after a letter (sdb2),
+// or "p2" after a digit (nvme0n1p2, ada0p3).
+var rePartSuffix = regexp.MustCompile(`^p?[0-9]+$`)
+
+// vdevMatchesDevice reports whether a resolved vdev name refers to the whole
+// disk dev or one of its partitions.
+func vdevMatchesDevice(vdev, dev string) bool {
+	if vdev == dev {
+		return true
+	}
+	if rest, ok := strings.CutPrefix(vdev, dev); ok {
+		return rePartSuffix.MatchString(rest)
+	}
+	return false
+}
+
+// run executes a command with a timeout and returns its stdout.
+func run(name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, stderr.String())
+	}
+	return stdout.String(), nil
+}

--- a/internal/blockdev/blockdev_test.go
+++ b/internal/blockdev/blockdev_test.go
@@ -1,0 +1,90 @@
+package blockdev
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseGeomDiskList(t *testing.T) {
+	out := `Geom name: ada0
+Providers:
+1. Name: ada0
+   Mediasize: 21474836480 (20G)
+   Sectorsize: 512
+   Mode: r2w2e3
+   descr: VBOX HARDDISK
+   ident: VB1234-5678
+   rotationrate: unknown
+   fwsectors: 63
+   fwheads: 16
+
+Geom name: ada1
+Providers:
+1. Name: ada1
+   Mediasize: 10737418240 (10G)
+   Sectorsize: 512
+   Mode: r0w0e0
+   descr: VBOX HARDDISK
+`
+	devs := parseGeomDiskList(out)
+	want := []Device{
+		{Name: "ada0", Path: "/dev/ada0", SizeBytes: 21474836480, Model: "VBOX HARDDISK"},
+		{Name: "ada1", Path: "/dev/ada1", SizeBytes: 10737418240, Model: "VBOX HARDDISK"},
+	}
+	if !reflect.DeepEqual(devs, want) {
+		t.Errorf("parseGeomDiskList = %+v, want %+v", devs, want)
+	}
+}
+
+func TestParseGeomDiskListEmpty(t *testing.T) {
+	if devs := parseGeomDiskList(""); len(devs) != 0 {
+		t.Errorf("expected no devices, got %+v", devs)
+	}
+}
+
+func TestVdevMatchesDevice(t *testing.T) {
+	cases := []struct {
+		vdev, dev string
+		want      bool
+	}{
+		{"sdb", "sdb", true},
+		{"sdb1", "sdb", true},
+		{"sdb12", "sdb", true},
+		{"sdba", "sdb", false},
+		{"nvme0n1p2", "nvme0n1", true},
+		{"nvme0n1", "nvme0n1", true},
+		{"nvme0n12", "nvme0n1", true}, // ambiguous but acceptable best-effort
+		{"ada0p3", "ada0", true},
+		{"ada1", "ada0", false},
+		{"sdc", "sdb", false},
+		{"sd", "sdb", false},
+	}
+	for _, c := range cases {
+		if got := vdevMatchesDevice(c.vdev, c.dev); got != c.want {
+			t.Errorf("vdevMatchesDevice(%q, %q) = %v, want %v", c.vdev, c.dev, got, c.want)
+		}
+	}
+}
+
+func TestMarkInUse(t *testing.T) {
+	devs := []Device{
+		{Name: "sda", Path: "/dev/sda"},
+		{Name: "sdb", Path: "/dev/sdb"},
+		{Name: "sdc", Path: "/dev/sdc"},
+	}
+	// mirror-0 is a grouping vdev and matches nothing; sdb2 is a partition.
+	MarkInUse(devs, map[string]string{
+		"mirror-0": "tank",
+		"sda":      "tank",
+		"sdb2":     "tank",
+	})
+	if devs[0].InUseBy != "tank" {
+		t.Errorf("sda InUseBy = %q, want tank", devs[0].InUseBy)
+	}
+	if devs[1].InUseBy != "tank" {
+		t.Errorf("sdb InUseBy = %q, want tank", devs[1].InUseBy)
+	}
+	if devs[2].InUseBy != "" {
+		t.Errorf("sdc InUseBy = %q, want empty", devs[2].InUseBy)
+	}
+}

--- a/playbooks/zfs_device_offline.yml
+++ b/playbooks/zfs_device_offline.yml
@@ -1,0 +1,24 @@
+---
+# Required extra vars:
+#   pool    - pool name (e.g. tank)
+#   device  - vdev to take offline (device name, path, or guid)
+- name: Take a pool device offline
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pool is defined and pool is match("^[a-zA-Z][a-zA-Z0-9_.:-]*$")
+          - device is defined and device is match("^/?[a-zA-Z0-9][a-zA-Z0-9/_.:-]*$")
+        fail_msg: "pool and device must be valid identifiers"
+
+    - name: Offline device
+      ansible.builtin.command:
+        argv:
+          - zpool
+          - offline
+          - "{{ pool }}"
+          - "{{ device }}"
+      register: offline_result
+      changed_when: offline_result.rc == 0

--- a/playbooks/zfs_device_online.yml
+++ b/playbooks/zfs_device_online.yml
@@ -1,0 +1,24 @@
+---
+# Required extra vars:
+#   pool    - pool name (e.g. tank)
+#   device  - vdev to bring online (device name, path, or guid)
+- name: Bring a pool device online
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pool is defined and pool is match("^[a-zA-Z][a-zA-Z0-9_.:-]*$")
+          - device is defined and device is match("^/?[a-zA-Z0-9][a-zA-Z0-9/_.:-]*$")
+        fail_msg: "pool and device must be valid identifiers"
+
+    - name: Online device
+      ansible.builtin.command:
+        argv:
+          - zpool
+          - online
+          - "{{ pool }}"
+          - "{{ device }}"
+      register: online_result
+      changed_when: online_result.rc == 0

--- a/playbooks/zfs_disk_replace.yml
+++ b/playbooks/zfs_disk_replace.yml
@@ -1,0 +1,28 @@
+---
+# Required extra vars:
+#   pool        - pool name (e.g. tank)
+#   old_device  - vdev to replace (device name, path, or guid from zpool status)
+#   new_device  - replacement device (e.g. /dev/sdc)
+- name: Replace a pool device
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pool is defined and pool is match("^[a-zA-Z][a-zA-Z0-9_.:-]*$")
+          - old_device is defined and old_device is match("^/?[a-zA-Z0-9][a-zA-Z0-9/_.:-]*$")
+          - new_device is defined and new_device is match("^/?[a-zA-Z0-9][a-zA-Z0-9/_.:-]*$")
+          - old_device != new_device
+        fail_msg: "pool, old_device and new_device must be valid identifiers"
+
+    - name: Replace device (starts resilver)
+      ansible.builtin.command:
+        argv:
+          - zpool
+          - replace
+          - "{{ pool }}"
+          - "{{ old_device }}"
+          - "{{ new_device }}"
+      register: replace_result
+      changed_when: replace_result.rc == 0

--- a/static/index.html
+++ b/static/index.html
@@ -931,6 +931,30 @@
     </div>
   </dialog>
 
+  <!-- REPLACE DEVICE DIALOG -->
+  <dialog id="replaceDeviceDialog">
+    <h3>Replace Device &mdash; <span id="replaceDevicePool"></span></h3>
+    <div class="dialog-body">
+      <p class="muted" style="margin:0 0 1rem">
+        Replace <code id="replaceDeviceOld"></code>. The pool resilvers onto the
+        new device automatically; the old device is detached when the resilver
+        completes.
+      </p>
+      <div class="form-row">
+        <label for="replaceDeviceNew">New device</label>
+        <select id="replaceDeviceNew"></select>
+      </div>
+      <div class="form-row">
+        <label for="replaceDeviceManual">or enter manually</label>
+        <input type="text" id="replaceDeviceManual" placeholder="/dev/sdX (overrides selection)">
+      </div>
+      <div class="dialog-actions">
+        <button type="button" id="replaceDeviceConfirmBtn" class="btn-primary">Replace</button>
+        <button type="button" id="replaceDeviceCancelBtn" class="btn-secondary">Cancel</button>
+      </div>
+    </div>
+  </dialog>
+
   <!-- AUTO-SNAPSHOT SCHEDULE DIALOG -->
   <dialog id="autoSnapDialog">
     <h3>Auto-Snapshot &mdash; <span id="autoSnapDatasetName"></span></h3>

--- a/static/js/pools.js
+++ b/static/js/pools.js
@@ -151,6 +151,13 @@ export function renderPools() {
       ? `<div class="pool-errors">${esc(detail.errors)}</div>`
       : '';
 
+    const resilver = detail?.scan ? resilverInfoOf(detail.scan) : null;
+    _trackResilver(p.name, resilver);
+    const resilverLine = resilver?.state === 'in_progress' ? `
+      <div class="resilver-label">Resilver in progress${resilver.pct != null ? ` — ${resilver.pct.toFixed(1)}%` : ''}</div>
+      <div class="pool-bar-wrap"><div class="pool-bar warn" style="width:${Math.min(resilver.pct ?? 0, 100).toFixed(1)}%"></div></div>`
+      : '';
+
     const vdevRows = (detail?.vdevs || [])
       .filter(v => v.depth > 0)   // skip the root pool entry (depth 0)
       .map(v => {
@@ -158,11 +165,20 @@ export function renderPools() {
         const errs = v.read || v.write || v.cksum
           ? `<span class="vdev-errs">${v.read}/${v.write}/${v.cksum}</span>`
           : '';
+        // Grouping vdevs (mirror-0, raidz1-0, …) take no device actions.
+        const isLeaf = !/^(mirror|raidz|draid|spare|replacing|logs|cache|special|dedup)/.test(v.name);
+        const actions = isLeaf ? `
+          <span class="vdev-actions">
+            <button class="btn-vdev" onclick="openReplaceDeviceDialog('${esc(p.name)}','${esc(v.name)}')">Replace</button>
+            ${v.state === 'OFFLINE'
+              ? `<button class="btn-vdev" onclick="onlineDevice('${esc(p.name)}','${esc(v.name)}')">Online</button>`
+              : `<button class="btn-vdev" onclick="offlineDevice('${esc(p.name)}','${esc(v.name)}')">Offline</button>`}
+          </span>` : '';
         return `
           <div class="vdev-row" style="--vdepth:${indent}">
             <span class="vdev-name">${esc(v.name)}</span>
             <span class="vdev-state state-${esc(v.state || 'UNKNOWN')}">${esc(v.state || '—')}</span>
-            ${errs}
+            ${errs}${actions}
           </div>`;
       }).join('');
 
@@ -205,10 +221,104 @@ export function renderPools() {
             <div class="stat-value">${esc(p.dedup)}</div>
           </div>
         </div>
-        ${scanLine}${scrubActions}${statusLine}${errLine}${vdevSection}
+        ${resilverLine}${scanLine}${scrubActions}${statusLine}${errLine}${vdevSection}
       </div>`;
   }).join('');
 }
+
+// ── Resilver helpers ──────────────────────────────────────────────────────────
+// Parses the raw scan string from `zpool status`. Returns
+// { state: 'in_progress', pct } while a resilver runs, { state: 'done' } right
+// after one finished, or null when the scan line is about something else.
+function resilverInfoOf(scan) {
+  if (!scan) return null;
+  if (scan.startsWith('resilver in progress')) {
+    const m = scan.match(/([\d.]+)% done/);
+    return { state: 'in_progress', pct: m ? parseFloat(m[1]) : null };
+  }
+  if (scan.startsWith('resilvered')) return { state: 'done' };
+  return null;
+}
+
+// Tracks pools with an active resilver so completion can be announced when a
+// poolstatus SSE update flips the scan line from in-progress to resilvered.
+const _resilveringPools = new Set();
+
+function _trackResilver(pool, resilver) {
+  if (resilver?.state === 'in_progress') {
+    _resilveringPools.add(pool);
+  } else if (_resilveringPools.has(pool)) {
+    _resilveringPools.delete(pool);
+    toast(`Resilver finished on ${pool}`, 'ok');
+  }
+}
+
+// ── Device actions (replace / offline / online) ───────────────────────────────
+let _replaceCtx = { pool: '', old: '' };
+
+async function openReplaceDeviceDialog(pool, oldDev) {
+  _replaceCtx = { pool, old: oldDev };
+  document.getElementById('replaceDevicePool').textContent = pool;
+  document.getElementById('replaceDeviceOld').textContent = oldDev;
+  document.getElementById('replaceDeviceManual').value = '';
+  const sel = document.getElementById('replaceDeviceNew');
+  sel.innerHTML = '<option value="">Loading devices&hellip;</option>';
+  document.getElementById('replaceDeviceDialog').showModal();
+  try {
+    const devs = await api('GET', '/api/devices');
+    const free = (devs || []).filter(d => !d.in_use_by);
+    sel.innerHTML = free.length
+      ? '<option value="">— select a device —</option>' + free.map(d =>
+          `<option value="${esc(d.path)}">${esc(d.path)} · ${fmtBytes(d.size_bytes)}${d.model ? ' · ' + esc(d.model) : ''}</option>`).join('')
+      : '<option value="">No unused devices found</option>';
+  } catch (err) {
+    sel.innerHTML = '<option value="">Failed to list devices</option>';
+  }
+}
+
+async function confirmReplaceDevice() {
+  const manual = document.getElementById('replaceDeviceManual').value.trim();
+  const newDev = manual || document.getElementById('replaceDeviceNew').value;
+  if (!newDev) { toast('Choose a replacement device', 'err'); return; }
+  const { pool, old } = _replaceCtx;
+  document.getElementById('replaceDeviceDialog').close();
+  showOpLogRunning(`Replace ${old} in ${pool}`);
+  try {
+    const data = await api('POST', `/api/pools/${encodeURIComponent(pool)}/replace`,
+      { old_device: old, new_device: newDev });
+    showOpLog(`Replace ${old} in ${pool}`, data.tasks, null);
+    toast(`Replace started on ${pool} — resilver running`, 'ok');
+    await loadAll();
+  } catch (err) {
+    showOpLog(`Replace ${old} in ${pool}`, err.tasks, err.message);
+  }
+}
+
+async function offlineDevice(pool, device) {
+  if (!confirm(`Take ${device} offline?\n\nPool ${pool} will run without this device — redundancy is reduced until it is brought back online.`)) return;
+  await _deviceStateOp(pool, device, 'offline');
+}
+
+async function onlineDevice(pool, device) {
+  await _deviceStateOp(pool, device, 'online');
+}
+
+async function _deviceStateOp(pool, device, op) {
+  const title = `${op === 'offline' ? 'Offline' : 'Online'} ${device} (${pool})`;
+  showOpLogRunning(title);
+  try {
+    const data = await api('POST', `/api/pools/${encodeURIComponent(pool)}/${op}`, { device });
+    showOpLog(title, data.tasks, null);
+    toast(`${device} is now ${op}`, 'ok');
+    await loadAll();
+  } catch (err) {
+    showOpLog(title, err.tasks, err.message);
+  }
+}
+
+// ── Replace-device dialog wiring ──────────────────────────────────────────────
+document.getElementById('replaceDeviceConfirmBtn').addEventListener('click', confirmReplaceDevice);
+document.getElementById('replaceDeviceCancelBtn').addEventListener('click', () => document.getElementById('replaceDeviceDialog').close());
 
 // ── Pool scrub helpers ────────────────────────────────────────────────────────
 // Returns 'in_progress', 'paused', or 'idle' based on the raw scan string.
@@ -510,5 +620,8 @@ function renderDriveCard(d) {
 // ── window assignments for inline onclick handlers and cross-module calls ─────
 window.startScrub = startScrub;
 window.cancelScrub = cancelScrub;
+window.openReplaceDeviceDialog = openReplaceDeviceDialog;
+window.offlineDevice = offlineDevice;
+window.onlineDevice = onlineDevice;
 window.openScrubScheduleDialog = openScrubScheduleDialog;
 window.openAutoSnapDialog = openAutoSnapDialog;

--- a/static/style.css
+++ b/static/style.css
@@ -336,6 +336,13 @@ main {
   font-family: var(--font);
 }
 .vdev-state { font-weight: 600; min-width: 52px; font-size: 10px; }
+.vdev-actions { display: flex; gap: 4px; }
+.vdev-actions .btn-vdev { font-size: 10px; padding: 1px 6px; }
+.resilver-label {
+  font-size: 11px;
+  color: var(--yellow);
+  margin-bottom: 0.3rem;
+}
 .vdev-errs  { font-size: 10px; color: var(--text-muted); white-space: nowrap; }
 .state-ONLINE   { color: var(--green); }
 .state-DEGRADED { color: var(--yellow); }
@@ -794,11 +801,11 @@ dialog label select:focus { border-color: var(--accent); }
 .btn-iscsi:hover { background: var(--surface); color: var(--text); }
 .btn-iscsi.active { background: color-mix(in srgb, var(--accent) 15%, var(--surface2)); color: var(--accent); border-color: var(--accent-dim); }
 .btn-iscsi.active:hover { background: color-mix(in srgb, var(--accent) 25%, var(--surface2)); }
-.btn-rename, .btn-clone, .btn-send, .btn-job-detail {
+.btn-rename, .btn-clone, .btn-send, .btn-job-detail, .btn-vdev {
   background: var(--surface2); color: var(--text-muted);
   border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer;
 }
-.btn-rename:hover, .btn-clone:hover, .btn-send:hover, .btn-job-detail:hover {
+.btn-rename:hover, .btn-clone:hover, .btn-send:hover, .btn-job-detail:hover, .btn-vdev:hover {
   background: var(--surface); color: var(--text);
 }
 .btn-cancel-job, .btn-remove-job {

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -52,6 +52,10 @@ All endpoints are served at `http://<host>:8080`. The API is JSON-over-HTTP; all
 | GET    | `/api/smb/timemachine`      | List all Time Machine shares |
 | POST   | `/api/smb/timemachine`      | Create/update a Time Machine share |
 | DELETE | `/api/smb/timemachine/{name}` | Remove a Time Machine share |
+| GET    | `/api/devices`              | List physical block devices (vdev candidates, in-use flag) |
+| POST   | `/api/pools/{pool}/replace` | Replace a pool device (starts resilver) |
+| POST   | `/api/pools/{pool}/offline` | Take a pool device offline |
+| POST   | `/api/pools/{pool}/online`  | Bring a pool device online |
 | POST   | `/api/scrub/{pool}`         | Start a pool scrub |
 | DELETE | `/api/scrub/{pool}`         | Cancel a running pool scrub |
 | GET    | `/api/scrub-schedules`      | List periodic scrub schedule config |
@@ -245,6 +249,39 @@ Returns the recent `RunRecord` list (capped at 20):
 ### DELETE /api/snapshots/{dataset}@{snapname}
 
 Append `?recursive=true` to also destroy clones.
+
+---
+
+## Devices & drive replacement
+
+### GET /api/devices
+
+Returns the physical block devices on the host (Linux: `/sys/block`, skipping loop/ram/zvol/dm pseudo-devices; FreeBSD: `geom disk list`). `in_use_by` carries the pool name when the device currently backs a vdev (best-effort matching: by-id/by-path symlinks resolved, partition suffixes stripped).
+
+```json
+[
+  { "name": "sdb", "path": "/dev/sdb", "size_bytes": 4000787030016, "model": "WDC WD40EFRX", "in_use_by": "tank" },
+  { "name": "sdc", "path": "/dev/sdc", "size_bytes": 4000787030016, "model": "WDC WD40EFRX", "in_use_by": "" }
+]
+```
+
+### POST /api/pools/{pool}/replace
+
+Replace a vdev with a new device via `zpool replace`. A resilver onto the new device starts automatically; progress is visible in the pool's `scan` field (`GET /api/poolstatus`, `poolstatus` SSE topic).
+
+```json
+{ "old_device": "sdb", "new_device": "/dev/sdc" }
+```
+
+`old_device` accepts a device name, path, or the numeric guid `zpool status` prints for missing devices. Returns Ansible task steps.
+
+### POST /api/pools/{pool}/offline
+
+Take a device offline for maintenance via `zpool offline`. Body: `{ "device": "sdb" }`. Returns Ansible task steps.
+
+### POST /api/pools/{pool}/online
+
+Bring an offlined device back via `zpool online`. Body: `{ "device": "sdb" }`. Returns Ansible task steps.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements #55 — replace a faulted/degraded disk and monitor the resilver from the UI.

## What's included

**Backend**
- New `internal/blockdev` package — physical block device enumeration (`/sys/block` on Linux skipping loop/ram/zd/dm/sr pseudo-devices, `geom disk list` on FreeBSD) with best-effort in-use detection against pool vdevs (by-id/by-path symlink resolution, partition suffix stripping). Unit-tested.
- `GET /api/devices` — devices with `in_use_by` pool flag (feeds the replacement picker)
- `POST /api/pools/{pool}/replace` — `zpool replace` via new `zfs_disk_replace.yml` (argv-form, input asserts)
- `POST /api/pools/{pool}/offline` / `/online` — `zpool offline/online` via new playbooks
- Vdev-name validation regex (`reVdevName`) accepts device names, paths, and the numeric guids `zpool status` prints for missing devices

**Frontend**
- Replace / Offline / Online row actions on leaf devices in the vdev tree (grouping vdevs like `mirror-0` excluded); reuses the existing muted row-action button style (`.btn-vdev` added to the shared CSS rule)
- Replace dialog with unused-device picker + manual path fallback
- Resilver progress bar with live percentage parsed from the `scan` line (existing poolstatus SSE topic) and completion toast
- Faulted/degraded states were already color-coded in the vdev tree and pool health badge — unchanged

**Docs**: README (features, API table, file map), wiki/API-Reference, docs/index.html, FEATURES.md (Planned → Implemented), CHANGELOG, CLAUDE.md

## Verification

- `go build`, `go vet`, `go test ./...` all pass (new blockdev parser/matcher tests included)
- `ansible-playbook --syntax-check` passes for the three new playbooks
- `node --check` passes on modified JS
- Not exercised against a live pool — needs a VM with a spare disk for end-to-end validation

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)