### PR TITLE
fix(jobs): don't lose pipeline output tail on close/drain race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented here.
 
 ### Fixed
 
+- **Pipeline jobs no longer lose their final output tail** — `RunPipeline` closed the stdout/stderr pipe read ends before the collector goroutines had drained them, so on loaded machines the buffered tail of a `zfs send | zfs recv` job's output was sometimes discarded (this also made `TestRunPipeline_Success` flaky in CI). The waiter now lets the collectors drain to EOF first, with a bounded grace window before force-closing in case a lingering grandchild keeps a write end open.
 - **Auto-snapshot takeover no longer fails on hosts missing zfs-auto-snapshot timers** — the Linux takeover task now enumerates installed `zfs-auto-snapshot-*.timer` units via `systemctl list-unit-files` and only stops/disables units that actually exist, instead of relying on fragile error-message matching. A new op-log task reports the per-timer outcome (stopped and disabled / not present). Closes #93.
 
 ### Security

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -22,6 +22,11 @@ const (
 	defaultTailSize   = 64 * 1024 // 64 KiB stdout + stderr each
 	defaultRetention  = 50        // completed-job records to keep
 	cancelGracePeriod = 10 * time.Second
+	// collectGracePeriod bounds how long RunPipeline waits for the output
+	// collectors to drain after both children exited, before force-closing
+	// the pipe read ends (only relevant when a lingering grandchild keeps a
+	// write end open).
+	collectGracePeriod = 2 * time.Second
 )
 
 // Notifier is invoked when a job's state changes (creation, start, finish).
@@ -323,11 +328,24 @@ func (m *Manager) RunPipeline(jobType string, left, right []string) (Job, error)
 	go func() {
 		leftErr := leftCmd.Wait()
 		rightErr := rightCmd.Wait()
-		// Now that both children are dead, closing the read ends lets the
-		// collect goroutines see EOF and return.
+		// Both children are dead, so every write end they held is closed and
+		// the collect goroutines drain whatever is buffered in the pipes and
+		// then see EOF. Closing the read ends before the collectors finish
+		// would discard that buffered output (this was a real race: the final
+		// stdout tail was sometimes lost on loaded machines). The force-close
+		// after a grace window only exists for the pathological case of a
+		// lingering grandchild that inherited a write end and keeps the pipe
+		// open — without it this goroutine would hang and the job would stay
+		// "running" forever.
+		drained := make(chan struct{})
+		go func() { wg.Wait(); close(drained) }()
+		select {
+		case <-drained:
+		case <-time.After(collectGracePeriod):
+		}
 		_ = stdoutR.Close()
 		_ = stderrR.Close()
-		wg.Wait()
+		<-drained
 		var runErr error
 		switch {
 		case leftErr != nil:


### PR DESCRIPTION
## Summary

Fixes the CI flake that hit PR #109 (`TestRunPipeline_Success: stdout = "", want to contain HELLO`) — which turned out to be a real output-loss bug, not just a flaky test.

## Root cause

`RunPipeline`'s waiter goroutine closed the stdout/stderr pipe **read ends** before `wg.Wait()`. Once both children exit, all write ends are closed, so the collectors would drain the remaining buffered bytes and hit EOF naturally — but when the force-close won the race, the buffered tail (e.g. the last output of `zfs send | zfs recv`) was discarded. `Run()` is unaffected (io.Pipe, closes write ends).

## Fix

Wait for the collectors to drain first; force-close only after a bounded 2 s grace window, which exists solely for the pathological case of a lingering grandchild holding an inherited write end open (without it the job would stay `running` forever).

## Verification

- `go test -race -count=30 ./internal/jobs/` passes (8 s)
- `go build`, `go vet` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)