### PR TITLE
feat(ui): software card requirement tiers + ZFS presence checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **Installed Software card shows requirement tiers** — each probed tool now carries `required`/`feature` metadata; the System tab table gained a "Needed for" column (Core for ZFS/Ansible/Python, otherwise the feature the tool unlocks — SMB shares, iSCSI targets, Windows share discovery, …), and a missing required tool renders a red "missing" badge instead of the same grey N/A as optional tools. Closes #135.
+- **FreeBSD warning when the ZFS kernel module is not loaded** — `platformWarnings()` runs `kldstat -q -m zfs` (also matches compiled-in modules) and surfaces a System-panel warning with the fix (`kldload zfs` / `zfs_enable=YES`), since userland binaries can be present while the module is not loaded. Part of #136.
+
+### Fixed
+
+- **Startup now fails fast when ZFS is missing** — `checkDeps()` verifies `zfs` and `zpool` are in PATH alongside the existing `ansible-playbook` check, instead of starting a server where every tab errors at runtime. Closes #136.
 
 ## [v0.2.0] — 2026-07-13
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -62,6 +62,8 @@
 | Datasets tab redesign      | v0.2.0 | Per-pool sections with health/capacity header rows, usage bars, status chips, hover-revealed quick actions, and a slide-in detail drawer with grouped actions and inline property editing; part 1 of #63 |
 | Snapshots tab redesign     | v0.2.0 | Collapsible per-dataset groups with count/size/age headers, relative ages, per-group bulk select, hover-revealed actions; part 2 of #63, closes #63 |
 | Drive replacement          | v0.1.14 | Replace pool devices from the vdev tree with an unused-device picker (`zpool replace`); offline/online devices for maintenance; resilver progress bar + completion toast; `GET /api/devices` lists block devices with in-use detection (new `internal/blockdev`); closes #55 |
+| Software card tiers        | Unreleased | Installed Software card distinguishes required tools (ZFS, Ansible, Python) from optional ones — new "Needed for" column names the feature each optional tool unlocks; a missing required tool shows a red "missing" badge instead of grey N/A. Closes #135 |
+| ZFS presence checks        | Unreleased | Startup dependency check now verifies `zfs`/`zpool` in PATH (fail fast instead of every tab erroring); on FreeBSD a System-panel warning appears when the ZFS kernel module is not loaded (`kldstat -q -m zfs`). Closes #136 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you run a Helios64, an old server, or any ZFS box where you care about what i
 
 ## Features
 
-- **System info** — hostname, OS, kernel, CPU, uptime, load averages, process stats
+- **System info** — hostname, OS, kernel, CPU, uptime, load averages, process stats; the Installed Software card distinguishes required tools (ZFS, Ansible, Python) from optional ones and names the feature each optional tool unlocks — a missing required tool is flagged with a red badge; platform warnings surface common misconfigurations (e.g. FreeBSD: ZFS kernel module not loaded, `zfs_enable` not set)
 - **Pool overview** — health badges, usage bars, fragmentation, deduplication ratio, vdev tree
 - **Pool scrub management** — trigger and cancel scrubs; last scrub time, status, and progress per pool; configure periodic scrub schedules (Linux: `zfsutils-linux`; FreeBSD: `periodic.conf`)
 - **Pool lifecycle** — create pools (single/mirror/raidz1-3/draid1-3) with an unused-device picker, optional ashift/compression, and confirm-by-typing; import exported pools (with force option); export pools from the pool card
@@ -388,7 +388,7 @@ dumpstore runs as root (required for ZFS). See [SECURITY.md](SECURITY.md) for no
 | TLS / ACME (optional)  | `openssl` (usually pre-installed); `lego` for ACME         | same                                         |
 | Build                  | Go 1.22+                                                  | Go 1.22+                                     |
 
-Go and Ansible are the only hard requirements. ZFS must be available on the target machine; the binary itself builds and runs on any platform.
+Go and Ansible are the only hard requirements. ZFS must be available on the target machine — the server checks for `zfs`, `zpool`, and `ansible-playbook` in PATH at startup and refuses to start with a clear error if any is missing; the binary itself builds and runs on any platform. On FreeBSD, the System tab additionally warns when the ZFS kernel module is not loaded even though the userland tools are installed. The Installed Software card on the System tab shows which of the optional tools below are present and which feature each one unlocks.
 
 The NFS server and ACL tools are optional — the relevant dialogs will show an error if the required tool is not installed. Install only what you need:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -661,7 +661,7 @@
           <span class="pool-name">system info</span>
           <span class="health-badge badge-blue">sysinfo</span>
         </div>
-        <p>Hostname, OS, kernel, CPU, uptime, load averages, and process stats. Software inventory tab shows versions of all runtime tools (Go, ZFS, Ansible, smartctl, etc.).</p>
+        <p>Hostname, OS, kernel, CPU, uptime, load averages, and process stats. The software inventory distinguishes required tools (ZFS, Ansible, Python) from optional ones, names the feature each optional tool unlocks, and flags a missing required tool with a red badge. Platform warnings surface common misconfigurations (e.g. FreeBSD: ZFS kernel module not loaded).</p>
       </div>
       <div class="pool-card">
         <div class="pool-card-header">

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -219,8 +219,10 @@ func UIDMin() int {
 // SoftwareTool holds the name and detected version of an external tool.
 // Version is empty when the tool is not found (rendered as N/A in the UI).
 type SoftwareTool struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Required bool   `json:"required"`          // dumpstore core does not function without it
+	Feature  string `json:"feature,omitempty"` // what the tool enables when optional
 }
 
 // NetworkInterface holds information about a single network interface.
@@ -598,19 +600,19 @@ func probeNFSServer() string {
 
 func softwareVersions() []SoftwareTool {
 	return []SoftwareTool{
-		{Name: "ZFS", Version: probeVersion("zfs", "version")},
-		{Name: "Ansible", Version: probeVersion("ansible-playbook", "--version")},
-		{Name: "Python", Version: probePython()},
-		{Name: "smartctl", Version: probeVersion("smartctl", "--version")},
-		{Name: "NFS server", Version: probeNFSServer()},
-		{Name: "nfs4-acl-tools", Version: probePresence("nfs4_setfacl")},
-		{Name: "setfacl (ACL)", Version: probePresence("setfacl")},
-		{Name: "zfs-auto-snapshot", Version: probePresence("zfs-auto-snapshot")},
-		{Name: "Samba (smbd)", Version: probeVersion("smbd", "--version")},
-		{Name: "wsdd (WS-Discovery)", Version: probePresence("wsdd")},
-		{Name: "iSCSI backend", Version: probeISCSIBackend()},
-		{Name: "lego (ACME)", Version: probeVersion("lego", "--version")},
-		{Name: "Package manager", Version: detectPkgManager()},
+		{Name: "ZFS", Version: probeVersion("zfs", "version"), Required: true},
+		{Name: "Ansible", Version: probeVersion("ansible-playbook", "--version"), Required: true},
+		{Name: "Python", Version: probePython(), Required: true},
+		{Name: "smartctl", Version: probeVersion("smartctl", "--version"), Feature: "SMART drive health"},
+		{Name: "NFS server", Version: probeNFSServer(), Feature: "NFS sharing"},
+		{Name: "nfs4-acl-tools", Version: probePresence("nfs4_setfacl"), Feature: "NFSv4 ACLs"},
+		{Name: "setfacl (ACL)", Version: probePresence("setfacl"), Feature: "POSIX ACLs"},
+		{Name: "zfs-auto-snapshot", Version: probePresence("zfs-auto-snapshot"), Feature: "Auto-snapshots"},
+		{Name: "Samba (smbd)", Version: probeVersion("smbd", "--version"), Feature: "SMB shares"},
+		{Name: "wsdd (WS-Discovery)", Version: probePresence("wsdd"), Feature: "Windows share discovery"},
+		{Name: "iSCSI backend", Version: probeISCSIBackend(), Feature: "iSCSI targets"},
+		{Name: "lego (ACME)", Version: probeVersion("lego", "--version"), Feature: "TLS via ACME (Let's Encrypt)"},
+		{Name: "Package manager", Version: detectPkgManager(), Feature: "Install hints"},
 	}
 }
 
@@ -618,6 +620,12 @@ func softwareVersions() []SoftwareTool {
 func platformWarnings() []string {
 	var w []string
 	if runtime.GOOS == "freebsd" {
+		// #136: userland binaries can be present while the kernel module is not
+		// loaded. -q also matches modules compiled into a custom kernel.
+		if err := exec.Command("kldstat", "-q", "-m", "zfs").Run(); err != nil {
+			w = append(w, "ZFS kernel module is not loaded — run 'kldload zfs' or set zfs_enable=YES in rc.conf")
+		}
+
 		// #76: Check zfs_enable in rc.conf — pools won't mount after reboot without it.
 		out, err := exec.Command("sysrc", "-n", "zfs_enable").Output()
 		if err != nil || strings.TrimSpace(string(out)) != "YES" {

--- a/main.go
+++ b/main.go
@@ -213,6 +213,11 @@ func main() {
 }
 
 func checkDeps(baseDir string) error {
+	for _, bin := range []string{"zfs", "zpool"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			return fmt.Errorf("%s not found in PATH (is ZFS installed?): %w", bin, err)
+		}
+	}
 	if _, err := exec.LookPath("ansible-playbook"); err != nil {
 		return fmt.Errorf("ansible-playbook not found in PATH: %w", err)
 	}

--- a/static/js/pools.js
+++ b/static/js/pools.js
@@ -70,16 +70,20 @@ export function renderSoftware() {
 
   const rows = tools.map(t => {
     const na = !t.version;
+    const status = na
+      ? (t.required ? '<span class="type-badge sw-missing">missing</span>' : 'N/A')
+      : esc(t.version);
     return `<tr>
       <td class="mono">${esc(t.name)}</td>
-      <td class="${na ? 'sw-na' : 'mono'}">${na ? 'N/A' : esc(t.version)}</td>
+      <td class="${na && !t.required ? 'sw-na' : 'mono'}">${status}</td>
+      <td class="${t.required ? '' : 'sw-na'}">${t.required ? 'Core (required)' : esc(t.feature || '—')}</td>
     </tr>`;
   }).join('');
 
   wrap.innerHTML = `
     <div class="table-wrap">
       <table>
-        <thead><tr><th>Tool</th><th>Version / Status</th></tr></thead>
+        <thead><tr><th>Tool</th><th>Version / Status</th><th>Needed for</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
     </div>`;

--- a/static/style.css
+++ b/static/style.css
@@ -417,6 +417,7 @@ tr.row-muted td { color: var(--text-muted); opacity: 0.6; }
 .type-snapshot    { background: #1a2e1a; color: #7cff9a; }
 .net-up           { background: #0d3d2e; color: var(--green); }
 .net-down         { background: #3d1010; color: var(--red); }
+.sw-missing       { background: #3d1010; color: var(--red); }
 
 .dataset-indent { padding-left: calc(4px + var(--depth, 0) * 16px); display: flex; align-items: center; gap: 4px; }
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -6,7 +6,7 @@ No container runtime, no database, no Node.js. Just a single compiled binary, so
 
 ## Features
 
-- **System info** — hostname, OS, kernel, CPU, uptime, load averages, process stats
+- **System info** — hostname, OS, kernel, CPU, uptime, load averages, process stats; the Installed Software card distinguishes required tools (ZFS, Ansible, Python) from optional ones, names the feature each optional tool unlocks, and flags a missing required tool with a red badge; platform warnings surface common misconfigurations (e.g. FreeBSD: ZFS kernel module not loaded)
 - **Pool overview** — health badges, usage bars, fragmentation, deduplication ratio, vdev tree
 - **Pool scrub management** — trigger scrubs, cancel running scrubs, view last scrub time/status/progress per pool; configure periodic scrub schedules (Linux: `zfsutils-linux`; FreeBSD: `periodic.conf`)
 - **I/O statistics** — live read/write IOPS and bandwidth per pool

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -15,7 +15,7 @@
 | iSCSI (optional)       | `targetcli-fb` (`targetcli`)                               | built-in `ctld`                              |
 | Build                  | Go 1.22+                                                  | Go 1.22+                                     |
 
-Go and Ansible are the only hard requirements. ZFS must be available on the target machine.
+Go and Ansible are the only hard requirements. ZFS must be available on the target machine — the server checks for `zfs`, `zpool`, and `ansible-playbook` in PATH at startup and refuses to start with a clear error if any is missing. On FreeBSD, the System tab warns when the ZFS kernel module is not loaded even though the userland tools are installed.
 
 ### Optional packages
 


### PR DESCRIPTION
## Summary

- **Installed Software card requirement tiers** (closes #135): `SoftwareTool` now carries `required`/`feature` metadata; the System tab table gained a "Needed for" column (Core for ZFS/Ansible/Python, otherwise the feature the tool unlocks), and a missing required tool renders a red `missing` badge (`.type-badge .sw-missing`, same colorway as `.net-down`) instead of the same grey N/A as optional tools.
- **ZFS presence checks** (closes #136): `checkDeps()` verifies `zfs`/`zpool` in PATH at startup — fail fast with a clear message instead of starting a server where every tab errors. On FreeBSD, `platformWarnings()` runs `kldstat -q -m zfs` (`-q` also matches compiled-in modules) and surfaces a System-panel warning with the fix (`kldload zfs` / `zfs_enable=YES`) when the userland binaries are present but the module isn't loaded.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- UI verified visually in headless Chrome against the real `pools.js` + `style.css` with mocked state: warning banner, new column, red missing badge on required tools, grey N/A on optional ones — badge matches sibling styles.
- The `kldstat` path can only be exercised on FreeBSD; runtime verification on the FreeBSD VM is pending (code-reviewed + compiled).

Closes #135. Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)