### PR TITLE
ci: smoke-test the release build path on every PR (#118)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,23 @@ jobs:
       - run: go build ./...
       - run: go vet ./...
       - run: go test -race ./...
+
+  # Exercises the exact release recipe (make release, all four GOOS/GOARCH
+  # targets) so a broken release pipeline is caught on the PR, not at tag
+  # time — the v0.1.14 tag build broke on drift nothing ever tested (#118).
+  release-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Build the full release matrix
+        run: make release VERSION=v0.0.0-smoke
+      - name: Verify the version ldflag in the native binary
+        run: |
+          tar -xzf dist/dumpstore-v0.0.0-smoke-linux-amd64.tar.gz
+          OUT=$(./dumpstore-v0.0.0-smoke-linux-amd64/dumpstore --version)
+          echo "version reported: $OUT"
+          test "$OUT" = "v0.0.0-smoke"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,36 +18,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # The build recipe lives in the Makefile (make release) and is smoke-
+      # tested on every PR by the release-smoke job in ci.yml (#118).
       - name: Build and package
-        run: |
-          VERSION=${GITHUB_REF_NAME}
-          mkdir -p dist
-
-          build() {
-            local OS=$1 ARCH=$2
-            local NAME="dumpstore-${VERSION}-${OS}-${ARCH}"
-
-            GOOS=$OS GOARCH=$ARCH go build \
-              -ldflags="-s -w -X main.version=${VERSION}" \
-              -o dumpstore .
-
-            mkdir -p dist/${NAME}
-            cp dumpstore dist/${NAME}/
-            cp -r playbooks static README.md install.sh dist/${NAME}/
-
-            case "$OS" in
-              linux)   cp contrib/dumpstore.service dist/${NAME}/ ;;
-              freebsd) cp contrib/dumpstore.rc      dist/${NAME}/ ;;
-            esac
-
-            tar -czf dist/${NAME}.tar.gz -C dist ${NAME}
-            rm -rf dist/${NAME} dumpstore
-          }
-
-          build linux   amd64
-          build linux   arm64
-          build freebsd amd64
-          build freebsd arm64
+        run: make release VERSION=${GITHUB_REF_NAME}
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented here.
 
 ### Added
 
+- **Release build smoke test on every PR** — the release recipe now lives in a single `make release VERSION=…` target (all four linux/freebsd × amd64/arm64 cross-builds with release ldflags, packaged into `dist/`), used verbatim by `release.yml` on tags and by a new `release-smoke` job in `ci.yml` on every PR, which also asserts the native binary reports the injected version via `--version`. A broken release pipeline is now caught at PR time instead of at tag time (the v0.1.14 tag build broke on a Go-version drift nothing ever exercised). Closes #118.
+
 - **VM-based integration test suite** — `tests/integration` (build tag `integration`, stdlib only) drives a deployed dumpstore instance over HTTP and asserts on real ZFS state: session auth, dataset lifecycle (create / property PATCH / rename / destroy), snapshots with `zfs diff` and clone, per-user quotas, a `zfs send | recv` pipeline followed through the jobs API, and a full pool lifecycle — mirror create, duplicate-name refusal, device offline/online, `zpool replace` with resilver, hot-spare add/remove, export, importable discovery, import — on three dedicated 1 GiB scratch disks the Lima VMs now provision (never on the `tank` data pool). Run locally with `make test-integration`; CI (`.github/workflows/integration-tests.yml`) boots the same Lima VM on a KVM-enabled runner nightly, on manual dispatch, and on PRs labeled `run-integration`. Closes #117.
 
 ### Fixed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,7 @@
 | Samba full ownership       | v0.1.10 | dumpstore owns smb.conf entirely — rendered from Go template on every write; directories auto-created; init gate blocks sub-features until Samba is bootstrapped; FreeBSD smb4.conf created on first init; resolves #75 #77 #78 #79 #81 |
 | FreeBSD-compliant paths    | v0.1.10 | `/usr/local/etc/dumpstore/` on FreeBSD, `/etc/dumpstore/` on Linux — `internal/platform.ConfigDir(goos)` as single source of truth; usershares, TLS certs, rc.d script, Makefile, install.sh all updated |
 | VM integration test suite  | v0.1.15 | End-to-end tests (`tests/integration`, `make test-integration`) drive the deployed API in the Lima VM against real ZFS: auth, dataset/snapshot lifecycle, diff, quotas, send/recv jobs, full pool lifecycle on dedicated scratch disks. CI runs it nightly and on PRs labeled `run-integration`. Closes #117 |
+| Release build smoke test   | v0.1.15 | Release recipe unified into `make release`; `release-smoke` CI job cross-builds all four targets on every PR and asserts `--version` reports the injected ldflag. Closes #118 |
 | SMB init status badge      | v0.1.10 | Users & Groups tab shows green "Initialised" badge with last-applied timestamp, or red "Not initialised"; `GET /api/smb/status` now includes `conf_mtime` |
 | Dev VM environment         | v0.1.11 | `make vm-linux-start/deploy` and `make vm-freebsd-start/deploy`; Ubuntu 24.04 + FreeBSD 15 with ZFS + Ansible; default admin/admin; closes #83 |
 | Dataset rename             | v0.1.11 | Rename a dataset or volume in place; same-parent constraint; closes #21 |
@@ -72,7 +73,6 @@
 |------------------------------------|----------|-------|--------------------------------------------------------------------------------------------------------------------------|
 | Go ops layer (shrink Ansible)      | Medium   | [#115](https://github.com/langerma/dumpstore/issues/115) | Single-command mutations move from playbooks to an in-process executor; Ansible keeps config files + OS resources |
 | Privilege separation               | Medium   | [#116](https://github.com/langerma/dumpstore/issues/116) | Non-root web frontend + narrow root helper over a unix socket |
-| Release build smoke test           | Medium   | [#118](https://github.com/langerma/dumpstore/issues/118) | CI cross-builds the release matrix on every PR so release.yml can't drift (v0.1.14 tag build broke on a pinned Go version) |
 | ZFS capability gating              | Medium   | [#119](https://github.com/langerma/dumpstore/issues/119) | Probe OpenZFS features at startup; hide/disable rewrite (needs 2.3+), draid, etc. instead of failing at runtime |
 | wsdd configuration management      | Medium   | [#86](https://github.com/langerma/dumpstore/issues/86) | Enable/configure wsdd (WS-Discovery) for Windows network visibility of SMB shares |
 | FreeBSD port (sysutils/dumpstore)  | Medium   | [#89](https://github.com/langerma/dumpstore/issues/89) | Port skeleton in contrib/, poudriere testing, ports-tree submission |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY  := dumpstore
 INSTALL := /usr/local/lib/dumpstore
 .PHONY: all build clean dev install uninstall check-prereqs install-go install-ansible \
-        test-integration \
+        test-integration release \
         vm-linux-start vm-linux-stop vm-linux-ssh vm-linux-deploy vm-linux-destroy \
         vm-freebsd-start vm-freebsd-stop vm-freebsd-ssh vm-freebsd-deploy vm-freebsd-destroy
 
@@ -9,6 +9,35 @@ all: build
 
 build:
 	go build -buildvcs=false -ldflags="-s -w -X main.version=$$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o $(BINARY) .
+
+# Cross-build and package every release target into dist/.
+# Single source of truth for the release recipe — used by release.yml on
+# tags and by the CI release-smoke job on every PR (#118) so the two
+# cannot drift.
+# Usage: make release VERSION=v1.2.3
+RELEASE_TARGETS := linux/amd64 linux/arm64 freebsd/amd64 freebsd/arm64
+
+release:
+	@test -n "$(VERSION)" || { echo "error: VERSION is required (make release VERSION=v1.2.3)" >&2; exit 1; }
+	@rm -rf dist && mkdir -p dist
+	@set -e; \
+	for target in $(RELEASE_TARGETS); do \
+	  OS=$${target%/*}; ARCH=$${target#*/}; \
+	  NAME="dumpstore-$(VERSION)-$$OS-$$ARCH"; \
+	  echo "==> Building $$NAME"; \
+	  GOOS=$$OS GOARCH=$$ARCH go build -buildvcs=false \
+	    -ldflags="-s -w -X main.version=$(VERSION)" -o $(BINARY) .; \
+	  mkdir -p dist/$$NAME; \
+	  cp $(BINARY) dist/$$NAME/; \
+	  cp -r playbooks static README.md install.sh dist/$$NAME/; \
+	  case "$$OS" in \
+	    linux)   cp contrib/dumpstore.service dist/$$NAME/ ;; \
+	    freebsd) cp contrib/dumpstore.rc      dist/$$NAME/ ;; \
+	  esac; \
+	  tar -czf dist/$$NAME.tar.gz -C dist $$NAME; \
+	  rm -rf dist/$$NAME $(BINARY); \
+	done
+	@ls -l dist/
 
 # Run locally on macOS (or any machine without ZFS/Ansible).
 # Fake CLI stubs in dev/bin/ intercept zfs, zpool, and ansible-playbook.

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -200,4 +200,4 @@ All playbooks target `localhost` with `gather_facts: false`. Each playbook:
 
 - **Unit tests** — `go test ./...`; parser- and validator-level, no external dependencies.
 - **Integration tests** — `tests/integration` (build tag `integration`) drives a **deployed instance** in the Lima dev VM over HTTP and asserts on real ZFS state: auth, dataset/snapshot lifecycle, `zfs diff`, user quotas, send/recv jobs, and a full pool lifecycle (create, offline/online, `zpool replace` + resilver, spares, export/import) on three dedicated scratch disks. Run with `make vm-linux-start && make vm-linux-deploy && make test-integration`.
-- **CI** — `ci.yml` runs build/vet/unit tests on every PR; `integration-tests.yml` boots the Lima VM on a KVM-enabled runner and runs the integration suite nightly, on manual dispatch, and on PRs labeled `run-integration`.
+- **CI** — `ci.yml` runs build/vet/unit tests plus a `release-smoke` job (the full `make release` cross-build matrix with a `--version` check) on every PR; `integration-tests.yml` boots the Lima VM on a KVM-enabled runner and runs the integration suite nightly, on manual dispatch, and on PRs labeled `run-integration`.


### PR DESCRIPTION
## Summary

Implements #118. The release recipe (linux/freebsd × amd64/arm64 cross-builds with release ldflags, packaged into `dist/`) moves out of `release.yml`'s inline shell into a single **`make release VERSION=…`** target. Both consumers now call the identical definition:

- **`release.yml`** (on tags): `make release VERSION=${GITHUB_REF_NAME}` — behavior unchanged
- **`ci.yml`** (every PR/push): new `release-smoke` job runs `make release VERSION=v0.0.0-smoke`, then unpacks the linux-amd64 tarball and asserts `./dumpstore --version` prints exactly `v0.0.0-smoke`

One build definition — the workflows cannot drift apart the way the v0.1.14 tag build did (Go version pinned in release.yml while go.mod required newer; sat undetected for months because nothing exercised the release path before tagging, fixed in #114).

## Acceptance criteria from the issue

- ✅ All four GOOS/GOARCH targets cross-compile on every PR
- ✅ release.yml and the CI smoke share one build definition (`make release`)
- ✅ Native binary's `--version` output checked

## Verification

Local `make release VERSION=v0.0.0-smoke` produces all four tarballs (linux-amd64 artifact confirmed a stripped x86-64 ELF); a native build with the same ldflags reports `v0.0.0-smoke` and passes the exact `test` assertion the CI job uses. The `release-smoke` job also runs on this very PR.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)