### PR TITLE
fix(ci): release workflow uses go.mod toolchain version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
 
       - name: Build and package
         run: |


### PR DESCRIPTION
## Summary

The `v0.1.14` release build failed immediately: `release.yml` pins `go-version: '1.22'` while `go.mod` requires Go ≥ 1.25 (`GOTOOLCHAIN=local` on the runner refuses to self-upgrade):

```
go: go.mod requires go >= 1.25.0 (running go 1.22.12; GOTOOLCHAIN=local)
```

## Fix

Use `go-version-file: go.mod` — same as `ci.yml` — so the release workflow always builds with the module's declared toolchain and the two workflows can't drift apart again.

After merge I'll re-point the `v0.1.14` tag at the fixed main and re-run the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)