### PR TITLE
test: VM-based integration test suite wired into CI (#117)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,7 +51,9 @@ jobs:
         env:
           LIMA_VERSION: "1.0.7"
         run: |
-          sudo apt-get update -qq
+          # Tolerate index failures from unrelated third-party repos on the
+          # runner image; qemu comes from the default Ubuntu archive.
+          sudo apt-get update -qq || true
           sudo apt-get install -y -qq --no-install-recommends qemu-system-x86 qemu-utils
           curl -fsSL "https://github.com/lima-vm/lima/releases/download/v${LIMA_VERSION}/lima-${LIMA_VERSION}-Linux-x86_64.tar.gz" \
             | sudo tar Cxz /usr/local

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,7 +54,8 @@ jobs:
           # Tolerate index failures from unrelated third-party repos on the
           # runner image; qemu comes from the default Ubuntu archive.
           sudo apt-get update -qq || true
-          sudo apt-get install -y -qq --no-install-recommends qemu-system-x86 qemu-utils
+          # ovmf: UEFI firmware Lima needs to boot x86_64 guests
+          sudo apt-get install -y -qq --no-install-recommends qemu-system-x86 qemu-utils ovmf
           curl -fsSL "https://github.com/lima-vm/lima/releases/download/v${LIMA_VERSION}/lima-${LIMA_VERSION}-Linux-x86_64.tar.gz" \
             | sudo tar Cxz /usr/local
           limactl --version
@@ -71,5 +72,7 @@ jobs:
       - name: Collect VM logs on failure
         if: failure()
         run: |
+          tail -n 100 ~/.lima/dumpstore-linux/ha.stderr.log 2>/dev/null || true
+          tail -n 50 ~/.lima/dumpstore-linux/serial*.log 2>/dev/null || true
           limactl shell --tty=false dumpstore-linux -- sudo journalctl -u dumpstore --no-pager -n 200 || true
           limactl shell --tty=false dumpstore-linux -- sudo zpool status || true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,73 @@
+# VM-based integration tests (#117).
+#
+# Boots the same Lima VM developers use (dev/lima-linux.yaml), deploys
+# dumpstore into it with `make install`, and runs tests/integration against
+# the live API — real zpool/zfs/Ansible, no mocks.
+#
+# Triggers:
+#   - nightly (cron)
+#   - manually (workflow_dispatch)
+#   - on PRs carrying the `run-integration` label
+#
+# FreeBSD is not covered here: GitHub's macOS arm64 runners do not support
+# nested virtualization, so the FreeBSD VM remains a local target
+# (make vm-freebsd-start; see tests/integration/README.md).
+name: Integration Tests
+
+on:
+  schedule:
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-vm:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-integration')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Enable KVM for the runner user
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install QEMU and Lima
+        env:
+          LIMA_VERSION: "1.0.7"
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends qemu-system-x86 qemu-utils
+          curl -fsSL "https://github.com/lima-vm/lima/releases/download/v${LIMA_VERSION}/lima-${LIMA_VERSION}-Linux-x86_64.tar.gz" \
+            | sudo tar Cxz /usr/local
+          limactl --version
+
+      - name: Start Linux VM
+        run: make vm-linux-start
+
+      - name: Deploy dumpstore into VM
+        run: make vm-linux-deploy
+
+      - name: Run integration tests
+        run: make test-integration
+
+      - name: Collect VM logs on failure
+        if: failure()
+        run: |
+          limactl shell --tty=false dumpstore-linux -- sudo journalctl -u dumpstore --no-pager -n 200 || true
+          limactl shell --tty=false dumpstore-linux -- sudo zpool status || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented here.
 
+## [Unreleased]
+
+### Added
+
+- **VM-based integration test suite** — `tests/integration` (build tag `integration`, stdlib only) drives a deployed dumpstore instance over HTTP and asserts on real ZFS state: session auth, dataset lifecycle (create / property PATCH / rename / destroy), snapshots with `zfs diff` and clone, per-user quotas, a `zfs send | recv` pipeline followed through the jobs API, and a full pool lifecycle — mirror create, duplicate-name refusal, device offline/online, `zpool replace` with resilver, hot-spare add/remove, export, importable discovery, import — on three dedicated 1 GiB scratch disks the Lima VMs now provision (never on the `tank` data pool). Run locally with `make test-integration`; CI (`.github/workflows/integration-tests.yml`) boots the same Lima VM on a KVM-enabled runner nightly, on manual dispatch, and on PRs labeled `run-integration`. Closes #117.
+
+### Fixed
+
+- **Dev VM admin login never worked after provisioning** — `dev/lima-{linux,freebsd}.yaml` wrote a bcrypt `password_hash` into `dumpstore.conf`, but the server rejects bcrypt hashes since the argon2id migration, so `admin`/`admin` on a freshly provisioned VM always failed. The provision scripts now write the correct argon2id PHC hash.
+
 ## [v0.1.14] — 2026-06-10
 
 ### Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -38,6 +38,7 @@
 | TLS / HTTPS                | v0.1.10 | `--tls` flag; self-signed cert generation (openssl via Ansible); path loader for existing certs; ACME issuance/renewal via `lego`; HTTP→HTTPS redirect; cert status card with expiry countdown |
 | Samba full ownership       | v0.1.10 | dumpstore owns smb.conf entirely — rendered from Go template on every write; directories auto-created; init gate blocks sub-features until Samba is bootstrapped; FreeBSD smb4.conf created on first init; resolves #75 #77 #78 #79 #81 |
 | FreeBSD-compliant paths    | v0.1.10 | `/usr/local/etc/dumpstore/` on FreeBSD, `/etc/dumpstore/` on Linux — `internal/platform.ConfigDir(goos)` as single source of truth; usershares, TLS certs, rc.d script, Makefile, install.sh all updated |
+| VM integration test suite  | v0.1.15 | End-to-end tests (`tests/integration`, `make test-integration`) drive the deployed API in the Lima VM against real ZFS: auth, dataset/snapshot lifecycle, diff, quotas, send/recv jobs, full pool lifecycle on dedicated scratch disks. CI runs it nightly and on PRs labeled `run-integration`. Closes #117 |
 | SMB init status badge      | v0.1.10 | Users & Groups tab shows green "Initialised" badge with last-applied timestamp, or red "Not initialised"; `GET /api/smb/status` now includes `conf_mtime` |
 | Dev VM environment         | v0.1.11 | `make vm-linux-start/deploy` and `make vm-freebsd-start/deploy`; Ubuntu 24.04 + FreeBSD 15 with ZFS + Ansible; default admin/admin; closes #83 |
 | Dataset rename             | v0.1.11 | Rename a dataset or volume in place; same-parent constraint; closes #21 |
@@ -69,7 +70,6 @@
 
 | Feature                            | Priority | Issue | Notes                                                                                                                    |
 |------------------------------------|----------|-------|--------------------------------------------------------------------------------------------------------------------------|
-| VM integration tests in CI         | High     | [#117](https://github.com/langerma/dumpstore/issues/117) | Nightly CI runs the integration suite against real pools (file-backed vdevs on Linux); FreeBSD pre-release checklist |
 | Go ops layer (shrink Ansible)      | Medium   | [#115](https://github.com/langerma/dumpstore/issues/115) | Single-command mutations move from playbooks to an in-process executor; Ansible keeps config files + OS resources |
 | Privilege separation               | Medium   | [#116](https://github.com/langerma/dumpstore/issues/116) | Non-root web frontend + narrow root helper over a unix socket |
 | Release build smoke test           | Medium   | [#118](https://github.com/langerma/dumpstore/issues/118) | CI cross-builds the release matrix on every PR so release.yml can't drift (v0.1.14 tag build broke on a pinned Go version) |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BINARY  := dumpstore
 INSTALL := /usr/local/lib/dumpstore
 .PHONY: all build clean dev install uninstall check-prereqs install-go install-ansible \
+        test-integration \
         vm-linux-start vm-linux-stop vm-linux-ssh vm-linux-deploy vm-linux-destroy \
         vm-freebsd-start vm-freebsd-stop vm-freebsd-ssh vm-freebsd-deploy vm-freebsd-destroy
 
@@ -122,6 +123,10 @@ vm-linux-start:
 	else \
 	  echo "==> Creating ZFS data disk..."; \
 	  limactl disk create dumpstore-linux-data --size 10GiB 2>/dev/null || true; \
+	  echo "==> Creating integration-test scratch disks..."; \
+	  for n in 1 2 3; do \
+	    limactl disk create dumpstore-linux-test$$n --size 1GiB 2>/dev/null || true; \
+	  done; \
 	  echo "==> Creating and provisioning VM $(VM_LINUX) (first run, takes a few minutes)..."; \
 	  limactl create --name=$(VM_LINUX) dev/lima-linux.yaml; \
 	  limactl start $(VM_LINUX); \
@@ -154,6 +159,15 @@ vm-linux-deploy:
 vm-linux-destroy:
 	limactl delete --force $(VM_LINUX) || true
 	limactl disk delete dumpstore-linux-data 2>/dev/null || true
+	@for n in 1 2 3; do \
+	  limactl disk delete dumpstore-linux-test$$n 2>/dev/null || true; \
+	done
+
+# Integration tests — drive the deployed dumpstore API in the Lima VM.
+# Prerequisites: make vm-linux-start && make vm-linux-deploy
+# See tests/integration/README.md for env overrides (FreeBSD VM, disks, …).
+test-integration:
+	go test -tags integration -count=1 -timeout 30m -v ./tests/integration/...
 
 vm-freebsd-start:
 	@command -v limactl >/dev/null 2>&1 || { \
@@ -168,6 +182,10 @@ vm-freebsd-start:
 	else \
 	  echo "==> Creating ZFS data disk..."; \
 	  limactl disk create dumpstore-freebsd-data --size 10GiB 2>/dev/null || true; \
+	  echo "==> Creating integration-test scratch disks..."; \
+	  for n in 1 2 3; do \
+	    limactl disk create dumpstore-freebsd-test$$n --size 1GiB 2>/dev/null || true; \
+	  done; \
 	  echo "==> Creating and provisioning VM $(VM_FREEBSD) (first run, takes a few minutes)..."; \
 	  limactl create --name=$(VM_FREEBSD) dev/lima-freebsd.yaml; \
 	  limactl start $(VM_FREEBSD); \
@@ -205,6 +223,9 @@ vm-freebsd-deploy:
 vm-freebsd-destroy:
 	limactl delete --force $(VM_FREEBSD) || true
 	limactl disk delete dumpstore-freebsd-data 2>/dev/null || true
+	@for n in 1 2 3; do \
+	  limactl disk delete dumpstore-freebsd-test$$n 2>/dev/null || true; \
+	done
 
 uninstall:
 	@set -e; \

--- a/README.md
+++ b/README.md
@@ -571,7 +571,17 @@ make vm-freebsd-stop
 make vm-freebsd-destroy
 ```
 
-Both VMs run arm64 via QEMU. Each gets a dedicated 10 GiB extra disk for ZFS (`tank` pool created at first boot). Deployment packs the source tree on the host, copies it into the VM, and runs `make install` natively — no cross-compilation. Port forwards are fixed: Linux on `:8080`, FreeBSD on `:8081`, so both can be up simultaneously. Default credentials: **admin / admin**.
+Both VMs run via QEMU (the Linux VM follows the host architecture; FreeBSD is arm64). Each gets a dedicated 10 GiB extra disk for ZFS (`tank` pool created at first boot) plus three 1 GiB scratch disks used by the integration tests. Deployment packs the source tree on the host, copies it into the VM, and runs `make install` natively — no cross-compilation. Port forwards are fixed: Linux on `:8080`, FreeBSD on `:8081`, so both can be up simultaneously. Default credentials: **admin / admin**.
+
+### Integration tests (real ZFS, via the VM)
+
+With the Linux VM up and deployed, run the end-to-end suite from the host:
+
+```bash
+make test-integration
+```
+
+It drives the deployed API over HTTP — auth, dataset/snapshot lifecycle, `zfs diff`, user quotas, send/recv jobs, and a full pool lifecycle (create, offline/online, `zpool replace` + resilver, spares, export/import) on the scratch disks. CI runs the same suite nightly and on PRs labeled `run-integration` (`.github/workflows/integration-tests.yml`). See [tests/integration/README.md](tests/integration/README.md) for configuration and for running it against the FreeBSD VM.
 
 ## Uninstall
 

--- a/dev/lima-freebsd.yaml
+++ b/dev/lima-freebsd.yaml
@@ -13,10 +13,18 @@ cpus: 2
 memory: 2GiB
 disk: 20GiB
 
-# Extra disk for a second ZFS pool (zroot already exists from base install)
+# Extra disks: one for a second ZFS pool (zroot already exists from base
+# install), three scratch disks for the integration test suite's pool
+# lifecycle tests. They appear as /dev/vtbd1 through /dev/vtbd4.
 additionalDisks:
   - name: dumpstore-freebsd-data
     format: false   # raw, unformatted — ZFS will own it
+  - name: dumpstore-freebsd-test1
+    format: false
+  - name: dumpstore-freebsd-test2
+    format: false
+  - name: dumpstore-freebsd-test3
+    format: false
 
 images:
   - location: "https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/aarch64/Latest/FreeBSD-15.0-RELEASE-arm64-aarch64-BASIC-CLOUDINIT-zfs.qcow2.xz"
@@ -51,7 +59,7 @@ provision:
 
       echo "==> Writing default dev config (admin/admin)..."
       install -d -m 0700 /usr/local/etc/dumpstore
-      python3.11 -c 'import json,os; cfg={"username":"admin","password_hash":"$2a$10$7Kfic7R28U4V1ePxnvrA.OkJwiahwkmbRrnEDEKW6RbvC/G86Q8nC","session_ttl":"24h","trusted_proxies":[],"unprotected_paths":["/metrics"],"tls_enabled":False,"tls_cert_path":"","tls_key_path":"","acme_enabled":False,"acme_email":"","acme_domain":""}; f=open("/usr/local/etc/dumpstore/dumpstore.conf","w"); json.dump(cfg,f,indent=2); f.close(); os.chmod("/usr/local/etc/dumpstore/dumpstore.conf",0o600)'
+      python3.11 -c 'import json,os; cfg={"username":"admin","password_hash":"$argon2id$v=19$m=65536,t=3,p=4$ZHVtcHN0b3JlLWRldi12bQ$+quqbq+vJQm6WpP8GUB9+CeE6fPwSXXOl+XuSi1R4aM","session_ttl":"24h","trusted_proxies":[],"unprotected_paths":["/metrics"],"tls_enabled":False,"tls_cert_path":"","tls_key_path":"","acme_enabled":False,"acme_email":"","acme_domain":""}; f=open("/usr/local/etc/dumpstore/dumpstore.conf","w"); json.dump(cfg,f,indent=2); f.close(); os.chmod("/usr/local/etc/dumpstore/dumpstore.conf",0o600)'
 
       echo "==> Creating second ZFS pool on /dev/vtbd1..."
       # Wait for the extra disk to appear

--- a/dev/lima-linux.yaml
+++ b/dev/lima-linux.yaml
@@ -7,20 +7,30 @@
 
 vmType: qemu
 os: Linux
-arch: aarch64
+# arch defaults to the host: aarch64 on Apple silicon, x86_64 on CI runners.
 
 cpus: 2
 memory: 2GiB
 disk: 20GiB
 
-# Extra disk for ZFS pool (separate from the OS disk)
+# Extra disks: one for the main ZFS pool, three scratch disks that the
+# integration test suite (tests/integration) uses for pool lifecycle tests
+# (create/replace/spare/export). They appear as /dev/vdc, /dev/vdd, /dev/vde.
 additionalDisks:
   - name: dumpstore-linux-data
     format: false   # raw, unformatted — ZFS will own it
+  - name: dumpstore-linux-test1
+    format: false
+  - name: dumpstore-linux-test2
+    format: false
+  - name: dumpstore-linux-test3
+    format: false
 
 images:
   - location: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img"
     arch: aarch64
+  - location: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+    arch: x86_64
 
 # Forward dumpstore UI port to host
 portForwards:
@@ -51,7 +61,7 @@ provision:
 
       echo "==> Writing default dev config (admin/admin)..."
       install -d -m 0700 /etc/dumpstore
-      python3 -c 'import json,os; cfg={"username":"admin","password_hash":"$2a$10$7Kfic7R28U4V1ePxnvrA.OkJwiahwkmbRrnEDEKW6RbvC/G86Q8nC","session_ttl":"24h","trusted_proxies":[],"unprotected_paths":["/metrics"],"tls_enabled":False,"tls_cert_path":"","tls_key_path":"","acme_enabled":False,"acme_email":"","acme_domain":""}; f=open("/etc/dumpstore/dumpstore.conf","w"); json.dump(cfg,f,indent=2); f.close(); os.chmod("/etc/dumpstore/dumpstore.conf",0o600)'
+      python3 -c 'import json,os; cfg={"username":"admin","password_hash":"$argon2id$v=19$m=65536,t=3,p=4$ZHVtcHN0b3JlLWRldi12bQ$+quqbq+vJQm6WpP8GUB9+CeE6fPwSXXOl+XuSi1R4aM","session_ttl":"24h","trusted_proxies":[],"unprotected_paths":["/metrics"],"tls_enabled":False,"tls_cert_path":"","tls_key_path":"","acme_enabled":False,"acme_email":"","acme_domain":""}; f=open("/etc/dumpstore/dumpstore.conf","w"); json.dump(cfg,f,indent=2); f.close(); os.chmod("/etc/dumpstore/dumpstore.conf",0o600)'
 
       echo "==> Creating ZFS pool on /dev/vdb..."
       for i in $(seq 1 10); do

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,62 @@
+# Integration tests
+
+End-to-end tests that drive a **deployed dumpstore instance** over HTTP and
+verify real ZFS state changes — `zpool create`, resilver, `zfs diff`, jobs —
+inside the Lima dev VM. No mocks: every write goes through the same
+Ansible/jobs machinery production uses.
+
+They are excluded from `go test ./...` by the `integration` build tag.
+
+## Running locally
+
+```sh
+make vm-linux-start     # boot the Lima VM (first run: creates it + 3 scratch disks)
+make vm-linux-deploy    # build + install dumpstore inside the VM
+make test-integration   # run the suite from the host against http://localhost:8080
+```
+
+The suite logs in as `admin` / `admin` (the dev VM default) and uses
+`limactl shell` for fixtures the API can't provide (writing files into
+datasets, pre-cleaning stale state).
+
+## What is covered
+
+| Test | Exercises |
+|------|-----------|
+| `TestAuth` | session gate (401), failed login, session cookie login |
+| `TestDatasetLifecycle` | dataset create, property PATCH, rename, destroy |
+| `TestSnapshotsAndDiff` | snapshot create/list, `zfs diff` between snapshots, clone, batch delete |
+| `TestUserQuota` | `userquota@` set/clear + userspace report |
+| `TestSendReceiveJob` | `zfs send \| recv` pipeline through the jobs manager, job polling, job removal |
+| `TestPoolLifecycle` | pool create (mirror), duplicate-name refusal, device offline/online, `zpool replace` + resilver, spare add/remove, export, importable discovery, import |
+
+Pool tests run on the three dedicated 1 GiB scratch disks
+(`/dev/vdc`–`/dev/vde`), never on the `tank` data pool. All fixtures are
+prefixed `itest` and cleaned up defensively before *and* after each test, so
+an aborted run cannot poison the next one.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `DUMPSTORE_URL` | `http://localhost:8080` | Base URL of the instance under test |
+| `DUMPSTORE_VM` | `dumpstore-linux` | Lima VM name used for fixture commands |
+| `DUMPSTORE_USER` / `DUMPSTORE_PASS` | `admin` / `admin` | Login credentials |
+| `DUMPSTORE_TEST_POOL` | `tank` | Existing pool for dataset/snapshot tests |
+| `DUMPSTORE_TEST_DISKS` | `/dev/vdc,/dev/vdd,/dev/vde` | Three unused disks for pool tests (set empty to skip them) |
+
+### Against the FreeBSD VM
+
+```sh
+make vm-freebsd-start && make vm-freebsd-deploy
+DUMPSTORE_URL=http://localhost:8081 \
+DUMPSTORE_VM=dumpstore-freebsd \
+DUMPSTORE_TEST_DISKS=/dev/vtbd2,/dev/vtbd3,/dev/vtbd4 \
+make test-integration
+```
+
+## CI
+
+`.github/workflows/integration-tests.yml` runs the Linux VM suite nightly,
+on manual dispatch, and on PRs labeled `run-integration`. FreeBSD stays a
+local target — GitHub's macOS arm64 runners lack nested virtualization.

--- a/tests/integration/api_test.go
+++ b/tests/integration/api_test.go
@@ -1,0 +1,235 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAuth verifies the session gate: unauthenticated API calls are rejected,
+// bad credentials bounce back to the login page, good credentials set a session.
+func TestAuth(t *testing.T) {
+	// No cookie yet (login() has not run in this fresh client for this request):
+	// use a bare request without the shared jar's session by hitting the API
+	// through a throwaway client.
+	resp, err := http.Get(baseURL + "/api/pools")
+	if err != nil {
+		t.Fatalf("GET /api/pools: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated GET /api/pools: got %d, want 401", resp.StatusCode)
+	}
+
+	if resp := postLogin(t, adminUser, "definitely-wrong-password"); resp.StatusCode != http.StatusFound ||
+		!strings.HasPrefix(resp.Header.Get("Location"), "/login?error=") {
+		t.Fatalf("bad-password login: got %d -> %q, want 302 -> /login?error=...",
+			resp.StatusCode, resp.Header.Get("Location"))
+	}
+
+	login(t) // asserts 302 -> / with a session cookie
+	body := apiOK(t, "GET", "/api/version", nil)
+	v := decode[map[string]string](t, body)
+	if v["version"] == "" {
+		t.Fatalf("GET /api/version returned empty version: %s", body)
+	}
+	t.Logf("ZFS version on VM: %s", strings.ReplaceAll(v["version"], "\n", " "))
+}
+
+// TestDatasetLifecycle creates a filesystem through the API, updates a
+// property, renames it, and destroys it — verifying real ZFS state after
+// each mutation.
+func TestDatasetLifecycle(t *testing.T) {
+	name := testPool + "/itest-ds"
+	renamed := testPool + "/itest-ds-renamed"
+	destroyDatasetInVM(name)
+	destroyDatasetInVM(renamed)
+	t.Cleanup(func() { destroyDatasetInVM(name); destroyDatasetInVM(renamed) })
+
+	apiOK(t, "POST", "/api/datasets", map[string]any{
+		"name": name, "type": "filesystem", "compression": "lz4",
+	})
+	ds, ok := datasetByName(t, name)
+	if !ok {
+		t.Fatalf("dataset %s not in /api/datasets after create", name)
+	}
+	if ds.Compression != "lz4" {
+		t.Errorf("compression after create: got %q, want lz4", ds.Compression)
+	}
+
+	apiOK(t, "PATCH", "/api/datasets/"+name, map[string]string{"compression": "zstd"})
+	if ds, _ := datasetByName(t, name); ds.Compression != "zstd" {
+		t.Errorf("compression after PATCH: got %q, want zstd", ds.Compression)
+	}
+
+	apiOK(t, "POST", "/api/datasets/rename", map[string]string{
+		"name": name, "new_name": renamed,
+	})
+	if _, ok := datasetByName(t, renamed); !ok {
+		t.Fatalf("dataset %s not found after rename", renamed)
+	}
+	if _, ok := datasetByName(t, name); ok {
+		t.Fatalf("old name %s still present after rename", name)
+	}
+
+	apiOK(t, "DELETE", "/api/datasets/"+renamed, nil)
+	if _, ok := datasetByName(t, renamed); ok {
+		t.Fatalf("dataset %s still present after delete", renamed)
+	}
+}
+
+// TestSnapshotsAndDiff exercises snapshot create, list, zfs diff between two
+// snapshots, clone, and batch delete — with file changes made directly in the
+// VM between snapshots.
+func TestSnapshotsAndDiff(t *testing.T) {
+	name := testPool + "/itest-snap"
+	clone := testPool + "/itest-clone"
+	destroyDatasetInVM(clone)
+	destroyDatasetInVM(name)
+	t.Cleanup(func() { destroyDatasetInVM(clone); destroyDatasetInVM(name) })
+
+	apiOK(t, "POST", "/api/datasets", map[string]any{"name": name, "type": "filesystem"})
+	ds, ok := datasetByName(t, name)
+	if !ok || ds.Mountpoint == "" {
+		t.Fatalf("dataset %s missing or has no mountpoint: %+v", name, ds)
+	}
+
+	vmExec(t, fmt.Sprintf("echo one > %s/first.txt", ds.Mountpoint))
+	apiOK(t, "POST", "/api/snapshots", map[string]any{"dataset": name, "snapname": "s1"})
+
+	vmExec(t, fmt.Sprintf("echo two > %s/second.txt", ds.Mountpoint))
+	apiOK(t, "POST", "/api/snapshots", map[string]any{"dataset": name, "snapname": "s2"})
+
+	var found int
+	for _, s := range listSnapshots(t) {
+		if s.Name == name+"@s1" || s.Name == name+"@s2" {
+			found++
+		}
+	}
+	if found != 2 {
+		t.Fatalf("expected both snapshots in /api/snapshots, found %d", found)
+	}
+
+	diffBody := apiOK(t, "GET",
+		"/api/snapshots/diff?from="+name+"@s1&to="+name+"@s2", nil)
+	diff := decode[struct {
+		Entries []struct {
+			Change string `json:"change"`
+			Path   string `json:"path"`
+		} `json:"entries"`
+	}](t, diffBody)
+	var sawNewFile bool
+	for _, e := range diff.Entries {
+		if e.Change == "+" && strings.HasSuffix(e.Path, "/second.txt") {
+			sawNewFile = true
+		}
+	}
+	if !sawNewFile {
+		t.Fatalf("diff s1..s2 did not report second.txt as created: %s", truncate(diffBody, 2000))
+	}
+
+	apiOK(t, "POST", "/api/snapshots/clone", map[string]string{
+		"snapshot": name + "@s2", "target": clone,
+	})
+	if _, ok := datasetByName(t, clone); !ok {
+		t.Fatalf("clone %s not in /api/datasets", clone)
+	}
+	// The clone depends on s2, so drop it before deleting the snapshots.
+	apiOK(t, "DELETE", "/api/datasets/"+clone, nil)
+
+	apiOK(t, "POST", "/api/snapshots/delete-batch", map[string]any{
+		"snapshots": []string{name + "@s1", name + "@s2"},
+	})
+	for _, s := range listSnapshots(t) {
+		if s.Dataset == name {
+			t.Fatalf("snapshot %s survived batch delete", s.Name)
+		}
+	}
+}
+
+// TestUserQuota sets and clears a per-user quota and verifies it via the
+// userspace report.
+func TestUserQuota(t *testing.T) {
+	name := testPool + "/itest-quota"
+	destroyDatasetInVM(name)
+	t.Cleanup(func() { destroyDatasetInVM(name) })
+
+	apiOK(t, "POST", "/api/datasets", map[string]any{"name": name, "type": "filesystem"})
+
+	apiOK(t, "POST", "/api/userquota/"+name, map[string]string{
+		"kind": "user", "principal": "root", "quota": "25M",
+	})
+	rows := decode[struct {
+		Rows []spaceRow `json:"rows"`
+	}](t, apiOK(t, "GET", "/api/userspace/"+name+"?kind=user", nil))
+	const want = 25 * 1024 * 1024
+	var got uint64
+	for _, r := range rows.Rows {
+		if r.Name == "root" {
+			got = r.Quota
+		}
+	}
+	if got != want {
+		t.Fatalf("root quota after set: got %d, want %d", got, want)
+	}
+
+	apiOK(t, "POST", "/api/userquota/"+name, map[string]string{
+		"kind": "user", "principal": "root", "quota": "none",
+	})
+	rows = decode[struct {
+		Rows []spaceRow `json:"rows"`
+	}](t, apiOK(t, "GET", "/api/userspace/"+name+"?kind=user", nil))
+	for _, r := range rows.Rows {
+		if r.Name == "root" && r.Quota != 0 {
+			t.Fatalf("root quota not cleared: still %d", r.Quota)
+		}
+	}
+}
+
+// TestSendReceiveJob runs a local zfs send | zfs recv through the jobs
+// manager and follows the job to completion via the jobs API.
+func TestSendReceiveJob(t *testing.T) {
+	src := testPool + "/itest-send"
+	dst := testPool + "/itest-recv"
+	destroyDatasetInVM(src)
+	destroyDatasetInVM(dst)
+	t.Cleanup(func() { destroyDatasetInVM(src); destroyDatasetInVM(dst) })
+
+	apiOK(t, "POST", "/api/datasets", map[string]any{"name": src, "type": "filesystem"})
+	ds, _ := datasetByName(t, src)
+	vmExec(t, fmt.Sprintf("dd if=/dev/urandom of=%s/blob bs=1M count=8 2>/dev/null", ds.Mountpoint))
+	apiOK(t, "POST", "/api/snapshots", map[string]any{"dataset": src, "snapname": "xfer"})
+
+	status, body := api(t, "POST", "/api/snapshots/send", map[string]any{
+		"snapshot": src + "@xfer", "target": dst,
+	})
+	if status != http.StatusAccepted {
+		t.Fatalf("POST /api/snapshots/send: got %d, want 202; body: %s", status, truncate(body, 2000))
+	}
+	jobID := decode[struct {
+		JobID string `json:"job_id"`
+	}](t, body).JobID
+	if jobID == "" {
+		t.Fatalf("no job_id in send response: %s", body)
+	}
+
+	var j job
+	waitFor(t, "send job to finish", 2*time.Minute, func() bool {
+		j = decode[job](t, apiOK(t, "GET", "/api/jobs/"+jobID, nil))
+		return j.Status != "pending" && j.Status != "running"
+	})
+	if j.Status != "success" {
+		t.Fatalf("send job ended %q (error %q, stderr %q)", j.Status, j.Error, j.Stderr)
+	}
+	if _, ok := datasetByName(t, dst); !ok {
+		t.Fatalf("received dataset %s not in /api/datasets", dst)
+	}
+
+	if status, body := api(t, "DELETE", "/api/jobs/"+jobID, nil); status != http.StatusNoContent {
+		t.Fatalf("DELETE job: got %d, body: %s", status, truncate(body, 500))
+	}
+}

--- a/tests/integration/harness_test.go
+++ b/tests/integration/harness_test.go
@@ -1,0 +1,293 @@
+//go:build integration
+
+// Package integration drives a deployed dumpstore instance over HTTP and
+// verifies real ZFS state changes. It expects the Lima dev VM to be running
+// with dumpstore deployed:
+//
+//	make vm-linux-start
+//	make vm-linux-deploy
+//	make test-integration
+//
+// Fixtures that cannot be created through the API (files inside datasets,
+// pre-cleaning stale state) are set up via `limactl shell` in the VM.
+// See README.md in this directory for configuration knobs.
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var (
+	baseURL   = envOr("DUMPSTORE_URL", "http://localhost:8080")
+	vmName    = envOr("DUMPSTORE_VM", "dumpstore-linux")
+	adminUser = envOr("DUMPSTORE_USER", "admin")
+	adminPass = envOr("DUMPSTORE_PASS", "admin")
+	testPool  = envOr("DUMPSTORE_TEST_POOL", "tank")
+	testDisks = splitNonEmpty(envOr("DUMPSTORE_TEST_DISKS", "/dev/vdc,/dev/vdd,/dev/vde"))
+)
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func splitNonEmpty(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// client holds the shared authenticated session. Redirects are not followed
+// so login tests can assert on the 302 responses directly.
+var client = &http.Client{
+	Timeout: 3 * time.Minute,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+var loginOnce sync.Once
+
+func TestMain(m *testing.M) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "cookiejar:", err)
+		os.Exit(1)
+	}
+	client.Jar = jar
+
+	// Fail fast with instructions if no server is listening.
+	resp, err := client.Get(baseURL + "/login")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot reach dumpstore at %s: %v\n", baseURL, err)
+		fmt.Fprintln(os.Stderr, "start the dev VM first:  make vm-linux-start && make vm-linux-deploy")
+		os.Exit(1)
+	}
+	resp.Body.Close()
+
+	os.Exit(m.Run())
+}
+
+// login authenticates the shared client once per test run.
+func login(t *testing.T) {
+	t.Helper()
+	loginOnce.Do(func() {
+		resp := postLogin(t, adminUser, adminPass)
+		if loc := resp.Header.Get("Location"); resp.StatusCode != http.StatusFound || loc != "/" {
+			t.Fatalf("login as %s failed: status %d, Location %q (expected 302 -> /)",
+				adminUser, resp.StatusCode, loc)
+		}
+	})
+}
+
+// postLogin submits the login form and returns the (unfollowed) response.
+func postLogin(t *testing.T, user, pass string) *http.Response {
+	t.Helper()
+	form := url.Values{"username": {user}, "password": {pass}}
+	resp, err := client.PostForm(baseURL+"/auth/login", form)
+	if err != nil {
+		t.Fatalf("POST /auth/login: %v", err)
+	}
+	resp.Body.Close()
+	return resp
+}
+
+// api performs an authenticated JSON request and returns status code and body.
+func api(t *testing.T, method, path string, body any) (int, []byte) {
+	t.Helper()
+	login(t)
+
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request body: %v", err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, baseURL+path, rdr)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response of %s %s: %v", method, path, err)
+	}
+	return resp.StatusCode, b
+}
+
+// apiOK is api plus an assertion that the status is 2xx.
+func apiOK(t *testing.T, method, path string, body any) []byte {
+	t.Helper()
+	status, b := api(t, method, path, body)
+	if status < 200 || status > 299 {
+		t.Fatalf("%s %s: status %d, body: %s", method, path, status, truncate(b, 2000))
+	}
+	return b
+}
+
+func decode[T any](t *testing.T, b []byte) T {
+	t.Helper()
+	var v T
+	if err := json.Unmarshal(b, &v); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, truncate(b, 2000))
+	}
+	return v
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) > n {
+		return string(b[:n]) + "…"
+	}
+	return string(b)
+}
+
+// vmExec runs a shell script as root inside the Lima VM and returns stdout.
+func vmExec(t *testing.T, script string) string {
+	t.Helper()
+	out, err := vmExecErr(script)
+	if err != nil {
+		t.Fatalf("vm command failed: %v\nscript: %s\noutput: %s", err, script, out)
+	}
+	return out
+}
+
+// vmExecErr is vmExec without the fatal-on-error behavior, for cleanup paths.
+func vmExecErr(script string) (string, error) {
+	cmd := exec.Command("limactl", "shell", "--tty=false", vmName, "--", "sudo", "sh", "-c", script)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+// waitFor polls cond until it returns true or the timeout expires.
+func waitFor(t *testing.T, desc string, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("timed out after %s waiting for %s", timeout, desc)
+}
+
+// --- typed views of API responses (only the fields the tests assert on) ---
+
+type dataset struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Mountpoint  string `json:"mountpoint"`
+	Compression string `json:"compression"`
+}
+
+type snapshot struct {
+	Name    string `json:"name"`
+	Dataset string `json:"dataset"`
+}
+
+type pool struct {
+	Name   string `json:"name"`
+	Health string `json:"health"`
+}
+
+type vdevEntry struct {
+	Name  string `json:"name"`
+	State string `json:"state"`
+}
+
+type poolDetail struct {
+	Name  string      `json:"name"`
+	State string      `json:"state"`
+	Scan  string      `json:"scan"`
+	Vdevs []vdevEntry `json:"vdevs"`
+}
+
+type spaceRow struct {
+	Name  string `json:"name"`
+	Used  uint64 `json:"used"`
+	Quota uint64 `json:"quota"`
+}
+
+type job struct {
+	ID     string `json:"id"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Stderr string `json:"stderr"`
+	Error  string `json:"error"`
+}
+
+func listDatasets(t *testing.T) []dataset {
+	t.Helper()
+	return decode[[]dataset](t, apiOK(t, "GET", "/api/datasets", nil))
+}
+
+func datasetByName(t *testing.T, name string) (dataset, bool) {
+	t.Helper()
+	for _, d := range listDatasets(t) {
+		if d.Name == name {
+			return d, true
+		}
+	}
+	return dataset{}, false
+}
+
+func listSnapshots(t *testing.T) []snapshot {
+	t.Helper()
+	return decode[[]snapshot](t, apiOK(t, "GET", "/api/snapshots", nil))
+}
+
+func poolByName(t *testing.T, name string) (pool, bool) {
+	t.Helper()
+	for _, p := range decode[[]pool](t, apiOK(t, "GET", "/api/pools", nil)) {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return pool{}, false
+}
+
+func poolStatus(t *testing.T, name string) (poolDetail, bool) {
+	t.Helper()
+	for _, d := range decode[[]poolDetail](t, apiOK(t, "GET", "/api/poolstatus", nil)) {
+		if d.Name == name {
+			return d, true
+		}
+	}
+	return poolDetail{}, false
+}
+
+// destroyDatasetInVM force-destroys a dataset tree directly in the VM.
+// Used for cleanup so a failed test cannot strand state for the next run.
+func destroyDatasetInVM(name string) {
+	_, _ = vmExecErr("zfs destroy -r " + name + " 2>/dev/null || true")
+}

--- a/tests/integration/pool_test.go
+++ b/tests/integration/pool_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+const itestPool = "itestpool"
+
+// base returns the short device name zpool status displays ("/dev/vdd" -> "vdd").
+func base(dev string) string {
+	return dev[strings.LastIndexByte(dev, '/')+1:]
+}
+
+func hasVdev(d poolDetail, name string) bool {
+	for _, v := range d.Vdevs {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func vdevState(d poolDetail, name string) string {
+	for _, v := range d.Vdevs {
+		if v.Name == name {
+			return v.State
+		}
+	}
+	return ""
+}
+
+func cleanupItestPool() {
+	_, _ = vmExecErr("zpool destroy -f " + itestPool + " 2>/dev/null || true")
+	for _, d := range testDisks {
+		clearDiskLabels(d)
+	}
+}
+
+// clearDiskLabels removes any stale ZFS labels and partition tables so the
+// disk can be reused. ZFS labels whole-disk vdevs on partition 1, so both
+// locations are cleared. Best-effort: tools or labels may be absent.
+func clearDiskLabels(dev string) {
+	_, _ = vmExecErr("zpool labelclear -f " + dev + "1 2>/dev/null; " +
+		"zpool labelclear -f " + dev + " 2>/dev/null; " +
+		"wipefs -a " + dev + " 2>/dev/null; true")
+}
+
+// TestPoolLifecycle walks a scratch pool through its whole life on the VM's
+// dedicated test disks: create (mirror), device offline/online, disk
+// replacement with resilver, spare add/remove, export, import, destroy.
+func TestPoolLifecycle(t *testing.T) {
+	if len(testDisks) < 3 {
+		t.Skipf("need 3 test disks, have %v (set DUMPSTORE_TEST_DISKS)", testDisks)
+	}
+	d0, d1, d2 := testDisks[0], testDisks[1], testDisks[2]
+
+	cleanupItestPool()
+	t.Cleanup(cleanupItestPool)
+
+	// Create a two-way mirror.
+	apiOK(t, "POST", "/api/pools", map[string]any{
+		"name": itestPool, "vdev_type": "mirror", "devices": []string{d0, d1},
+	})
+	if p, ok := poolByName(t, itestPool); !ok || p.Health != "ONLINE" {
+		t.Fatalf("pool after create: present=%v health=%q, want ONLINE", ok, p.Health)
+	}
+
+	// Creating a pool with a name that already exists must be refused.
+	if status, _ := api(t, "POST", "/api/pools", map[string]any{
+		"name": itestPool, "vdev_type": "single", "devices": []string{d2},
+	}); status != http.StatusConflict {
+		t.Fatalf("duplicate pool create: got %d, want 409", status)
+	}
+
+	// Offline one side of the mirror, then bring it back.
+	apiOK(t, "POST", "/api/pools/"+itestPool+"/offline", map[string]string{"device": d1})
+	waitFor(t, "vdev offline", 30*time.Second, func() bool {
+		d, ok := poolStatus(t, itestPool)
+		return ok && vdevState(d, base(d1)) == "OFFLINE"
+	})
+	apiOK(t, "POST", "/api/pools/"+itestPool+"/online", map[string]string{"device": d1})
+	waitFor(t, "pool back to ONLINE", time.Minute, func() bool {
+		d, ok := poolStatus(t, itestPool)
+		return ok && d.State == "ONLINE" && vdevState(d, base(d1)) == "ONLINE"
+	})
+
+	// Replace the second mirror leg with the third disk and let it resilver.
+	apiOK(t, "POST", "/api/pools/"+itestPool+"/replace", map[string]string{
+		"old_device": d1, "new_device": d2,
+	})
+	waitFor(t, "resilver onto "+d2, 2*time.Minute, func() bool {
+		d, ok := poolStatus(t, itestPool)
+		return ok && d.State == "ONLINE" && hasVdev(d, base(d2)) && !hasVdev(d, base(d1))
+	})
+
+	// The freed disk becomes a hot spare, then is removed again. The replace
+	// detached it with its old label intact, so clear it first.
+	clearDiskLabels(d1)
+	apiOK(t, "POST", "/api/pools/"+itestPool+"/spare", map[string]any{
+		"devices": []string{d1},
+	})
+	waitFor(t, "spare visible", 30*time.Second, func() bool {
+		d, ok := poolStatus(t, itestPool)
+		return ok && hasVdev(d, base(d1))
+	})
+	apiOK(t, "DELETE", "/api/pools/"+itestPool+"/devices/"+base(d1), nil)
+	waitFor(t, "spare removed", 30*time.Second, func() bool {
+		d, ok := poolStatus(t, itestPool)
+		return ok && !hasVdev(d, base(d1))
+	})
+
+	// Export: pool leaves the active list and shows up as importable.
+	apiOK(t, "POST", "/api/pools/"+itestPool+"/export", nil)
+	if _, ok := poolByName(t, itestPool); ok {
+		t.Fatalf("pool %s still active after export", itestPool)
+	}
+	importable := decode[[]struct {
+		Name string `json:"name"`
+	}](t, apiOK(t, "GET", "/api/pools/importable", nil))
+	found := false
+	for _, p := range importable {
+		if p.Name == itestPool {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("pool %s not in importable list after export: %+v", itestPool, importable)
+	}
+
+	// Import it back.
+	apiOK(t, "POST", "/api/pools/import", map[string]any{"pool": itestPool})
+	if p, ok := poolByName(t, itestPool); !ok || p.Health != "ONLINE" {
+		t.Fatalf("pool after import: present=%v health=%q, want ONLINE", ok, p.Health)
+	}
+}

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -195,3 +195,9 @@ All playbooks target `localhost` with `gather_facts: false`. Each playbook:
 - Input to Ansible extra-vars is validated for shell-special characters (`@;|&$\``) before the playbook call
 - `static/` is served by `http.FileServer` — do not put secrets there
 - The service runs as root (required for ZFS); do not expose it on a public interface without authentication in front of it
+
+## Testing
+
+- **Unit tests** — `go test ./...`; parser- and validator-level, no external dependencies.
+- **Integration tests** — `tests/integration` (build tag `integration`) drives a **deployed instance** in the Lima dev VM over HTTP and asserts on real ZFS state: auth, dataset/snapshot lifecycle, `zfs diff`, user quotas, send/recv jobs, and a full pool lifecycle (create, offline/online, `zpool replace` + resilver, spares, export/import) on three dedicated scratch disks. Run with `make vm-linux-start && make vm-linux-deploy && make test-integration`.
+- **CI** — `ci.yml` runs build/vet/unit tests on every PR; `integration-tests.yml` boots the Lima VM on a KVM-enabled runner and runs the integration suite nightly, on manual dispatch, and on PRs labeled `run-integration`.


### PR DESCRIPTION
## Summary

Implements #117 for real this time: an end-to-end integration suite (`tests/integration`, build tag `integration`, stdlib only) that drives a **deployed dumpstore instance** over HTTP and asserts on actual ZFS state — every write goes through the production Ansible/jobs machinery, no mocks.

| Test | Exercises |
|------|-----------|
| `TestAuth` | session gate (401), failed login, cookie login |
| `TestDatasetLifecycle` | create, property PATCH, rename, destroy |
| `TestSnapshotsAndDiff` | snapshots, `zfs diff`, clone, batch delete |
| `TestUserQuota` | `userquota@` set/clear + userspace report |
| `TestSendReceiveJob` | `zfs send \| recv` pipeline followed through the jobs API |
| `TestPoolLifecycle` | mirror create, 409 on duplicate name, device offline/online, `zpool replace` + resilver, spare add/remove, export, importable discovery, import |

Pool tests run on three new dedicated 1 GiB scratch disks (`/dev/vdc`–`/dev/vde`), never on `tank`. All fixtures are `itest`-prefixed and cleaned defensively before **and** after each test.

## Infra

- **`dev/lima-linux.yaml`** — scratch disks; amd64 image added so the same config boots on CI runners (arch now follows the host)
- **`dev/lima-freebsd.yaml`** — matching scratch disks for manual runs
- **`Makefile`** — scratch-disk lifecycle, new `make test-integration`
- **`.github/workflows/integration-tests.yml`** — boots the Lima VM on a KVM-enabled ubuntu runner: nightly, on manual dispatch, and on PRs labeled `run-integration`. FreeBSD stays a local target (GH macOS arm64 runners lack nested virtualization); see `tests/integration/README.md` for running the suite against the FreeBSD VM.

## Bug fix (found while wiring this up)

The Lima provision scripts wrote a **bcrypt** admin hash into `dumpstore.conf`, but the server rejects bcrypt since the argon2id migration — `admin`/`admin` on a freshly provisioned VM never worked. Both configs now write an argon2id PHC hash.

## Verification

Ran locally against a freshly created Lima VM:

```
--- PASS: TestAuth (0.18s)
--- PASS: TestDatasetLifecycle (2.32s)
--- PASS: TestSnapshotsAndDiff (3.50s)
--- PASS: TestUserQuota (1.47s)
--- PASS: TestSendReceiveJob (3.29s)
--- PASS: TestPoolLifecycle (6.40s)
ok  dumpstore/tests/integration 17.638s
```

`zpool history` in the VM confirms the real `zfs`/`zpool` commands executed; no `itest` state left behind. This PR carries the `run-integration` label so the CI path is exercised here too.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)