### PR TITLE
refactor(ui): event delegation for dataset row actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented here.
 
 ### Changed
 
+- **Datasets tab uses event delegation for row actions** — a new `delegate()` helper in `static/js/utils.js` attaches one click listener to the stable table wrapper and dispatches on `data-action` attributes, replacing the eleven per-button `querySelectorAll().addEventListener()` loops that `renderDatasets()` re-ran on every render. No behavior change; groundwork for migrating the remaining tabs.
+
 - **Single-command writes moved from Ansible to an in-process Go ops layer** (`internal/ops`) — scrub start/cancel, device replace/offline/online, pool create/import/export/add/remove-device, per-user/group quotas, and snapshot create/destroy/batch-destroy/clone now execute their one `zpool`/`zfs` command directly (argv, no shell), eliminating the ~1 s Python startup per write and the duplicated Go-regex/Jinja-assert validation for these ops. The API contract is unchanged: identical `{tasks: [...]}` step shape, same `ansible.progress` SSE topic, same op-log dialog. 15 command-wrapper playbooks deleted; Ansible remains required for config-file and OS-resource writes only (SMB, users/groups, TLS, ACLs, dataset property playbooks, scrub schedules, service control). New Prometheus metrics `dumpstore_op_runs_total` / `dumpstore_op_duration_seconds`. Closes #115.
 
 ### Added

--- a/static/js/datasets.js
+++ b/static/js/datasets.js
@@ -1,5 +1,5 @@
 import { state, storeSet } from './store.js';
-import { api, esc, fmtBytes, showOpLog, showOpLogRunning, toast, reZFSName } from './utils.js';
+import { api, delegate, esc, fmtBytes, showOpLog, showOpLogRunning, toast, reZFSName } from './utils.js';
 
 // ── Render: Datasets ──────────────────────────────────────────────────────────
 let datasetFilter = '';
@@ -47,7 +47,7 @@ export function renderDatasets() {
       const collapsed = state.collapsedDatasets.has(d.name);
       const icon = collapsed ? '▶' : '▼';
       const title = collapsed ? `Expand (${childCount} hidden)` : 'Collapse';
-      toggle = `<button class="tree-toggle" data-name="${esc(d.name)}" title="${title}">${icon}</button>`;
+      toggle = `<button class="tree-toggle" data-action="collapse" data-ds="${esc(d.name)}" title="${title}">${icon}</button>`;
     }
 
     // Pool roots (depth 0) cannot be deleted here — use zpool destroy
@@ -64,16 +64,16 @@ export function renderDatasets() {
         <td class="muted">${d.mountpoint !== 'none' ? esc(d.mountpoint) : '—'}</td>
         <td>
           <div class="row-actions">
-            <button class="btn-edit" data-ds="${esc(d.name)}" data-type="${esc(d.type)}">Edit</button>
-            ${d.type !== 'volume' ? `<button class="btn-acl btn-small${state.aclStatus[d.name] ? ' active' : ''}" data-ds="${esc(d.name)}" title="${state.aclStatus[d.name] ? 'ACL entries configured' : 'No ACL'}">ACL</button>` : ''}
-            ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-chown btn-small" data-ds="${esc(d.name)}">Chown</button>` : ''}
-            ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-nfs btn-small${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? ' active' : ''}" data-ds="${esc(d.name)}" title="${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? 'NFS shared: ' + esc(d.sharenfs) : 'Not shared'}">NFS</button>` : ''}
-            ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? (() => { const _sh = state.smbShares.find(s => s.path === d.mountpoint); return `<button class="btn-smb btn-small${_sh ? ' active' : ''}" data-ds="${esc(d.name)}" title="${_sh ? 'SMB shared: ' + esc(_sh.name) : 'Not shared'}">SMB</button>`; })() : ''}
-            ${d.type === 'volume' ? (() => { const _it = state.iscsiTargets.find(t => t.zvol_name === d.name); return `<button class="btn-iscsi btn-small${_it ? ' active' : ''}" data-ds="${esc(d.name)}" title="${_it ? 'iSCSI target: ' + esc(_it.iqn) : 'Not exposed as iSCSI target'}">iSCSI</button>`; })() : ''}
-            ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-usage btn-small" data-ds="${esc(d.name)}" title="Per-user/group space and quotas">Usage</button>` : ''}
-            <button class="btn-autosnap btn-small${state.autoSnapshot[d.name]?.['com.sun:auto-snapshot']?.value === 'true' ? ' active' : ''}" data-ds="${esc(d.name)}" title="Auto-snapshot schedule">Snap</button>
-            ${canDelete ? `<button class="btn-rename btn-small" data-ds="${esc(d.name)}">Rename</button>` : ''}
-            ${canDelete ? `<button class="btn-del" data-ds="${esc(d.name)}" data-type="${esc(d.type)}">Delete</button>` : ''}
+            <button class="btn-edit" data-action="edit" data-ds="${esc(d.name)}" data-type="${esc(d.type)}">Edit</button>
+            ${d.type !== 'volume' ? `<button class="btn-acl btn-small${state.aclStatus[d.name] ? ' active' : ''}" data-action="acl" data-ds="${esc(d.name)}" title="${state.aclStatus[d.name] ? 'ACL entries configured' : 'No ACL'}">ACL</button>` : ''}
+            ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-chown btn-small" data-action="chown" data-ds="${esc(d.name)}">Chown</button>` : ''}
+            ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-nfs btn-small${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? ' active' : ''}" data-action="nfs" data-ds="${esc(d.name)}" title="${d.sharenfs && d.sharenfs !== 'off' && d.sharenfs !== '-' ? 'NFS shared: ' + esc(d.sharenfs) : 'Not shared'}">NFS</button>` : ''}
+            ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? (() => { const _sh = state.smbShares.find(s => s.path === d.mountpoint); return `<button class="btn-smb btn-small${_sh ? ' active' : ''}" data-action="smb" data-ds="${esc(d.name)}" title="${_sh ? 'SMB shared: ' + esc(_sh.name) : 'Not shared'}">SMB</button>`; })() : ''}
+            ${d.type === 'volume' ? (() => { const _it = state.iscsiTargets.find(t => t.zvol_name === d.name); return `<button class="btn-iscsi btn-small${_it ? ' active' : ''}" data-action="iscsi" data-ds="${esc(d.name)}" title="${_it ? 'iSCSI target: ' + esc(_it.iqn) : 'Not exposed as iSCSI target'}">iSCSI</button>`; })() : ''}
+            ${d.type === 'filesystem' && d.mountpoint !== 'none' && d.mountpoint !== '-' ? `<button class="btn-usage btn-small" data-action="usage" data-ds="${esc(d.name)}" title="Per-user/group space and quotas">Usage</button>` : ''}
+            <button class="btn-autosnap btn-small${state.autoSnapshot[d.name]?.['com.sun:auto-snapshot']?.value === 'true' ? ' active' : ''}" data-action="autosnap" data-ds="${esc(d.name)}" title="Auto-snapshot schedule">Snap</button>
+            ${canDelete ? `<button class="btn-rename btn-small" data-action="rename" data-ds="${esc(d.name)}">Rename</button>` : ''}
+            ${canDelete ? `<button class="btn-del" data-action="del" data-ds="${esc(d.name)}" data-type="${esc(d.type)}">Delete</button>` : ''}
           </div>
         </td>
       </tr>`;
@@ -89,59 +89,26 @@ export function renderDatasets() {
         <tbody>${rows}</tbody>
       </table>
     </div>`;
-
-  wrap.querySelectorAll('.tree-toggle').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const name = btn.dataset.name;
-      if (state.collapsedDatasets.has(name)) {
-        state.collapsedDatasets.delete(name);
-      } else {
-        state.collapsedDatasets.add(name);
-      }
-      renderDatasets();
-    });
-  });
-
-  wrap.querySelectorAll('.btn-edit[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => openEditDatasetDialog(btn.dataset.ds, btn.dataset.type));
-  });
-
-  wrap.querySelectorAll('.btn-rename[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => openRenameDatasetDialog(btn.dataset.ds));
-  });
-
-  wrap.querySelectorAll('.btn-del[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => openDeleteDatasetDialog(btn.dataset.ds, btn.dataset.type));
-  });
-
-  wrap.querySelectorAll('.btn-acl[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => openACLDialog(btn.dataset.ds));
-  });
-
-  wrap.querySelectorAll('.btn-chown[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => openChownDialog(btn.dataset.ds));
-  });
-
-  wrap.querySelectorAll('.btn-nfs[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => openNFSDialog(btn.dataset.ds));
-  });
-
-  wrap.querySelectorAll('.btn-smb[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => openSMBDialog(btn.dataset.ds));
-  });
-
-  wrap.querySelectorAll('.btn-iscsi[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => openISCSIDialog(btn.dataset.ds));
-  });
-
-  wrap.querySelectorAll('.btn-autosnap[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => window.openAutoSnapDialog(btn.dataset.ds));
-  });
-
-  wrap.querySelectorAll('.btn-usage[data-ds]').forEach(btn => {
-    btn.addEventListener('click', () => openUserSpaceDialog(btn.dataset.ds));
-  });
 }
+
+// One delegated listener on the stable wrapper; survives every innerHTML render.
+delegate(document.getElementById('datasets-table-wrap'), {
+  collapse: ({ ds }) => {
+    if (state.collapsedDatasets.has(ds)) state.collapsedDatasets.delete(ds);
+    else state.collapsedDatasets.add(ds);
+    renderDatasets();
+  },
+  edit:     ({ ds, type }) => openEditDatasetDialog(ds, type),
+  rename:   ({ ds }) => openRenameDatasetDialog(ds),
+  del:      ({ ds, type }) => openDeleteDatasetDialog(ds, type),
+  acl:      ({ ds }) => openACLDialog(ds),
+  chown:    ({ ds }) => openChownDialog(ds),
+  nfs:      ({ ds }) => openNFSDialog(ds),
+  smb:      ({ ds }) => openSMBDialog(ds),
+  iscsi:    ({ ds }) => openISCSIDialog(ds),
+  autosnap: ({ ds }) => window.openAutoSnapDialog(ds),
+  usage:    ({ ds }) => openUserSpaceDialog(ds),
+});
 
 function typeBadge(type) {
   return `<span class="type-badge type-${esc(type)}">${esc(type)}</span>`;

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -135,6 +135,21 @@ export function toast(msg, type = 'ok') {
   toastTimer = setTimeout(() => { el.className = 'toast'; }, 3500);
 }
 
+// ── Event delegation ──────────────────────────────────────────────────────────
+// One listener per stable container, bound once at module init. Render
+// functions replace the container's innerHTML freely; the listener survives.
+// Dispatches on the closest [data-action] ancestor of the event target, so
+// an inner button wins over an outer row that also carries data-action.
+// Handlers receive (dataset, element, event).
+export function delegate(container, handlers, type = 'click') {
+  container.addEventListener(type, e => {
+    const el = e.target.closest('[data-action]');
+    if (!el || !container.contains(el)) return;
+    const fn = handlers[el.dataset.action];
+    if (fn) fn(el.dataset, el, e);
+  });
+}
+
 // ── ZFS name validation regexes ───────────────────────────────────────────────
 export const reZFSName   = /^[a-zA-Z][a-zA-Z0-9_.:-]*(\/[a-zA-Z][a-zA-Z0-9_.:-]*)*$/;
 export const reSnapLabel = /^[a-zA-Z0-9][a-zA-Z0-9_.:-]*$/;


### PR DESCRIPTION
## Summary

- Add a `delegate()` helper in `static/js/utils.js`: one click listener on a stable container, dispatching on the closest `[data-action]` ancestor of the event target. Handlers receive `(dataset, element, event)`.
- Migrate the Datasets tab to it: row buttons and tree toggles now emit `data-action` attributes, and the full handler map is bound **once at module init** to `#datasets-table-wrap`, replacing the eleven `querySelectorAll().addEventListener()` loops that `renderDatasets()` re-ran after every innerHTML render.
- No behavior or visual change; groundwork for migrating the remaining tabs (snapshots, users, pools, …) in follow-ups.

## Verification

- `node --check` on both modified modules.
- Behavioral test of `delegate()` against a minimal DOM shim: correct dispatch with dataset values, non-action clicks ignored, buttons created after binding still fire across simulated re-renders, exactly one listener on the container.
- Cross-checked that the 11 `data-action` values emitted by the row template match the 11 handler keys one-to-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)